### PR TITLE
upgrade setuptools, pip on Travis

### DIFF
--- a/scripts/travis_before_install_py.sh
+++ b/scripts/travis_before_install_py.sh
@@ -1,1 +1,1 @@
-git clone --quiet --depth 1 https://github.com/minrk/travis-wheels travis-wheels
+pip install --upgrade setuptools pip

--- a/scripts/travis_install_py.sh
+++ b/scripts/travis_install_py.sh
@@ -1,1 +1,1 @@
-pip install -f travis-wheels/wheelhouse file://$PWD#egg=ipywidgets[test] coveralls
+pip install file://$PWD#egg=ipywidgets[test] coveralls


### PR DESCRIPTION
and drop use of deprecated travis-wheels repo, which hasn’t been updated in some time now that manylinux wheels are on PyPI.