### PR TITLE
Make WidgetModel.set docstring more specific

### DIFF
--- a/jupyter-js-widgets/src/widget.ts
+++ b/jupyter-js-widgets/src/widget.ts
@@ -277,9 +277,10 @@ class WidgetModel extends Backbone.Model {
     }
 
     /**
-     * Set a value.
+     * Set one or more values.
      *
-     * We just call the super method, in which val and options are optional
+     * We just call the super method, in which val and options are optional.
+     * Handles both "key", value and {key: value} -style arguments.
      */
     set(key, val?, options?) {
         var return_value = super.set(key, val, options);


### PR DESCRIPTION
Sometimes you might want to set several attributes of a model at the same time, with only one "change" notification. `WidgetModel.set()` can handle this directly, so this PR updates the docstring to be more explicit about this.