### PR TITLE
Fix datepicker reset on early dates

### DIFF
--- a/ipywidgets/widgets/tests/test_traits.py
+++ b/ipywidgets/widgets/tests/test_traits.py
@@ -27,21 +27,42 @@ class TestColor(TraitTestBase):
 class TestDateSerialization(TestCase):
 
     def setUp(self):
-        self.from_json = date_serialization['from_json']
         self.to_json = date_serialization['to_json']
         self.dummy_manager = None
 
     def test_serialize_none(self):
         self.assertIs(self.to_json(None, self.dummy_manager), None)
 
-    def serialize_date(self):
-        date = dt.date(1900, 2, 5)
+    def test_serialize_date(self):
+        date = dt.date(1900, 2, 18)
         expected = {
             'year': 1900,
             'month': 1,
-            'date': 4
+            'date': 18
         }
-        self.assertIs(self.to_json(date, self.dummy_manager), expected)
+        self.assertEqual(self.to_json(date, self.dummy_manager), expected)
+
+
+class TestDateDeserialization(TestCase):
+
+    def setUp(self):
+        self.from_json = date_serialization['from_json']
+        self.dummy_manager = None
+
+    def test_deserialize_none(self):
+        self.assertIs(self.from_json(None, self.dummy_manager), None)
+
+    def test_deserialize_date(self):
+        serialized_date = {
+            'year': 1900,
+            'month': 1,
+            'date': 18
+        }
+        expected = dt.date(1900, 2, 18)
+        self.assertEqual(
+            self.from_json(serialized_date, self.dummy_manager),
+            expected
+        )
 
 
 class TestBuffers(TestCase):

--- a/ipywidgets/widgets/tests/test_traits.py
+++ b/ipywidgets/widgets/tests/test_traits.py
@@ -3,12 +3,14 @@
 
 """Test trait types of the widget packages."""
 import array
+import datetime as dt
 
 from unittest import TestCase
 from traitlets import HasTraits
 from traitlets.tests.test_traitlets import TraitTestBase
 from ipywidgets import Color
 from ipywidgets.widgets.widget import _remove_buffers, _put_buffers
+from ipywidgets.widgets.trait_types import date_serialization
 
 
 class ColorTrait(HasTraits):
@@ -20,6 +22,26 @@ class TestColor(TraitTestBase):
 
     _good_values = ["blue", "#AA0", "#FFFFFF"]
     _bad_values = ["vanilla", "blues"]
+
+
+class TestDateSerialization(TestCase):
+
+    def setUp(self):
+        self.from_json = date_serialization['from_json']
+        self.to_json = date_serialization['to_json']
+        self.dummy_manager = None
+
+    def test_serialize_none(self):
+        self.assertIs(self.to_json(None, self.dummy_manager), None)
+
+    def serialize_date(self):
+        date = dt.date(1900, 2, 5)
+        expected = {
+            'year': 1900,
+            'month': 1,
+            'date': 4
+        }
+        self.assertIs(self.to_json(date, self.dummy_manager), expected)
 
 
 class TestBuffers(TestCase):

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -125,6 +125,7 @@ date_serialization = {
     'to_json': date_to_json
 }
 
+
 class InstanceDict(traitlets.Instance):
     """An instance trait which coerces a dict to an instance.
     

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -97,13 +97,11 @@ def date_to_json(pydate, manager):
     if pydate is None:
         return None
     else:
-        r = dict(
+        return dict(
             year=pydate.year,
             month=pydate.month - 1,  # Months are 0-based indices in JS
             date=pydate.day
         )
-        print(r)
-        return r
 
 
 def date_from_json(js, manager):

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -31,6 +31,14 @@ class Datetime(traitlets.TraitType):
     klass = dt.datetime
     default_value = dt.datetime(1900, 1, 1)
 
+
+class Date(traitlets.TraitType):
+    """A trait type holding a Python date object"""
+
+    klass = dt.date
+    default_value = dt.date(1900, 1, 1)
+
+
 def datetime_to_json(pydt, manager):
     """Serializes a Python datetime object to json.
 
@@ -59,6 +67,7 @@ def datetime_to_json(pydt, manager):
             milliseconds=pydt.microsecond / 1000
         )
 
+
 def datetime_from_json(js, manager):
     """Deserialize a Python datetime object from json"""
     if js is None:
@@ -74,9 +83,48 @@ def datetime_from_json(js, manager):
             js['milliseconds'] * 1000
         )
 
+
+def date_to_json(pydate, manager):
+    """Serializes a Python datetime object to json.
+
+    Instantiating a JavaScript Date object with a string assumes that the
+    string is a UTC string, while instantiating it with constructor arguments
+    assumes that it's in local time:
+
+    Attributes of this dictionary are to be passed to the JavaScript Date
+    constructor.
+    """
+    if pydate is None:
+        return None
+    else:
+        r = dict(
+            year=pydate.year,
+            month=pydate.month - 1,  # Months are 0-based indices in JS
+            date=pydate.day
+        )
+        print(r)
+        return r
+
+
+def date_from_json(js, manager):
+    """Deserialize a Python datetime object from json"""
+    if js is None:
+        return None
+    else:
+        return dt.date(
+            js['year'],
+            js['month'] + 1,  # Months are 1-based in Python
+            js['date'],
+        )
+
 datetime_serialization = {
     'from_json': datetime_from_json,
     'to_json': datetime_to_json
+}
+
+date_serialization = {
+    'from_json': date_from_json,
+    'to_json': date_to_json
 }
 
 class InstanceDict(traitlets.Instance):

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -40,7 +40,7 @@ class Date(traitlets.TraitType):
 
 
 def datetime_to_json(pydt, manager):
-    """Serializes a Python datetime object to json.
+    """Serialize a Python datetime object to json.
 
     Instantiating a JavaScript Date object with a string assumes that the
     string is a UTC string, while instantiating it with constructor arguments
@@ -69,7 +69,7 @@ def datetime_to_json(pydt, manager):
 
 
 def datetime_from_json(js, manager):
-    """Deserialize a Python datetime object from json"""
+    """Deserialize a Python datetime object from json."""
     if js is None:
         return None
     else:
@@ -83,13 +83,13 @@ def datetime_from_json(js, manager):
             js['milliseconds'] * 1000
         )
 
+datetime_serialization = {
+    'from_json': datetime_from_json,
+    'to_json': datetime_to_json
+}
 
 def date_to_json(pydate, manager):
-    """Serializes a Python datetime object to json.
-
-    Instantiating a JavaScript Date object with a string assumes that the
-    string is a UTC string, while instantiating it with constructor arguments
-    assumes that it's in local time:
+    """Serialize a Python date object.
 
     Attributes of this dictionary are to be passed to the JavaScript Date
     constructor.
@@ -105,7 +105,7 @@ def date_to_json(pydate, manager):
 
 
 def date_from_json(js, manager):
-    """Deserialize a Python datetime object from json"""
+    """Deserialize a Javascript date."""
     if js is None:
         return None
     else:
@@ -114,11 +114,6 @@ def date_from_json(js, manager):
             js['month'] + 1,  # Months are 1-based in Python
             js['date'],
         )
-
-datetime_serialization = {
-    'from_json': datetime_from_json,
-    'to_json': datetime_to_json
-}
 
 date_serialization = {
     'from_json': date_from_json,

--- a/ipywidgets/widgets/widget_date.py
+++ b/ipywidgets/widgets/widget_date.py
@@ -10,13 +10,14 @@ from .domwidget import LabeledWidget
 from .valuewidget import ValueWidget
 from .widget import register
 from .widget_core import CoreWidget
-from .trait_types import Datetime, datetime_serialization
+from .trait_types import Date, date_serialization
 from traitlets import Unicode
 
 
 @register
 class DatePicker(LabeledWidget, ValueWidget, CoreWidget):
-    value = Datetime(None, allow_none=True).tag(sync=True, **datetime_serialization)
+    value = Date(None, allow_none=True).tag(
+        sync=True, **date_serialization)
 
     _model_module = Unicode('jupyter-js-widgets').tag(sync=True)
     _view_module = Unicode('jupyter-js-widgets').tag(sync=True)

--- a/jupyter-js-widgets/src/widget_date.ts
+++ b/jupyter-js-widgets/src/widget_date.ts
@@ -9,14 +9,17 @@ import {
     CoreLabeledDOMWidgetModel
 } from './widget_core';
 
+import {
+    ManagerBase
+} from './manager-base'
+
 import * as _ from 'underscore';
 
 export
-function serialize_date(value, manager) {
+function serialize_date(value?: Date) {
     if (value === null) {
         return null;
     } else {
-        value = new Date(value);
         return {
             year: value.getUTCFullYear(),
             month: value.getUTCMonth(),
@@ -25,8 +28,14 @@ function serialize_date(value, manager) {
     }
 };
 
+export interface SerializedDate {
+    year: number,
+    month: number,
+    date: number
+};
+
 export
-function deserialize_date(value, manager) {
+function deserialize_date(value: SerializedDate) {
     if (value === null) {
         return null;
     } else {

--- a/jupyter-js-widgets/src/widget_date.ts
+++ b/jupyter-js-widgets/src/widget_date.ts
@@ -12,7 +12,7 @@ import {
 import * as _ from 'underscore';
 
 export
-function serialize_datetime(value, manager) {
+function serialize_date(value, manager) {
     if (value === null) {
         return null;
     } else {
@@ -20,71 +20,32 @@ function serialize_datetime(value, manager) {
         return {
             year: value.getFullYear(),
             month: value.getMonth(),
-            date: value.getDate(),
-            hours: value.getHours(),
-            minutes: value.getMinutes(),
-            seconds: value.getSeconds(),
-            milliseconds: value.getMilliseconds()
+            date: value.getDate()
         };
     }
 };
 
 export
-function deserialize_datetime(value, manager) {
+function deserialize_date(value, manager) {
+    console.log(value)
     if (value === null) {
         return null;
     } else {
         return new Date(
             value.year,
             value.month,
-            value.date,
-            value.hours,
-            value.minutes,
-            value.seconds,
-            value.milliseconds
+            value.date
         );
     }
 };
-
-function createDateAsUTC(date) {
-    if (date === null) {
-        return null;
-    } else {
-        return new Date(
-            Date.UTC(
-                date.getFullYear(),
-                date.getMonth(),
-                date.getDate(),
-                date.getHours(),
-                date.getMinutes(),
-                date.getSeconds()
-            )
-        );
-    }
-}
-
-function convertDateToUTC(date) {
-    if (date === null) {
-        return null;
-    } else {
-        return new Date(
-            date.getUTCFullYear(),
-            date.getUTCMonth(),
-            date.getUTCDate(),
-            date.getUTCHours(),
-            date.getUTCMinutes(),
-            date.getUTCSeconds()
-        );
-    }
-}
 
 export
 class DatePickerModel extends CoreLabeledDOMWidgetModel {
     static serializers = {
         ...CoreLabeledDOMWidgetModel.serializers,
         value: {
-            serialize: serialize_datetime,
-            deserialize: deserialize_datetime
+            serialize: serialize_date,
+            deserialize: deserialize_date
         }
     }
 
@@ -121,13 +82,13 @@ class DatePickerView extends LabeledDOMWidgetView {
 
     private _update_value() {
         var value = this.model.get('value');
-        this._datepicker.valueAsDate = createDateAsUTC(value);
+        this._datepicker.valueAsDate = value;
     }
 
     private _picker_change() {
-        this.model.set('value', convertDateToUTC(this._datepicker.valueAsDate));
+        this.model.set('value', this._datepicker.valueAsDate);
         this.touch();
     }
 
-    _datepicker: HTMLInputElement;
+    private _datepicker: HTMLInputElement;
 }

--- a/jupyter-js-widgets/src/widget_date.ts
+++ b/jupyter-js-widgets/src/widget_date.ts
@@ -81,7 +81,7 @@ class DatePickerView extends LabeledDOMWidgetView {
     }
 
     private _update_value() {
-        var value = this.model.get('value');
+        const value = this.model.get('value');
         this._datepicker.valueAsDate = value;
     }
 

--- a/jupyter-js-widgets/src/widget_date.ts
+++ b/jupyter-js-widgets/src/widget_date.ts
@@ -16,7 +16,7 @@ import {
 import * as _ from 'underscore';
 
 export
-function serialize_date(value?: Date) {
+function serialize_date(value: Date) {
     if (value === null) {
         return null;
     } else {
@@ -29,23 +29,31 @@ function serialize_date(value?: Date) {
 };
 
 export interface SerializedDate {
+    /**
+     * Full year
+     */
     year: number,
+
+    /**
+     * Zero-based month (0 means January, 11 means December)
+     */
     month: number,
+
+    /**
+     * Day of month
+     */
     date: number
 };
 
 export
-function deserialize_date(value?: SerializedDate) {
+function deserialize_date(value: SerializedDate) {
     if (value === null) {
         return null;
     } else {
-        return new Date(
-            Date.UTC(
-                value.year,
-                value.month,
-                value.date
-            )
-        );
+        let date = new Date();
+        date.setUTCFullYear(value.year, value.month, value.date);
+        date.setUTCHours(0, 0, 0, 0);
+        return date;
     }
 };
 

--- a/jupyter-js-widgets/src/widget_date.ts
+++ b/jupyter-js-widgets/src/widget_date.ts
@@ -35,7 +35,7 @@ export interface SerializedDate {
 };
 
 export
-function deserialize_date(value: SerializedDate) {
+function deserialize_date(value?: SerializedDate) {
     if (value === null) {
         return null;
     } else {

--- a/jupyter-js-widgets/src/widget_date.ts
+++ b/jupyter-js-widgets/src/widget_date.ts
@@ -18,23 +18,24 @@ function serialize_date(value, manager) {
     } else {
         value = new Date(value);
         return {
-            year: value.getFullYear(),
-            month: value.getMonth(),
-            date: value.getDate()
+            year: value.getUTCFullYear(),
+            month: value.getUTCMonth(),
+            date: value.getUTCDate()
         };
     }
 };
 
 export
 function deserialize_date(value, manager) {
-    console.log(value)
     if (value === null) {
         return null;
     } else {
         return new Date(
-            value.year,
-            value.month,
-            value.date
+            Date.UTC(
+                value.year,
+                value.month,
+                value.date
+            )
         );
     }
 };

--- a/jupyter-js-widgets/src/widget_date.ts
+++ b/jupyter-js-widgets/src/widget_date.ts
@@ -110,7 +110,6 @@ class DatePickerView extends LabeledDOMWidgetView {
         this.el.appendChild(this._datepicker);
 
         this.listenTo(this.model, 'change:value', this._update_value);
-
         this._update_value();
     }
 
@@ -130,5 +129,5 @@ class DatePickerView extends LabeledDOMWidgetView {
         this.touch();
     }
 
-    private _datepicker: HTMLInputElement;
+    _datepicker: HTMLInputElement;
 }

--- a/jupyter-js-widgets/test/src/index.ts
+++ b/jupyter-js-widgets/test/src/index.ts
@@ -3,3 +3,4 @@
 
 import './manager_test';
 import './widget_test';
+import './widget_date_test';

--- a/jupyter-js-widgets/test/src/widget_date_test.ts
+++ b/jupyter-js-widgets/test/src/widget_date_test.ts
@@ -56,4 +56,20 @@ describe('DatePickerView', function() {
         expect(getDatepicker(view.el).valueAsDate.getTime())
             .to.equal(testDate.getTime());
     });
+
+    it('set the model date', function() {
+        this.model.set('value', new Date(2017, 2, 25));
+        const options = { model: this.model };
+        const view = new widgets.DatePickerView(options);
+        view.render()
+
+        // Simulate setting the date in the datepicker
+        const testDate = new Date(2015, 2, 22)
+        const datepicker = getDatepicker(view.el)
+        datepicker.valueAsDate = testDate
+        datepicker.dispatchEvent(new Event('change', {"bubbles":true}))
+
+        expect(this.model.get('value').getTime())
+            .to.equal(testDate.getTime());
+    })
 })

--- a/jupyter-js-widgets/test/src/widget_date_test.ts
+++ b/jupyter-js-widgets/test/src/widget_date_test.ts
@@ -94,4 +94,32 @@ describe('DatePickerView', function() {
             .to.equal(testDate.getTime());
     });
 
-})
+});
+
+describe('serialize_date', function() {
+    it('null date', function() {
+        expect(widgets.serialize_date(null)).to.be.a('null')
+    });
+
+    it('UTC date', function() {
+        const date = new Date('Sat May 13 2017 00:00:00 UTC')
+        const expectedSerialization = {
+            year: 2017,
+            month: 4,
+            date: 13
+        }
+        expect(widgets.serialize_date(date))
+            .to.deep.equal(expectedSerialization)
+    });
+
+    it('date in other locale as UTC', function() {
+        const date = new Date('Sat May 13 2017 00:00:00 GMT+0100 (BST)')
+        const expectedSerialization = {
+            year: 2017,
+            month: 4,
+            date: 12 // still on 12th May in UTC
+        }
+        expect(widgets.serialize_date(date))
+            .to.deep.equal(expectedSerialization)
+    });
+});

--- a/jupyter-js-widgets/test/src/widget_date_test.ts
+++ b/jupyter-js-widgets/test/src/widget_date_test.ts
@@ -69,13 +69,13 @@ describe('DatePickerView', function() {
         this.model.set('value', null);
         const options = { model: this.model };
         const view = new widgets.DatePickerView(options);
-        view.render()
+        view.render();
 
         // Simulate setting the date in the datepicker
-        const testDate = new Date(2015, 2, 22)
-        const datepicker = getDatepicker(view.el)
-        datepicker.valueAsDate = testDate
-        datepicker.dispatchEvent(new Event('change', {"bubbles":true}))
+        const testDate = new Date(2015, 2, 22);
+        const datepicker = getDatepicker(view.el);
+        datepicker.valueAsDate = testDate;
+        datepicker.dispatchEvent(new Event('change', {"bubbles":true}));
 
         expect(this.model.get('value').getTime())
             .to.equal(testDate.getTime());
@@ -89,9 +89,9 @@ describe('DatePickerView', function() {
 
         const testDate = new Date(2015, 2, 22);
         this.model.set('value', testDate);
-        const datepicker = getDatepicker(view.el)
+        const datepicker = getDatepicker(view.el);
         expect(datepicker.valueAsDate.getTime())
-            .to.equal(testDate.getTime())
+            .to.equal(testDate.getTime());
     });
 
 })

--- a/jupyter-js-widgets/test/src/widget_date_test.ts
+++ b/jupyter-js-widgets/test/src/widget_date_test.ts
@@ -123,3 +123,20 @@ describe('serialize_date', function() {
             .to.deep.equal(expectedSerialization)
     });
 });
+
+describe('deserialize_date', function() {
+    it('null date', function() {
+        expect(widgets.deserialize_date(null)).to.be.a('null')
+    });
+
+    it('valid date', function() {
+        const serialized = {
+            year: 2017,
+            month: 4,
+            date: 12
+        };
+        const expectedDate = new Date('2017-05-12');
+        expect(widgets.deserialize_date(serialized).getTime())
+            .to.equal(expectedDate.getTime())
+    });
+})

--- a/jupyter-js-widgets/test/src/widget_date_test.ts
+++ b/jupyter-js-widgets/test/src/widget_date_test.ts
@@ -1,0 +1,59 @@
+import {
+    DummyManager
+} from './dummy-manager';
+
+import {
+    expect
+} from 'chai';
+
+import * as sinon from 'sinon';
+
+import * as widgets from '../../lib';
+
+function getDatepicker(parent: Element): HTMLInputElement {
+    const elem = parent.querySelector('input[type="date"]')
+    return <HTMLInputElement>elem;
+}
+
+describe('DatePickerView', function() {
+    beforeEach(function() {
+        this.manager = new DummyManager();
+        const modelId = Math.random()
+            .toString(36)
+            .replace(/[^a-z]+/g, '')
+            .substr(0, 5);
+
+        return this.manager.new_widget({
+            model_module: 'jupyter-js-widgets',
+            model_name: 'WidgetModel',
+            model_id: modelId,
+            widget_class: 'ipywidgets.Widget'
+        }, { description: 'test-date-model'} ).then(model => {
+            this.model = model;
+        }).catch(err => {
+            console.error('Could not create widget', Error.prototype.toString.call(err));
+            if (err.stack) {
+              console.error('  Trace:', err.stack);
+            }
+            if (err.error_stack) {
+              err.error_stack.forEach((subErr, i) => console.error(`  Chain[${i}]:`, Error.prototype.toString.call(subErr)));
+            }
+        });
+    });
+
+    it('construction', function() {
+        const options = { model: this.model };
+        const view = new widgets.DatePickerView(options);
+        expect(view).to.not.be.undefined;
+    });
+
+    it('initial date value', function() {
+        const testDate = new Date(2017, 2, 25); // initial date value
+        this.model.set('value', testDate);
+        const options = { model: this.model };
+        const view = new widgets.DatePickerView(options);
+        view.render();
+        expect(getDatepicker(view.el).valueAsDate.getTime())
+            .to.equal(testDate.getTime());
+    });
+})

--- a/jupyter-js-widgets/test/src/widget_date_test.ts
+++ b/jupyter-js-widgets/test/src/widget_date_test.ts
@@ -57,8 +57,16 @@ describe('DatePickerView', function() {
             .to.equal(testDate.getTime());
     });
 
+    it('no initial value', function() {
+        this.model.set('value', null);
+        const options = { model: this.model };
+        const view = new widgets.DatePickerView(options);
+        view.render();
+        expect(getDatepicker(view.el).valueAsDate).to.be.a('null');
+    });
+
     it('set the model date', function() {
-        this.model.set('value', new Date(2017, 2, 25));
+        this.model.set('value', null);
         const options = { model: this.model };
         const view = new widgets.DatePickerView(options);
         view.render()

--- a/jupyter-js-widgets/test/src/widget_date_test.ts
+++ b/jupyter-js-widgets/test/src/widget_date_test.ts
@@ -79,5 +79,19 @@ describe('DatePickerView', function() {
 
         expect(this.model.get('value').getTime())
             .to.equal(testDate.getTime());
-    })
+    });
+
+    it('update when the model changes', function() {
+        this.model.set('value', null);
+        const options = { model: this.model };
+        const view = new widgets.DatePickerView(options);
+        view.render();
+
+        const testDate = new Date(2015, 2, 22);
+        this.model.set('value', testDate);
+        const datepicker = getDatepicker(view.el)
+        expect(datepicker.valueAsDate.getTime())
+            .to.equal(testDate.getTime())
+    });
+
 })

--- a/jupyter-js-widgets/test/src/widget_date_test.ts
+++ b/jupyter-js-widgets/test/src/widget_date_test.ts
@@ -122,6 +122,17 @@ describe('serialize_date', function() {
         expect(widgets.serialize_date(date))
             .to.deep.equal(expectedSerialization)
     });
+
+    it('date before 100AD', function() {
+        const date = new Date("0005-04-28")
+        const expectedSerialization = {
+            year: 5,
+            month: 3,
+            date: 28
+        }
+        expect(widgets.serialize_date(date))
+            .to.deep.equal(expectedSerialization)
+    });
 });
 
 describe('deserialize_date', function() {


### PR DESCRIPTION
This addresses issue #1322.

Prior to this PR, all the characters were reset when a user started typing the year in the datepicker. This arose because `new Date(year, ...)` interprets a number below 100 as a two-digit year (i.e. 5 gets mapped to 1905), whereas the datepicker interprets it as a 4-digit year (i.e. 5 gets mapped to 5AD). Every time the user typed a character, the view forced a roundtrip to a timestamp and back to convert the date to UTC.

The fix implemented here removes that roundtrip: dates in the view and the JS model are stored as `Date` object without trying to force them to UTC -- there is no loss of information here since dates are time-zone aware anyway. The conversion to UTC happens just before serialization: the date gets passed to the Python layer as a UTC date.

This PR also:
 - changes the trait in the Python model to a `datetime.date`, rather than a `datetime.datetime`. The datepicker object doesn't let us set the time, so it seems a bit strange to pretend we can give that information back to the user. This change is orthogonal to the fix, so we can remove it if you don't think it's the right choice.
 - implements tests for the JS view.

What's left to do:

 - [x] unit tests for {de,}serializers on both the JS and Python side
