### PR TITLE
Fix a bug where custom serializers are not used

### DIFF
--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -409,7 +409,7 @@ class WidgetModel extends Backbone.Model {
                     // the default serializer just deep-copies the object
                     state[k] = JSON.parse(JSON.stringify(state[k]));
                 }
-                if (state[k].toJSON) {
+                if (state[k] && state[k].toJSON) {
                     state[k] = state[k].toJSON();
                 }
             } catch (e) {

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -401,7 +401,7 @@ class WidgetModel extends Backbone.Model {
      */
     serialize(state) {
         const serializers = (this.constructor as typeof WidgetModel).serializers || {};
-        for (const k in state) {
+        for (const k of Object.keys(state)) {
             try {
                 if (serializers[k] && serializers[k].serialize) {
                     state[k] = (serializers[k].serialize)(state[k], this);

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -401,7 +401,7 @@ class WidgetModel extends Backbone.Model {
      */
     serialize(state) {
         const serializers = (this.constructor as typeof WidgetModel).serializers || {};
-        for (const k of state) {
+        for (const k in state) {
             try {
                 if (serializers[k] && serializers[k].serialize) {
                     state[k] = (serializers[k].serialize)(state[k], this);

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -399,7 +399,7 @@ class WidgetModel extends Backbone.Model {
      * primitive object that is a snapshot of the widget state that may have
      * binary array buffers.
      */
-    serialize(state) {
+    serialize(state: {[key: string]: any}) {
         const serializers = (this.constructor as typeof WidgetModel).serializers || {};
         for (const k of Object.keys(state)) {
             try {

--- a/jupyter-js-widgets/test/src/widget_test.ts
+++ b/jupyter-js-widgets/test/src/widget_test.ts
@@ -169,19 +169,19 @@ describe("Widget", function() {
                 use_this: 6,
                 ignored: 'should not get serialized'
             }
-        }
+        };
         this.widget.constructor.serializers = {
             ...this.widget.constructor.serializers,
             need_custom_serializer: {
                 serialize: (value) => value.use_this
             }
-        }
+        };
         const serialized_state = this.widget.serialize(state);
         expect(serialized_state).to.deep.equal({
             a: 5,
             need_custom_serializer: 6
-        })
-    })
+        });
+    });
 
     it('_handle_comm_msg', function() {
         expect(this.widget._handle_comm_msg).to.not.be.undefined;

--- a/jupyter-js-widgets/test/src/widget_test.ts
+++ b/jupyter-js-widgets/test/src/widget_test.ts
@@ -162,6 +162,27 @@ describe("Widget", function() {
         expect(serialized_state).to.deep.equal(state_with_null);
     });
 
+    it('serialize with custom serializers', function() {
+        const state = {
+            a: 5,
+            need_custom_serializer: {
+                use_this: 6,
+                ignored: 'should not get serialized'
+            }
+        }
+        this.widget.constructor.serializers = {
+            ...this.widget.constructor.serializers,
+            need_custom_serializer: {
+                serialize: (value) => value.use_this
+            }
+        }
+        const serialized_state = this.widget.serialize(state);
+        expect(serialized_state).to.deep.equal({
+            a: 5,
+            need_custom_serializer: 6
+        })
+    })
+
     it('_handle_comm_msg', function() {
         expect(this.widget._handle_comm_msg).to.not.be.undefined;
 

--- a/jupyter-js-widgets/test/src/widget_test.ts
+++ b/jupyter-js-widgets/test/src/widget_test.ts
@@ -141,6 +141,27 @@ describe("Widget", function() {
         });
     });
 
+    it('serialize', function() {
+        expect(this.widget.serialize).to.not.be.undefined;
+        const state = {
+            a: 5,
+            b: 'some-string'
+        };
+        const serialized_state = this.widget.serialize(state);
+        expect(serialized_state).to.be.an('object');
+        expect(serialized_state).to.deep.equal(state);
+    });
+
+    it('serialize null values', function() {
+        const state_with_null = {
+            a: 5,
+            b: null
+        };
+        const serialized_state = this.widget.serialize(state_with_null);
+        expect(serialized_state).to.be.an('object');
+        expect(serialized_state).to.deep.equal(state_with_null);
+    });
+
     it('_handle_comm_msg', function() {
         expect(this.widget._handle_comm_msg).to.not.be.undefined;
 


### PR DESCRIPTION
Prior to this commit, the `WidgetModel$serialize` method silently ignored custom serializers. Now fixed.

To reproduce:

```python
import ipywidgets as widgets
d = widgets.DatePicker()
d
# this displays the date picker
d.value
#  => None (while the date picker is not set)
# change the value in the date picker manually
d.value
# => Without the fix, this is still None. With the fix, it's the correct date.
```

This addresses issue #1320 , but stretches beyond date pickers: any widget that uses custom serialisers would have not worked (I think).

TODO:

 - [x] use `Object.keys()` instead of `for ... in`
 - [x] unit test for null value in state
 - [x] unit test that verifies that custom serializers are used