### PR TITLE
Make widget managers completely in charge of loading widgets

### DIFF
--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -728,7 +728,7 @@ def test_get_interact_value():
     from ipywidgets.widgets import ValueWidget
     from traitlets import Unicode
     class TheAnswer(ValueWidget):
-        _model_module = Unicode('jupyter-js-widgets')
+        _model_name = Unicode('TheAnswer')
         description = Unicode()
         def get_interact_value(self):
             return 42

--- a/ipywidgets/widgets/valuewidget.py
+++ b/ipywidgets/widgets/valuewidget.py
@@ -4,10 +4,13 @@
 """Contains the ValueWidget class"""
 
 from .widget import Widget
+from traitlets import Any
 
 
 class ValueWidget(Widget):
     """Widget that can be used for the input of an interactive function"""
+
+    value = Any(help="The value of the widget.")
 
     def get_interact_value(self):
         """Return the value for this widget which should be passed to

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -18,7 +18,7 @@ from IPython.display import display
 
 from base64 import standard_b64decode, standard_b64encode
 
-from .._version import __protocol_version__
+from .._version import __protocol_version__, __jupyter_widget_version__
 
 
 def _widget_to_json(x, obj):
@@ -316,18 +316,19 @@ class Widget(LoggingHasTraits):
     #-------------------------------------------------------------------------
     # Traits
     #-------------------------------------------------------------------------
-    _model_module = Unicode(None,
-        help="A JavaScript module name in which to find _model_name.", read_only=True).tag(sync=True)
     _model_name = Unicode('WidgetModel',
         help="Name of the model.", read_only=True).tag(sync=True)
-    _model_module_version = Unicode('*',
-        help="A semver requirement for the model module version.", read_only=True).tag(sync=True)
-    _view_module = Unicode(None, allow_none=True,
-        help="A JavaScript module in which to find _view_name.").tag(sync=True)
-    _view_name = Unicode(None, allow_none=True,
-        help="Name of the view object.").tag(sync=True)
-    _view_module_version = Unicode('*',
-        help="A semver requirement for the view module.").tag(sync=True)
+    _model_module = Unicode('jupyter-js-widgets',
+        help="The namespace for the model.", read_only=True).tag(sync=True)
+    _model_module_version = Unicode(__jupyter_widget_version__,
+        help="A semver requirement for namespace version containing the model.", read_only=True).tag(sync=True)
+    _view_name = Unicode('',
+        help="Name of the view.").tag(sync=True)
+    _view_module = Unicode('',
+        help="The namespace for the view.").tag(sync=True)
+    _view_module_version = Unicode('',
+        help="A semver requirement for the namespace version containing the view.").tag(sync=True)
+
     _view_count = Int(read_only=True,
         help="EXPERIMENTAL: The number of views of the model displayed in the frontend. This attribute is experimental and may change or be removed in the future.").tag(sync=True)
     comm = Instance('ipykernel.comm.Comm', allow_none=True)

--- a/ipywidgets/widgets/widget_core.py
+++ b/ipywidgets/widgets/widget_core.py
@@ -10,5 +10,7 @@ from traitlets import Unicode
 
 class CoreWidget(Widget):
 
+    _model_module = Unicode('jupyter-js-widgets').tag(sync=True)
     _model_module_version = Unicode(__jupyter_widget_version__).tag(sync=True)
+    _view_module = Unicode('jupyter-js-widgets').tag(sync=True)
     _view_module_version = Unicode(__jupyter_widget_version__).tag(sync=True)

--- a/ipywidgets/widgets/widget_link.py
+++ b/ipywidgets/widgets/widget_link.py
@@ -42,8 +42,6 @@ class Link(CoreWidget):
     target: a (Widget, 'trait_name') tuple that should be updated
     """
 
-    _model_module = Unicode('jupyter-js-widgets').tag(sync=True)
-    _view_module = Unicode('jupyter-js-widgets').tag(sync=True)
     _model_name = Unicode('LinkModel').tag(sync=True)
     target = WidgetTraitTuple(help="The target (widget, 'trait_name') pair").tag(sync=True, **widget_serialization)
     source = WidgetTraitTuple(help="The source (widget, 'trait_name') pair").tag(sync=True, **widget_serialization)

--- a/jupyter-js-widgets/examples/web3/src/manager.ts
+++ b/jupyter-js-widgets/examples/web3/src/manager.ts
@@ -28,6 +28,18 @@ class WidgetManager extends widgets.ManagerBase<HTMLElement> {
         });
     }
 
+    protected loadClass(className: string, moduleName: string, moduleVersion: string): Promise<any> {
+        if (moduleName === 'jupyter-js-widgets') {
+            if (widgets[className]) {
+                return Promise.resolve(widgets[className]);
+            } else {
+                return Promise.reject(`Cannot find class ${className}`)
+            }
+        } else {
+            return Promise.reject(`Cannot find module ${moduleName}`);
+        }
+    }
+
     _create_comm(targetName, id, metadata) {
         return this.commManager.new_comm(targetName, metadata, id);
     }

--- a/jupyter-js-widgets/examples/web5/src/manager.ts
+++ b/jupyter-js-widgets/examples/web5/src/manager.ts
@@ -27,6 +27,18 @@ class WidgetManager extends widgets.ManagerBase<HTMLElement> {
         });
     }
 
+    protected loadClass(className: string, moduleName: string, moduleVersion: string): Promise<any> {
+        if (moduleName === 'jupyter-js-widgets') {
+            if (widgets[className]) {
+                return Promise.resolve(widgets[className]);
+            } else {
+                return Promise.reject(`Cannot find class ${className}`)
+            }
+        } else {
+            return Promise.reject(`Cannot find module ${moduleName}`);
+        }
+    }
+
     _create_comm(targetName, id, metadata) {
         return this.commManager.new_comm(targetName, metadata, id);
     }

--- a/jupyter-js-widgets/src-embed/embed-webpack.ts
+++ b/jupyter-js-widgets/src-embed/embed-webpack.ts
@@ -6,7 +6,7 @@
 
 // Element.prototype.matches polyfill
 if (Element && !Element.prototype.matches) {
-    var proto = Element.prototype as any;
+    let proto = Element.prototype as any;
     proto.matches = proto.matchesSelector ||
     proto.mozMatchesSelector || proto.msMatchesSelector ||
     proto.oMatchesSelector || proto.webkitMatchesSelector;
@@ -31,22 +31,19 @@ import * as _ from 'underscore';
 // All it does is inserting a <script> tag for requirejs in the case it is not
 // available and call `renderInlineWidgets`
 function loadInlineWidgets(event) {
-    // If requirejs is not on the page on page load, load it from cdn.
-    if (!(window as any).requirejs) {
-        var scriptjs = require('scriptjs') as any;
-        scriptjs('https://unpkg.com/requirejs/require.js', function() {
-            // Define jupyter-js-widget requirejs module
-            //
-            // (This is needed for custom widget model to be able to AMD require jupyter-js-widgets.)
-            (window as any).define('jupyter-js-widgets', function() {
-                return widgets;
+    let loadRequire = new Promise(function(resolve, reject) {
+        if ((window as any).requirejs) {
+            resolve();
+        } else {
+            // If requirejs is not on the page on page load, load it from cdn.
+            let scriptjs = require('scriptjs') as any;
+            scriptjs('https://unpkg.com/requirejs/require.js', function() {
+                resolve();
             });
-            // Render inline widgets
-            renderInlineWidgets(event);
-        });
-    } else {
+        }
+    });
+    loadRequire.then(function() {
         // Define jupyter-js-widget requirejs module
-        //
         // (This is needed for custom widget model to be able to AMD require jupyter-js-widgets.)
         if (!(window as any).requirejs.defined('jupyter-js-widgets')) {
             (window as any).define('jupyter-js-widgets', function () {
@@ -55,7 +52,7 @@ function loadInlineWidgets(event) {
         }
         // Render inline widgets
         renderInlineWidgets(event);
-    }
+    });
 }
 
 // `renderInlineWidget` will call `renderManager(element, tag)` on each <script>
@@ -63,9 +60,9 @@ function loadInlineWidgets(event) {
 //     "application/vnd.jupyter.widget-state+json"
 // contained in `event.element`.
 export function renderInlineWidgets(event) {
-    var element = event.target || document;
-    var tags = element.querySelectorAll('script[type="application/vnd.jupyter.widget-state+json"]');
-    for (var i=0; i!=tags.length; ++i) {
+    let element = event.target || document;
+    let tags = element.querySelectorAll('script[type="application/vnd.jupyter.widget-state+json"]');
+    for (let i=0; i!=tags.length; ++i) {
         renderManager(element, tags[i]);
     }
 }
@@ -76,28 +73,28 @@ export function renderInlineWidgets(event) {
 // Then it performs a look up of all script tags under the specified DOM
 // element with the mime type
 //     "application/vnd.jupyter.widget-view+json".
-// For each oone of these <script> tag, if the contained json specifies a model id
+// For each one of these <script> tags, if the contained json specifies a model id
 // known to the aforementioned manager, it is replaced with a view of the model.
 //
 // Besides, if the view script tag has an <img> sibling DOM node with class `jupyter-widget`,
 // the <img> tag is deleted.
 function renderManager(element, tag) {
-    var widgetStateObject = JSON.parse(tag.innerHTML);
-    var ajv = new Ajv(); // options can be passed, e.g. {allErrors: true}
-    var model_validate = ajv.compile(widget_state_schema);
-    var valid = model_validate(widgetStateObject);
+    let widgetStateObject = JSON.parse(tag.innerHTML);
+    let ajv = new Ajv(); // options can be passed, e.g. {allErrors: true}
+    let model_validate = ajv.compile(widget_state_schema);
+    let valid = model_validate(widgetStateObject);
     if (!valid) {
         console.log(model_validate.errors);
     }
-    var manager = new embed.EmbedManager();
+    let manager = new embed.EmbedManager();
     manager.set_state(widgetStateObject, {}).then(function(models) {
-        var tags = element.querySelectorAll('script[type="application/vnd.jupyter.widget-view+json"]');
-        for (var i=0; i!=tags.length; ++i) {
+        let tags = element.querySelectorAll('script[type="application/vnd.jupyter.widget-view+json"]');
+        for (let i=0; i!=tags.length; ++i) {
             // TODO: validate view schema
             let viewtag = tags[i];
             let widgetViewObject = JSON.parse(viewtag.innerHTML);
-            var view_validate = ajv.compile(widget_view_schema);
-            var valid = view_validate(widgetViewObject);
+            let view_validate = ajv.compile(widget_view_schema);
+            let valid = view_validate(widgetViewObject);
             if (!valid) {
                 console.log(view_validate.errors);
             }

--- a/jupyter-js-widgets/src/utils.ts
+++ b/jupyter-js-widgets/src/utils.ts
@@ -46,66 +46,6 @@ class WrappedError extends Error {
 }
 
 /**
- * Tries to load a class
- *
- * Tries to load a class from a module using require.js, if a module
- * is specified, otherwise tries to load a class from the global
- * registry, if the global registry is provided.
- *
- * The optional require_error argument is a function that takes the success
- * handler and returns a requirejs error handler, which may call the success
- * handler with a fallback module.
- *
- */
-
-export
-function loadClass(class_name, module_name, module_version, registry, require_error): Promise<any> {
-    return new Promise(function(resolve, reject) {
-
-        // Try loading the view module using require.js
-        if (module_name) {
-            // If the module is jupyter-js-widgets, we can just self import.
-            var modulePromise;
-            var requirejsDefined = typeof window !== 'undefined' && (window as any).requirejs;
-            if (requirejsDefined) {
-                if (module_name !== 'jupyter-js-widgets' || (window as any).requirejs.defined('jupyter-js-widgets')) {
-                    modulePromise = new Promise(function(innerResolve, innerReject) {
-                        var success_callback = function(module) {
-                            innerResolve(module);
-                        };
-                        var failure_callback = require_error ? require_error(success_callback, reject, module_version) : reject;
-                        (window as any).require([module_name], success_callback, failure_callback);
-                    });
-                } else if (module_name === 'jupyter-js-widgets') {
-                    modulePromise = Promise.resolve(require('../'));
-                }
-            } else if (module_name === 'jupyter-js-widgets') {
-                modulePromise = Promise.resolve(require('../'));
-            } else {
-                // FUTURE: Investigate dynamic loading methods other than require.js.
-                throw new Error(['In order to use third party widgets, you ',
-                    'must have require.js loaded on the page.'].join(''));
-            }
-
-            modulePromise.then(function(module) {
-                if (module[class_name] === undefined) {
-                    reject(new Error('Class ' + class_name + ' not found in module ' + module_name));
-                } else {
-                    resolve(module[class_name]);
-                }
-            });
-        } else {
-            if (registry && registry[class_name]) {
-                resolve(registry[class_name]);
-            } else {
-                reject(new Error('Class ' + class_name + ' not found in registry '));
-            }
-        }
-    });
-}
-
-
-/**
  * Resolve a promiseful dictionary.
  * Returns a single Promise.
  */

--- a/jupyter-js-widgets/src/widget_core.ts
+++ b/jupyter-js-widgets/src/widget_core.ts
@@ -10,15 +10,15 @@ import {
 
 import * as _ from 'underscore';
 
-var semver_range = '^' + require('../package.json').version;
+let jupyterWidgetSpecVersion = '3';
 
 export
 class CoreWidgetModel extends WidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'CoreWidgetModel',
-            _model_module_version: semver_range,
-            _view_module_version: semver_range
+            _model_module_version: jupyterWidgetSpecVersion,
+            _view_module_version: jupyterWidgetSpecVersion
         });
     }
 }
@@ -28,8 +28,8 @@ class CoreDOMWidgetModel extends DOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'CoreDOMWidgetModel',
-            _model_module_version: semver_range,
-            _view_module_version: semver_range
+            _model_module_version: jupyterWidgetSpecVersion,
+            _view_module_version: jupyterWidgetSpecVersion
         });
     }
 }
@@ -39,8 +39,8 @@ class CoreLabeledDOMWidgetModel extends LabeledDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'CoreLabeledDOMWidgetModel',
-            _model_module_version: semver_range,
-            _view_module_version: semver_range
+            _model_module_version: jupyterWidgetSpecVersion,
+            _view_module_version: jupyterWidgetSpecVersion
         });
     }
 }

--- a/jupyter-js-widgets/test/src/dummy-manager.ts
+++ b/jupyter-js-widgets/test/src/dummy-manager.ts
@@ -3,9 +3,7 @@
 
 import expect = require('expect.js');
 
-import {
-    ManagerBase
-} from '../../lib';
+import * as widgets from '../../lib';
 import * as services from '@jupyterlab/services';
 import * as Backbone from 'backbone';
 
@@ -17,7 +15,7 @@ class MockComm {
 }
 
 export
-class DummyManager extends ManagerBase<HTMLElement> {
+class DummyManager extends widgets.ManagerBase<HTMLElement> {
     constructor() {
         super();
         this.el = window.document.createElement('div');
@@ -30,7 +28,19 @@ class DummyManager extends ManagerBase<HTMLElement> {
             return view.el;
         });
     }
-    
+
+    protected loadClass(className: string, moduleName: string, moduleVersion: string): Promise<any> {
+        if (moduleName === 'jupyter-js-widgets') {
+            if (widgets[className]) {
+                return Promise.resolve(widgets[className]);
+            } else {
+                return Promise.reject(`Cannot find class ${className}`)
+            }
+        } else {
+            return Promise.reject(`Cannot find module ${moduleName}`);
+        }
+    }
+
     _get_comm_info() {
         return Promise.resolve({});
     }

--- a/jupyterlab_widgets/src/index.ts
+++ b/jupyterlab_widgets/src/index.ts
@@ -179,10 +179,10 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
   /**
    * Load a class and return a promise to the loaded object.
    */
-  protected loadClass(className: string, moduleName: string, moduleVersion: string, error: any): any {
+  protected loadClass(className: string, moduleName: string, moduleVersion: string): any {
     let mod: any = this._registry.get(moduleName, moduleVersion);
     if (!mod) {
-    return Promise.reject(`Module ${moduleName}, semver range ${moduleVersion} is not registered as a widget module`);
+      return Promise.reject(`Module ${moduleName}, semver range ${moduleVersion} is not registered as a widget module`);
     }
     let cls: any = mod[className];
     if (!cls) {

--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -140,7 +140,7 @@ WidgetManager.set_state_callbacks(function() {
     }
 });
 
-WidgetManager.prototype.loadClass = function(className, moduleName, moduleVersion, error) {
+WidgetManager.prototype.loadClass = function(className, moduleName, moduleVersion) {
     if (moduleName === "jupyter-js-widgets") {
         if (className === "OutputModel" || className === "OutputView") {
             return Promise.resolve(output[className]);
@@ -148,7 +148,15 @@ WidgetManager.prototype.loadClass = function(className, moduleName, moduleVersio
             return Promise.resolve(widgets[className]);
         }
     } else {
-        return Object.getPrototypeOf(WidgetManager.prototype).loadClass.apply(this, arguments);
+        return new Promise(function(resolve, reject) {
+            window.require([moduleName], resolve, reject);
+        }).then(function(mod) {
+            if (mod[className]) {
+                return mod[className];
+            } else {
+                return Promise.reject('Class ' + className + ' not found in module ' + moduleName);
+            }
+        });
     }
 }
 


### PR DESCRIPTION
This is an iteration on fixing #1242.

The basic idea is that we now consider the module/version to be semantic namespace (i.e., the spec for the model or view implementation), and the package/version to be a concrete implementation that can be loaded. The original thought was that if the package/version was not specified, it would default to the module/version. However, since package/version will be set on basic widgets classes, they must be overridden in custom widgets to be consistent.