### PR TITLE
Avoid resetting the date on invalid keyboard input

### DIFF
--- a/jupyter-js-widgets/css/widgets-base.css
+++ b/jupyter-js-widgets/css/widgets-base.css
@@ -819,6 +819,10 @@
     border-color: var(--jp-widgets-input-focus-border-color);
 }
 
+.widget-datepicker input[type="date"]:invalid {
+    border-color: var(--jp-warn-color1);
+}
+
 /* Play Widget */
 
 .widget-play {

--- a/jupyter-js-widgets/src/widget_date.ts
+++ b/jupyter-js-widgets/src/widget_date.ts
@@ -104,8 +104,10 @@ class DatePickerView extends LabeledDOMWidgetView {
     }
 
     private _picker_change() {
-        this.model.set('value', this._datepicker.valueAsDate);
-        this.touch();
+        if (!this._datepicker.validity.badInput) {
+            this.model.set('value', this._datepicker.valueAsDate);
+            this.touch();
+        }
     }
 
     private _datepicker: HTMLInputElement;


### PR DESCRIPTION
Prior to this commit, the datepicker value was passed to the user for every change, even when it was invalid. This caused errors when the date was partly filled in: it would get reset to empty, losing the partial (invalid) state.

To reproduce:

 - create a datepicker (in Chrome) and set the date to 31st January 2000
 - click on the months field and cycle through the months -- prior to this PR, the input would get reset every time we encountered a month with fewer than 31 days. Now, the datepicker border just goes red and the input is not pushed to the backend.

Fixes #1115 .

It'd be great to get feedback on:

 - giving the user clues that their date is not getting transmitted to the backend. At the moment, I've just added a small orange border. Is that too subtle? Is there another way we do this for other widgets?
 - testing: it's surprisingly hard to inject a bad string into the datepicker programatically, as far as I can tell. I think we can either simulate the key presses directly, which seems error prone and brittle, or somehow mock out the datepicker element so we can give it arbitrary state, or assume that the changes are sufficiently simple that they don't need testing. I'm in favour of the latter, I think, but happy to implement a test if we think it's useful.