### PR TITLE
Make serializers synchronous and guarantee to return a snapshot of the data

### DIFF
--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -377,18 +377,19 @@ class WidgetModel extends Backbone.Model {
     serialize(state) {
         const serializers = (this.constructor as typeof WidgetModel).serializers || {};
         for (const k of state) {
-            if (serializers[k] && serializers[k].serialize) {
-                state[k] = (serializers[k].serialize)(state[k], this);
-            } else {
-                // the default serializer just deep-copies the object
-                // TODO: this won't work if the object is a primitive object with binary buffers!
-                // How should we handle those? One way is to declare a serializer for fields
-                // that could have binary that copies what fields it can, and makes a decision
-                // about whether to copy the ArrayBuffer
-                state[k] = JSON.parse(JSON.stringify(state[k]));
-            }
-            if (state[k].toJSON) {
-                state[k] = state[k].toJSON();
+            try {
+                if (serializers[k] && serializers[k].serialize) {
+                    state[k] = (serializers[k].serialize)(state[k], this);
+                } else {
+                    // the default serializer just deep-copies the object
+                    state[k] = JSON.parse(JSON.stringify(state[k]));
+                }
+                if (state[k].toJSON) {
+                    state[k] = state[k].toJSON();
+                }
+            } catch (e) {
+                console.error("Error serializing widget state attribute: ", k);
+                throw e;
             }
         }
         return state;


### PR DESCRIPTION
WIP, as this causes problems for binary arrays - basically we’ll need an explicit serializer on attributes that have binary arrays now, which can choose to implement the snapshot however they think best. The default serializer will make a copy.

This is work towards solving fundamental problems exposed at #1044.

CC @maartenbreddels - this affects the binary serialization.