### PR TITLE
Send a click event from ToggleButtons.

### DIFF
--- a/jupyter-js-widgets/src/widget_selection.ts
+++ b/jupyter-js-widgets/src/widget_selection.ts
@@ -477,6 +477,9 @@ class ToggleButtonsView extends LabeledDOMWidgetView {
         var value = event.target.value;
         this.model.set('value', value, { updated_view: this });
         this.touch();
+        // We also send a clicked event, since the value is only set if it changed.
+        // See https://github.com/jupyter-widgets/ipywidgets/issues/763
+        this.send({event: 'click'});
     }
 
     private _css_state: any;


### PR DESCRIPTION
Fixes #763.

To access this event from python, you can use something like:

```python
class MyToggleButtons(ToggleButtons):
    def __init__(self, **kwargs):
        super(MyToggleButtons, self).__init__(**kwargs)
        self.on_msg(self._handle_button_msg)
    def _handle_button_msg(self, _, content, buffers):
        print(content)
MyToggleButtons(options=list('abc'))
```

CC @jdemeyer - is this sufficient for your usecase?