### PR TITLE
WIP Don’t call the view general update method if just `_view_count` changes.

### DIFF
--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -651,7 +651,14 @@ abstract class WidgetView extends NativeView<WidgetModel> {
      * Public constructor.
      */
     initialize(parameters) {
-        this.listenTo(this.model, 'change', this.update);
+        this.listenTo(this.model, 'change', () => {
+            let changed = Object.keys(this.model.changedAttributes() || {});
+            if (changed[0] === '_view_count' && changed.length === 1) {
+                // Just the view count was updated
+                return;
+            }
+            this.update();
+        });
 
         this.options = parameters.options;
 


### PR DESCRIPTION
This may solve the issues we're having with _view_count changes in pythreejs causing infinite event trigger loops: https://github.com/jovyan/pythreejs/issues/95

CC @maartenbreddels, @SylvainCorlay 