### PR TITLE
Fixes the dependency of IPython version when Python version is < 3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,6 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
-    'ipython>=4.0.0',
     'ipykernel>=4.5.1',
     'traitlets>=4.3.1',
     # Requiring nbformat to specify bugfix version which is not required by
@@ -122,6 +121,8 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
+    ':python_version<"3.3"' : ['ipython>=4.0.0,<6.0.0'],
+    ':python_version>="3.3"': ['ipython>=4.0.0'],
     'test:python_version=="2.7"': ['mock'],
     'test': ['nose'],
 }


### PR DESCRIPTION
IPython 6.0+ does not support Python 2.7, 3.0, 3.1, or 3.2, but accordingly
to the current specification, it is a valid requirement, even if Python < 3.3 is installed.

This patch makes IPython 6.0+ valid requirement only for Python >= 3.3. Otherwise, it requires IPython to be between 4 and 6. 

Without this solution, I am not being able to install ipywidgets:

````
# pip install jupyter
# Collecting jupyter
#   Downloading jupyter-1.0.0-py2.py3-none-any.whl
# ...
# Collecting ipython>=4.0.0 (from ipywidgets->jupyter)
#   Downloading ipython-6.0.0.tar.gz (5.1MB)
#     100% |████████████████████████████████| 5.1MB 164kB/s 
#     Complete output from command python setup.py egg_info:
#     
#     IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
#     When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
````