### PR TITLE
Change tuple by list in order to avoid ValueError's when Dropdown is …

### DIFF
--- a/docs/source/examples/Using Interact.ipynb
+++ b/docs/source/examples/Using Interact.ipynb
@@ -309,7 +309,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Dropdown menus are constructed by passing a tuple of strings. In this case, the strings are both used as the names in the dropdown menu UI and passed to the underlying Python function."
+    "Dropdown menus are constructed by passing a list of strings. In this case, the strings are both used as the names in the dropdown menu UI and passed to the underlying Python function."
    ]
   },
   {


### PR DESCRIPTION
Hi all,

The narrative in the example of "Using interact" is wrong as if a tuple of strings is used it results in a `ValueError`. The docs say that a list or a dict should be used to create a dropdown widget using `interact`.
