### PR TITLE
Remove width restriction on Label widgets, and right-align them.

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -3,6 +3,13 @@ ipywidgets changelog
 
 A summary of changes in ipywidgets. For more detailed information, see [GitHub](https://github.com/jupyter-widgets/ipywidgets).
 
+
+7.0
+---
+Major user-visible changes in ipywidgets 7.0 include:
+
+- The `Label` widget is now right-aligned and has no width restriction: [#1269](https://github.com/jupyter-widgets/ipywidgets/pull/1269)
+
 6.0
 ---
 

--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -251,11 +251,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     line-height: var(--jp-widgets-inline-height);
-    max-width: var(--jp-widgets-inline-width);
-}
-
-.jupyter-widgets.widget-label {
-    width: var(--jp-widgets-inline-width-tiny);
+    text-align: right;
 }
 
 .widget-inline-hbox .widget-label {


### PR DESCRIPTION
Addresses the issue several people brought up with trying to use Label widgets to have long descriptions.

CC @britishbadger, @jdmeyer, @sylvaincorlay.

cf. #1010, #1246.