### PR TITLE
Fix Item ordering in 'Select*', 'ToggleButtons' and 'RadioButtons' widgets

### DIFF
--- a/jupyter-js-widgets/src/widget_selection.js
+++ b/jupyter-js-widgets/src/widget_selection.js
@@ -331,7 +331,9 @@ var ToggleButtonsView = widget.DOMWidgetView.extend({
          * changed by another view or by a state update from the back-end.
          */
         if (options === undefined || options.updated_view != this) {
-            // Add missing items to the DOM.
+            // Remove all options from the DOM and re-insert, to preserve
+            // ordering with respect to 'model._options_labels'.
+            this.$buttongroup.text('')
             var items = this.model.get('_options_labels');
             var icons = this.model.get('icons');
             var previous_icons = this.model.previous('icons') || [];
@@ -345,22 +347,19 @@ var ToggleButtonsView = widget.DOMWidgetView.extend({
                 } else {
                     item_html = utils.escape_html(item);
                 }
-                var item_query = '[data-value="' + encodeURIComponent(item) + '"]';
-                var $item_element = that.$buttongroup.find(item_query);
-                var $icon_element = $item_element.find('.fa');
-                if (!$item_element.length) {
-                    $item_element = $('<button/>')
-                        .attr('type', 'button')
-                        .addClass('btn btn-default')
-                        .html(item_html)
-                        .appendTo(that.$buttongroup)
-                        .attr('data-value', encodeURIComponent(item))
-                        .attr('data-toggle', 'tooltip')
-                        .attr('value', item)
-                        .on('click', $.proxy(that.handle_click, that));
-                    that.update_style_traits($item_element);
-                    $icon_element = $('<i class="fa"></i>').prependTo($item_element);
-                }
+
+                var $item_element = $('<button/>')
+                    .attr('type', 'button')
+                    .addClass('btn btn-default')
+                    .html(item_html)
+                    .appendTo(that.$buttongroup)
+                    .attr('data-value', encodeURIComponent(item))
+                    .attr('data-toggle', 'tooltip')
+                    .attr('value', item)
+                    .on('click', $.proxy(that.handle_click, that));
+                that.update_style_traits($item_element);
+                var $icon_element = $('<i class="fa"></i>').prependTo($item_element);
+
                 if (that.model.get('value') == item) {
                     $item_element.addClass('active');
                 } else {
@@ -371,22 +370,6 @@ var ToggleButtonsView = widget.DOMWidgetView.extend({
                 $icon_element
                     .removeClass(previous_icons[index])
                     .addClass(icons[index]);
-            });
-
-            // Remove items that no longer exist.
-            this.$buttongroup.find('button').each(function(i, obj) {
-                var value = $(obj).attr('value');
-                var found = false;
-                _.each(items, function(item, index) {
-                    if (item == value) {
-                        found = true;
-                        return false;
-                    }
-                });
-
-                if (!found) {
-                    $(obj).remove();
-                }
             });
 
             var description = this.model.get('description');

--- a/jupyter-js-widgets/src/widget_selection.js
+++ b/jupyter-js-widgets/src/widget_selection.js
@@ -504,19 +504,18 @@ var SelectView = widget.DOMWidgetView.extend({
          * changed by another view or by a state update from the back-end.
          */
         if (options === undefined || options.updated_view != this) {
-            // Add missing items to the DOM.
+            // Remove all options from the DOM and re-insert, to preserve
+            // ordering with respect to 'model._options_labels'.
+            this.$listbox.text('');
             var items = this.model.get('_options_labels');
             var that = this;
             _.each(items, function(item, index) {
-               var item_query = 'option[data-value="' + encodeURIComponent(item) + '"]';
-                if (that.$listbox.find(item_query).length === 0) {
-                    $('<option />')
-                        .text(item.replace ? item.replace(/ /g, '\xa0') : item) // replace string spaces with &nbsp; for correct rendering
-                        .attr('data-value', encodeURIComponent(item))
-                        .val(item)
-                        .on("click", $.proxy(that.handle_click, that))
-                        .appendTo(that.$listbox);
-                }
+                $('<option />')
+                    .text(item.replace ? item.replace(/ /g, '\xa0') : item) // replace string spaces with &nbsp; for correct rendering
+                    .attr('data-value', encodeURIComponent(item))
+                    .val(item)
+                    .on("click", $.proxy(that.handle_click, that))
+                    .appendTo(that.$listbox);
             });
 
             // Select the correct element
@@ -525,22 +524,6 @@ var SelectView = widget.DOMWidgetView.extend({
             // Disable listbox if needed
             var disabled = this.model.get('disabled');
             this.$listbox.prop('disabled', disabled);
-
-            // Remove items that no longer exist.
-            this.$listbox.find('option').each(function(i, obj) {
-                var value = $(obj).val();
-                var found = false;
-                _.each(items, function(item, index) {
-                    if (item == value) {
-                        found = true;
-                        return false;
-                    }
-                });
-
-                if (!found) {
-                    $(obj).remove();
-                }
-            });
 
             var description = this.model.get('description');
             if (description.length === 0) {

--- a/jupyter-js-widgets/src/widget_selection.js
+++ b/jupyter-js-widgets/src/widget_selection.js
@@ -228,50 +228,32 @@ var RadioButtonsView = widget.DOMWidgetView.extend({
          * changed by another view or by a state update from the back-end.
          */
         if (options === undefined || options.updated_view != this) {
-            // Add missing items to the DOM.
+            // Remove all options from the DOM and re-insert, to preserve
+            // ordering with respect to 'model._options_labels'.
+            this.$container.text('');
             var items = this.model.get('_options_labels');
             var disabled = this.model.get('disabled');
             var that = this;
             _.each(items, function(item, index) {
-                var item_query = ' :input[data-value="' + encodeURIComponent(item) + '"]';
-                if (that.$el.find(item_query).length === 0) {
-                    var $label = $('<label />')
-                        .addClass('radio')
-                        .text(item)
-                        .appendTo(that.$container);
+                var $label = $('<label />')
+                    .addClass('radio')
+                    .text(item)
+                    .appendTo(that.$container);
 
-                    $('<input />')
-                        .attr('type', 'radio')
-                        .addClass(that.model)
-                        .val(item)
-                        .attr('data-value', encodeURIComponent(item))
-                        .prependTo($label)
-                        .on('click', $.proxy(that.handle_click, that));
-                }
+                var $item_element = $('<input />')
+                    .attr('type', 'radio')
+                    .addClass(that.model)
+                    .val(item)
+                    .attr('data-value', encodeURIComponent(item))
+                    .prependTo($label)
+                    .on('click', $.proxy(that.handle_click, that));
 
-                var $item_element = that.$container.find(item_query);
                 if (that.model.get('value') == item) {
                     $item_element.prop('checked', true);
                 } else {
                     $item_element.prop('checked', false);
                 }
                 $item_element.prop('disabled', disabled);
-            });
-
-            // Remove items that no longer exist.
-            this.$container.find('input').each(function(i, obj) {
-                var value = $(obj).val();
-                var found = false;
-                _.each(items, function(item, index) {
-                    if (item == value) {
-                        found = true;
-                        return false;
-                    }
-                });
-
-                if (!found) {
-                    $(obj).parent().remove();
-                }
             });
 
             var description = this.model.get('description');


### PR DESCRIPTION
Fixes #1191.

I'm not sure if you are still accepting pull requests for bugs on the 5.x branch, but given jupyter-incubator/dashboards_server#317 I still need ipywidgets 5.x, so thought I would make this change available upstream.

I essentially change the logic to be more inline with that on the current `master` branch ([example](https://github.com/ipython/ipywidgets/blob/master/jupyter-js-widgets/src/widget_selection.ts#L87)),
where instead of updating the DOM with elements and then deleting any which are no longer present, we instead rebuild the list of DOM elements from scratch.

Now elements in the DOM respect the ordering of elements in the `options` of the model.