### PR TITLE
Added module name 'mywidget' to example Javascript

### DIFF
--- a/docs/source/examples/Widget Low Level.ipynb
+++ b/docs/source/examples/Widget Low Level.ipynb
@@ -485,7 +485,7 @@
     "\n",
     "JavaScript:\n",
     "```js\n",
-    "define(['jupyter-js-widgets'], function(widgets) {\n",
+    "define('mywidget', ['jupyter-js-widgets'], function(widgets) {\n",
     "\tvar MyWidgetView = widgets.DOMWidgetView.extend({\n",
     "    \trender: function() {\n",
     "        \tMyWidgetView.__super__.render.apply(this, arguments);\n",


### PR DESCRIPTION
The Javascript example code was missing the `'mywidget'` module name in the first argument. Omitting this argument may be allowed, but it is confusing for the reader. I am learning the ipywidgets low level widgets model and it was very confusing to me what the `_view_module` Python argument was doing (since I don't know Backbone.js, and barely know Javascript) until I saw [the Hello World page](http://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Custom.html). 
(by the way- this is my first contribution to any project ever)