### PR TITLE
Correct use of `save_changes` and `touch` methods

### DIFF
--- a/docs/source/examples/Widget Low Level.ipynb
+++ b/docs/source/examples/Widget Low Level.ipynb
@@ -538,7 +538,9 @@
     "\n",
     "`this.model.get` will get the current value of the trait.\n",
     "\n",
-    "`this.model.set` followed by `this.save_changes();` changes the model.  The view method `save_changes` is needed to associate the changes with the current view, thus associating any response messages with the view’s cell.\n",
+    "`this.model.set` followed by `this.model.save_changes();` changes the model.  ",
+    "\n",
+    "Use the view method `touch` instead of `model.save_changes` to associate the changes with the current view, thus associating any response messages with the view’s cell.\n",
     "\n",
     "The dictionary returned is the public members of the module.\n"
    ]


### PR DESCRIPTION
I have been trying for the past couple hours to `save_changes()` using the view object as shown on this page, but kept getting an error. Apparently this part of the API has been changed per this discussion: 

[https://github.com/jupyter-widgets/ipywidgets/issues/1052#issuecomment-274836038](url)

I have attempted to correct the explanation for use of the `save_changes` method (it is to be used on the model, not the view) and have added a line with an explanation for use of the view `touch` method. Hopefully everything is accurate.