### PR TITLE
Make jupyter widget version numbers consistent

### DIFF
--- a/ipywidgets/_version.py
+++ b/ipywidgets/_version.py
@@ -8,5 +8,5 @@ _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
   '' if version_info[3]=='final' else _specifier_[version_info[3]]+str(version_info[4]))
 
-__protocol_version__ = '2.0'
-__jupyter_widget_version__ = '3'
+__protocol_version__ = '2.0.0'
+__jupyter_widget_version__ = '3.0.0'

--- a/jupyter-js-widgets/src/index.ts
+++ b/jupyter-js-widgets/src/index.ts
@@ -23,9 +23,3 @@ export * from "./widget_string";
 
 export
 const version = (require('../package.json') as any).version;
-
-export
-const JUPYTER_WIDGETS_VERSION = '3';
-
-export
-const PROTOCOL_VERSION = '2.0';

--- a/jupyter-js-widgets/src/manager-base.ts
+++ b/jupyter-js-widgets/src/manager-base.ts
@@ -19,6 +19,9 @@ import {
     shims
 } from './services-shim';
 
+export
+const PROTOCOL_VERSION = '2.0.0';
+
 /**
  * The options for a model.
  *

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -19,6 +19,8 @@ import {
     Message, MessageLoop
 } from '@phosphor/messaging';
 
+export
+const JUPYTER_WIDGETS_VERSION = '3.0.0';
 
 /**
  * Replace model ids with models recursively.
@@ -56,10 +58,10 @@ class WidgetModel extends Backbone.Model {
         return {
             _model_module: "jupyter-js-widgets",
             _model_name: "WidgetModel",
-            _model_module_version: "*",
+            _model_module_version: JUPYTER_WIDGETS_VERSION,
             _view_module: "jupyter-js-widgets",
             _view_name: null,
-            _view_module_version: "*",
+            _view_module_version: JUPYTER_WIDGETS_VERSION,
             _view_count: 0,
             msg_throttle: 1,
         };

--- a/jupyter-js-widgets/src/widget_core.ts
+++ b/jupyter-js-widgets/src/widget_core.ts
@@ -10,15 +10,11 @@ import {
 
 import * as _ from 'underscore';
 
-let jupyterWidgetSpecVersion = '3';
-
 export
 class CoreWidgetModel extends WidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'CoreWidgetModel',
-            _model_module_version: jupyterWidgetSpecVersion,
-            _view_module_version: jupyterWidgetSpecVersion
         });
     }
 }
@@ -28,8 +24,6 @@ class CoreDOMWidgetModel extends DOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'CoreDOMWidgetModel',
-            _model_module_version: jupyterWidgetSpecVersion,
-            _view_module_version: jupyterWidgetSpecVersion
         });
     }
 }
@@ -39,8 +33,6 @@ class CoreLabeledDOMWidgetModel extends LabeledDOMWidgetModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'CoreLabeledDOMWidgetModel',
-            _model_module_version: jupyterWidgetSpecVersion,
-            _view_module_version: jupyterWidgetSpecVersion
         });
     }
 }


### PR DESCRIPTION
As a stepping stone to the big split taking care of version numbers in a more fine-grained way, this allows the current packages to work.