### PR TITLE
Make @register backwards-compatible

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -10,6 +10,11 @@ Major user-visible changes in ipywidgets 7.0 include:
 
 - The `Label` widget is now right-aligned and has no width restriction: [#1269](https://github.com/jupyter-widgets/ipywidgets/pull/1269)
 
+
+Major changes developers should be aware of include:
+
+- The python `@register` decorator for widget classes no longer takes a string argument, but registers a widget class using the `_model_*` and `_view_*` traits in the class. Using the decorator as `@register('name')` is deprecated and should be changed to just `@register`. [#1228](https://github.com/jupyter-widgets/ipywidgets/pull/1228), [#1276](https://github.com/jupyter-widgets/ipywidgets/pull/1276)
+
 6.0
 ---
 

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -213,17 +213,25 @@ class WidgetRegistry(object):
         widget_class = view_names[view_name]
         return widget_class
 
-def register(widget):
-    """A decorator registering a widget class in the widget registry."""
-    w = widget.class_traits()
-    Widget.widget_types.register(w['_model_module'].default_value,
-                                 w['_model_module_version'].default_value,
-                                 w['_model_name'].default_value,
-                                 w['_view_module'].default_value,
-                                 w['_view_module_version'].default_value,
-                                 w['_view_name'].default_value,
-                                 widget)
-    return widget
+def register(name=''):
+    "For backwards compatibility, we support @register(name) syntax."
+    def reg(widget):
+        """A decorator registering a widget class in the widget registry."""
+        w = widget.class_traits()
+        Widget.widget_types.register(w['_model_module'].default_value,
+                                    w['_model_module_version'].default_value,
+                                    w['_model_name'].default_value,
+                                    w['_view_module'].default_value,
+                                    w['_view_module_version'].default_value,
+                                    w['_view_name'].default_value,
+                                    widget)
+        return widget
+    if isinstance(name, string_types):
+        import warnings
+        warnings.warn("Widget registration using a string name has been deprecated. Widget registration now uses a plain `@register` decorator.", DeprecationWarning)
+        return reg
+    else:
+        return reg(name)
 
 class Widget(LoggingHasTraits):
     #-------------------------------------------------------------------------


### PR DESCRIPTION
This makes @register backwards compatible (but the old syntax deprecated) so current widget libraries have a chance to change it.