### PR TITLE
Document that the date picker doesn’t work in firefox or safari

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -1422,7 +1422,9 @@
     "editable": true
    },
    "source": [
-    "## Date picker"
+    "## Date picker\n",
+    "\n",
+    "The date picker widget works in Chrome and IE Edge, but does not currently work in Firefox or Safari because they do not support the HTML date input field."
    ]
   },
   {


### PR DESCRIPTION
Fixes #1182.