### PR TITLE
fix: old behavious back of first using require local, then unpkg.com

### DIFF
--- a/jupyter-js-widgets/src-embed/embed-manager.ts
+++ b/jupyter-js-widgets/src-embed/embed-manager.ts
@@ -56,7 +56,10 @@ class EmbedManager extends ManagerBase<HTMLElement> {
                 // case.
                 resolve(widgets);
             } else {
-                (window as any).require([`https://unpkg.com/${moduleName}@${moduleVersion}/dist/index.js`], resolve, reject);
+                var fallback = function(err) {
+                    (window as any).require([`https://unpkg.com/${moduleName}@${moduleVersion}/dist/index.js`], resolve, reject);
+                };
+                (window as any).require([`${moduleName}.js`], resolve, fallback);
             }
         }).then(function(module) {
             if (module[className]) {


### PR DESCRIPTION
As discussed in #1038 this fixes an issue in #1313, such that when say a requirement module is `ipyvolume` needed, it just called require('ipyvolume'), and on failure tries to load if from unpkg