### PR TITLE
Fix select boxes to respond to setting the height.

### DIFF
--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -16,7 +16,7 @@ from .domwidget import LabeledWidget
 from .valuewidget import ValueWidget
 from .widget_core import CoreWidget
 from .widget import register
-from traitlets import (Unicode, Bool, Any, Dict, TraitError, CaselessStrEnum,
+from traitlets import (Unicode, Bool, Int, Any, Dict, TraitError, CaselessStrEnum,
                        Tuple, List, Union, observe, validate)
 from ipython_genutils.py3compat import unicode_type
 
@@ -242,6 +242,7 @@ class Select(_Selection):
     """Listbox that only allows one item to be selected at any given time."""
     _view_name = Unicode('SelectView').tag(sync=True)
     _model_name = Unicode('SelectModel').tag(sync=True)
+    rows = Int(5).tag(sync=True)
 
 
 @register
@@ -269,3 +270,4 @@ class SelectMultiple(_MultipleSelection):
     """
     _view_name = Unicode('SelectMultipleView').tag(sync=True)
     _model_name = Unicode('SelectMultipleModel').tag(sync=True)
+    rows = Int(5).tag(sync=True)

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -612,16 +612,16 @@
 
 /* Select Widget Styling */
 
-.widget-select {
-    width: var(--jp-widgets-inline-width);
+.widget-dropdown {
     height: var(--jp-widgets-inline-height);
+    width: var(--jp-widgets-inline-width);
     line-height: var(--jp-widgets-inline-height);
 }
 
-.widget-select select {
+.widget-dropdown > select {
     border: var(--jp-widgets-input-border-width) solid var(--jp-widgets-input-border-color);
     border-radius: 0;
-    height: var(--jp-widgets-inline-height);
+    height: inherit;
     flex: 1 1 var(--jp-widgets-inline-width-short);
     min-width: 0; /* This makes it possible for the flexbox to shrink this input */
     box-sizing: border-box;
@@ -640,31 +640,30 @@
 	background-position: right center;
     background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjIuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxOCAxOCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMTggMTg7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDpub25lO30KPC9zdHlsZT4KPHBhdGggZD0iTTUuMiw1LjlMOSw5LjdsMy44LTMuOGwxLjIsMS4ybC00LjksNWwtNC45LTVMNS4yLDUuOXoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTAtMC42aDE4djE4SDBWLTAuNnoiLz4KPC9zdmc+Cg");
 }
-
-.widget-select select:focus {
+.widget-dropdown > select:focus {
     border-color: var(--jp-widgets-input-focus-border-color);
 }
 
 /* To disable the dotted border in Firefox around select controls.
    See http://stackoverflow.com/a/18853002 */
-.widget-select select:-moz-focusring {
+.widget-dropdown > select:-moz-focusring {
     color: transparent;
     text-shadow: 0 0 0 #000;
 }
 
-.widget-select select option:checked {
+.widget-dropdown > select > option:checked {
     color: var(--jp-ui-font-color0);
     background: var(--jp-layout-color0) repeat url("data:image/gif;base64,R0lGO...");
 }
 
-/* Select Multiple */
+/* Select and SelectMultiple */
 
-.widget-select-multiple {
+.widget-select {
     width: var(--jp-widgets-inline-width);
     line-height: var(--jp-widgets-inline-height);
 }
 
-.widget-select-multiple select {
+.widget-select > select {
     border: var(--jp-widgets-input-border-width) solid var(--jp-widgets-input-border-color);
     background-color: var(--jp-widgets-input-background-color);
     color: var(--jp-widgets-input-color);
@@ -672,18 +671,19 @@
     flex: 1 1 var(--jp-widgets-inline-width-short);
     outline: none !important;
     overflow: auto;
+    height: inherit;
 }
 
-.widget-select-multiple select:focus {
+.widget-select > select:focus {
     border-color: var(--jp-widgets-input-focus-border-color);
 }
 
-.widget-select-multiple select option:checked {
+.widget-select > select > option:checked {
     color: var(--jp-ui-font-color0);
     background: var(--jp-layout-color0) repeat url("data:image/gif;base64,R0lGO...");
 }
 
-.wiget-select-multiple select option {
+.wiget-select > select > option {
     padding-left: var(--jp-widgets-input-padding);
     line-height: var(--jp-widgets-inline-height);
     /* line-height doesn't work on some browsers for select options */


### PR DESCRIPTION
Fixes #1240.

There still is a small issue - setting height to inherit actually makes the listbox extend below the control just a bit when the height is set (because of the margin on the control itself). It extends only about as much as the top margin, though. Presumably this can be corrected with a calc() dynamic css property. I'm open to better ways to correct it, though!