### PR TITLE
Clarify that the custom serializers are given the widget instance as a second argument, not the widget manager.

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -26,11 +26,11 @@ Major changes developers should be aware of include:
 
 - The python `@register` decorator for widget classes no longer takes a string argument, but registers a widget class using the `_model_*` and `_view_*` traits in the class. Using the decorator as `@register('name')` is deprecated and should be changed to just `@register`. [#1228](https://github.com/jupyter-widgets/ipywidgets/pull/1228), [#1276](https://github.com/jupyter-widgets/ipywidgets/pull/1276)
 - Widgets will now need correct `_model_module` and `_view_module` Unicode traits defined.
-- Custom serializers in Javascript are now synchronous, and should return a snapshot of the widget state. The default serializer makes a copy of JSONable objects. ([#1270](https://github.com/jupyter-widgets/ipywidgets/pull/1270))
 - Selection widgets now sync the index of the selected item, rather than the label. ([#1262](https://github.com/jupyter-widgets/ipywidgets/pull/1262))
 - The widget protocol was significantly overhauled. The new widget messaging protocol (version 2) is specified in the [version 2 protocol documentation](https://github.com/jupyter-widgets/ipywidgets/blob/master/jupyter-widgets-schema/messages.md).
+- Custom serializers in Javascript are now synchronous, and should return a snapshot of the widget state. The default serializer makes a copy of JSONable objects. ([#1270](https://github.com/jupyter-widgets/ipywidgets/pull/1270))
 - Custom serializers in either Python or Javascript can now return a structure which contains binary buffers. If a binary buffer is in the serialized data structure, the message will be synced in binary, which is much more efficient. ([#1194](https://github.com/jupyter-widgets/ipywidgets/pull/1194))
-
+- A custom serializer is given the widget instance as its second argument, and a custom deserializer is given the widget manager as its second argument.
 
 6.0
 ---

--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -26,7 +26,7 @@ const JUPYTER_WIDGETS_VERSION = '3.0.0';
  * Replace model ids with models recursively.
  */
 export
-function unpack_models(value, manager) {
+function unpack_models(value, manager): Promise<any> {
     var unpacked;
     if (_.isArray(value)) {
         unpacked = [];
@@ -472,7 +472,7 @@ class WidgetModel extends Backbone.Model {
      * and the kernel-side serializer/deserializer.
      */
     toJSON(options) {
-        return 'IPY_MODEL_' + this.id;
+        return `IPY_MODEL_${this.id}`;
     }
 
     /**
@@ -498,29 +498,10 @@ class WidgetModel extends Backbone.Model {
         return utils.resolvePromisesDict(deserialized);
     }
 
-    /**
-     * Returns a promise for the serialized state. The second argument
-     * is an instance of widget manager.
-     */
-    static _serialize_state(state, manager) {
-        var serializers = this.serializers;
-        var serialized;
-        if (serializers) {
-            serialized = {};
-            for (var k in state) {
-                if (serializers[k] && serializers[k].serialize) {
-                     serialized[k] = (serializers[k].serialize)(state[k], manager);
-                } else {
-                     serialized[k] = state[k];
-                }
-            }
-        } else {
-            serialized = state;
-        }
-        return utils.resolvePromisesDict(serialized);
-    }
-
-    static serializers: any;
+    static serializers: {[key: string]: {
+        deserialize?: (value?: any, manager?: any) => any,
+        serialize?: (value?: any, widget?: any) => any
+    }};
     widget_manager: any;
     state_change: any
     _buffered_state_diff: any;

--- a/jupyter-js-widgets/test/src/widget_test.ts
+++ b/jupyter-js-widgets/test/src/widget_test.ts
@@ -121,12 +121,12 @@ describe("Widget", function() {
         // other asynchronously using a promise.
         this.widget.constructor.serializers = {
             a: {
-                deserialize: (value, widget) => {
+                deserialize: (value, manager) => {
                     return value*3.0;
                 }
             },
             b: {
-                deserialize: (value, widget) => {
+                deserialize: (value, manager) => {
                     return Promise.resolve(value/2.0);
                 }
             }


### PR DESCRIPTION
We had not been calling the static _serialize_state method, and there was ambiguity with what the second argument was.

This incorporates the last part of #1300.