### PR TITLE
More testing

### DIFF
--- a/jupyter-js-widgets/src/manager-base.ts
+++ b/jupyter-js-widgets/src/manager-base.ts
@@ -108,8 +108,8 @@ abstract class ManagerBase<T> {
      * Modifies view options. Generally overloaded in custom widget manager
      * implementations.
      */
-    setViewOptions(options) {
-        return options || {};
+    setViewOptions(options = {}) {
+        return options;
     };
 
     /**
@@ -118,7 +118,7 @@ abstract class ManagerBase<T> {
      * Make sure the view creation is not out of order with
      * any state updates.
      */
-    create_view(model, options) {
+    create_view(model, options = {}) {
         model.state_change = model.state_change.then(() => {
 
             return this.loadClass(model.get('_view_name'),

--- a/jupyter-js-widgets/test/src/dummy-manager.ts
+++ b/jupyter-js-widgets/test/src/dummy-manager.ts
@@ -111,7 +111,7 @@ class TestWidget extends widgets.WidgetModel {
             _model_name: "TestWidget",
             _model_module_version: '1.0.0',
             _view_module: "test-widgets",
-            _view_name: null,
+            _view_name: "TestWidgetView",
             _view_module_version: '1.0.0',
             _view_count: null,
         }
@@ -126,8 +126,16 @@ class BinaryWidget extends TestWidget {
     defaults() {
         return {...super.defaults(),
             _model_name: "BinaryWidget",
+            _view_name: "BinaryWidgetView",
             array: new Int8Array(0)};
     }
 }
 
-let testWidgets = {BinaryWidget}
+class BinaryWidgetView extends widgets.WidgetView {
+    render() {
+        this._rendered += 1
+    }
+    _rendered = 0;
+}
+
+let testWidgets = {BinaryWidget, BinaryWidgetView}


### PR DESCRIPTION
Takes us from

```
-------------------------------|----------|----------|----------|----------|----------------|
File                           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-------------------------------|----------|----------|----------|----------|----------------|
  manager-base.js              |    82.14 |    66.67 |     72.5 |    83.08 |... 317,318,319 |
```
to
```
-------------------------------|----------|----------|----------|----------|----------------|
File                           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-------------------------------|----------|----------|----------|----------|----------------|
  manager-base.js              |    92.36 |       75 |       90 |    91.67 |... 319,320,321 |
```