### PR TITLE
Introduce a ToggleButtons button_width style attribute.

### DIFF
--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -16,7 +16,9 @@ from itertools import chain
 from .widget_description import DescriptionWidget
 from .valuewidget import ValueWidget
 from .widget_core import CoreWidget
-from .widget import register
+from .widget_style import Style
+from .trait_types import InstanceDict
+from .widget import register, widget_serialization
 from traitlets import (Unicode, Bool, Int, Any, Dict, TraitError, CaselessStrEnum,
                        Tuple, List, Union, observe, validate)
 from ipython_genutils.py3compat import unicode_type
@@ -272,6 +274,11 @@ class _MultipleSelection(DescriptionWidget, ValueWidget, CoreWidget):
         for key in sorted(chain(keys, ('options',))):
             yield key
 
+@register
+class ToggleButtonsStyle(Style, CoreWidget):
+    """Button style widget."""
+    _model_name = Unicode('ToggleButtonsStyleModel').tag(sync=True)
+    button_width = Unicode(help="The width of each button.").tag(sync=True)
 
 @register
 class ToggleButtons(_Selection):
@@ -284,6 +291,7 @@ class ToggleButtons(_Selection):
 
     tooltips = List(Unicode(), help="Tooltips for each button.").tag(sync=True)
     icons = List(Unicode(), help="Icons names for each button (FontAwesome names without the fa- prefix).").tag(sync=True)
+    style = InstanceDict(ToggleButtonsStyle).tag(sync=True, **widget_serialization)
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''],

--- a/packages/base/src/widget_style.ts
+++ b/packages/base/src/widget_style.ts
@@ -41,6 +41,9 @@ class StyleView extends WidgetView {
         for (let key of Object.keys(ModelType.styleProperties)) {
             this.registerTrait(key)
         }
+
+        // Set the initial styles
+        this.style();
     }
 
     /**
@@ -54,9 +57,6 @@ class StyleView extends WidgetView {
         this.listenTo(this.model, 'change:' + trait, (model, value) => {
             this.handleChange(trait, value);
         });
-
-        // Set the initial value on display.
-        this.handleChange(trait, this.model.get(trait));
     }
 
     /**
@@ -84,6 +84,15 @@ class StyleView extends WidgetView {
             console.warn('Style not applied because a parent view does not exist');
         }
     }
+
+    /**
+     * Apply styles for all registered traits
+     */
+    style() {
+        for (let trait of this._traitNames) {
+            this.handleChange(trait, this.model.get(trait));
+        }
+     }
 
     /**
      * Remove the styling from the parent view.

--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -105,7 +105,10 @@
 /* General Button Styling */
 
 .jupyter-button {
-    padding: 0;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-top: 0px;
+    padding-bottom: 0px;
     display: inline-block;
     white-space: nowrap;
     overflow: hidden;

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+   StyleModel
+} from '@jupyter-widgets/base';
+
+import {
     CoreDescriptionModel,
 } from './widget_core';
 
@@ -356,7 +360,24 @@ class RadioButtonsView extends DescriptionView {
 }
 
 export
-class ToggleButtonsModel extends SelectionModel {
+class ToggleButtonsStyleModel extends StyleModel {
+    defaults() {
+        return _.extend(super.defaults(), {
+            _model_name: 'ToggleButtonsStyleModel',
+        });
+    }
+
+    public static styleProperties = {
+        button_width: {
+            selector: '.widget-toggle-button',
+            attribute: 'width',
+            default: null
+        }
+    };
+}
+
+export
+ class ToggleButtonsModel extends SelectionModel {
     defaults() {
         return {...super.defaults(),
             _model_name: 'ToggleButtonsModel',
@@ -463,6 +484,11 @@ class ToggleButtonsView extends DescriptionView {
             }
         });
 
+        this.stylePromise.then(function(style) {
+            if (style) {
+                style.style();
+            }
+        });
         return super.update(options);
     }
 


### PR DESCRIPTION
Fixes #1189 

<img width="464" alt="screen shot 2017-04-05 at 3 10 41 pm" src="https://cloud.githubusercontent.com/assets/192614/24722668/97a018d6-1a12-11e7-99ef-bbd84b5b9fd6.png">

However, after doing this, I'm thinking we should do it a different way. For one, the assumption at https://github.com/jupyter-widgets/ipywidgets/blob/master/jupyter-js-widgets/src/widget.ts#L818 is now not true - the size of the widget could change. Two, perhaps a more useful default is to size the buttons with the content with some margin, with a minimum width so things don't get too small. Or use flex to layout the buttons in the space of the widget, so it's easy to control the total size of the buttons by changing the size of the buttons container.