### PR TITLE
new: repeat button for Play widget, can be hidden

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -20,7 +20,7 @@ Major user-visible changes in ipywidgets 7.0 include:
   IntSlider(layout={'width': '100%'}, style={'handle_color': 'lightgreen'})
   ```
 - Removed the version validation check since it was causing too many false warnings about the widget javascript not being installed or the wrong version number. It is now up to the user to ensure that the ipywidgets and widgetsnbextension packages are compatible. ([#1219](https://github.com/jupyter-widgets/ipywidgets/pull/1219))
-
+- Play range is now inclusive (max value is max, instead of max-1), to be consistent with Sliders
 
 Major changes developers should be aware of include:
 

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -228,6 +228,8 @@ class Play(_BoundedInt):
     _model_module = Unicode('jupyter-js-widgets').tag(sync=True)
 
     _playing = Bool().tag(sync=True)
+    _repeat = Bool().tag(sync=True)
+    show_repeat = Bool(True).tag(sync=True)
 
 class _BoundedIntRange(_IntRange):
     max = CInt(100, help="Max value").tag(sync=True)

--- a/jupyter-js-widgets/src/widget_int.ts
+++ b/jupyter-js-widgets/src/widget_int.ts
@@ -727,8 +727,6 @@ class PlayModel extends BoundedIntModel {
             show_repeat: true,
             interval: 100,
             step: 1,
-            _repeat: false,
-            show_repeat: true,
         });
     }
     initialize(attributes, options) {

--- a/jupyter-js-widgets/src/widget_int.ts
+++ b/jupyter-js-widgets/src/widget_int.ts
@@ -745,8 +745,8 @@ class PlayModel extends BoundedIntModel {
                 this.set('value', next_value);
                 window.setTimeout(this.loop.bind(this), this.get('interval'));
             } else {
-                this.set('value', this.get('min'));
                 if(this.get('_repeat')) {
+                    this.set('value', this.get('min'));
                     window.setTimeout(this.loop.bind(this), this.get('interval'));
                 } else {
                     this.set('_playing', false);

--- a/jupyter-js-widgets/src/widget_int.ts
+++ b/jupyter-js-widgets/src/widget_int.ts
@@ -723,6 +723,8 @@ class PlayModel extends BoundedIntModel {
             _model_name: 'PlayModel',
             _view_name: 'PlayView',
             _playing: false,
+            _repeat: false,
+            show_repeat: true,
             interval: 100,
             step: 1,
             _repeat: false,


### PR DESCRIPTION
As discussed in #1186 this adds a repeat button. I've chosed the fa-retweet button, since the fa-repeat does not look like a repeat button.
Futhermore I've included what I think is a fix for Play, it now *includes* max, since that is more consistent with the slider's max behavious.

```python
import ipywidgets
p = ipywidgets.Play(min=0, max=3, interval=500, show_repeat=True)
s = ipywidgets.IntSlider(min=p.min, max=p.max, value=p.value)
ipywidgets.jslink((p, 'value'), (s, 'value'))
ipywidgets.HBox([p, s])
```

hide repeat button, and turn on repeat:
```python
p.show_repeat = False
p._repeat = True
```