### PR TITLE
Updates to use jupyter_alabaster_theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,7 +5,6 @@
 import os
 import subprocess
 import sys
-import jupyter_alabaster_theme
 import recommonmark.parser
 
 
@@ -66,7 +65,7 @@ release = _release['__version__']
 
 master_doc = 'index'
 project = 'ipywidgets and jupyter-js-widgets'
-copyright = '2016, Jupyter Team, https://jupyter.org'
+copyright = '2017 Project Jupyter'
 author = 'Jupyter Team'
 
 language = None

--- a/docs/source/developer_docs.rst
+++ b/docs/source/developer_docs.rst
@@ -1,0 +1,10 @@
+Developer Docs
+===============
+
+.. toctree::
+   :maxdepth: 3
+
+   dev_install.md
+   dev_testing.md
+   dev_docs
+   dev_release.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,33 +1,11 @@
 ipywidgets
 ==========
 
-Contents
+Full Table of Contents
 --------
 
 .. toctree::
     :maxdepth: 2
-    :caption: User Guide
 
-    user_install.md
-    examples/Using Interact.ipynb
-    examples/Widget Basics.ipynb
-    examples/Widget List.ipynb
-    examples/Widget Events.ipynb
-    examples/Widget Styling.ipynb
-    examples/Widget Custom.ipynb
-    examples/Widget Alignment.ipynb
-    examples/Widget Low Level.ipynb
-    examples/Widget Asynchronous.ipynb
-    embedding.md
-    contributing.md
-    changelog.md
-
-
-.. toctree::
-    :maxdepth: 2
-    :caption: Developer Docs
-
-    dev_install.md
-    dev_testing.md
-    dev_docs
-    dev_release.md
+    user_guide
+    developer_docs

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -1,0 +1,19 @@
+User Guide
+===========
+
+.. toctree::
+  :maxdepth: 3
+
+  user_install.md
+  examples/Using Interact.ipynb
+  examples/Widget Basics.ipynb
+  examples/Widget List.ipynb
+  examples/Widget Events.ipynb
+  examples/Widget Styling.ipynb
+  examples/Widget Custom.ipynb
+  examples/Widget Alignment.ipynb
+  examples/Widget Low Level.ipynb
+  examples/Widget Asynchronous.ipynb
+  embedding.md
+  contributing.md
+  changelog.md


### PR DESCRIPTION
It's really nice that this subproject is using the new theme!

To use the theme `captions` cannot be used in the `toctree` and there needs to be one `toctree`.
This PR consolidates User Guide and Developers Docs into their own sections within the toctree. There is a single Table of Contents on index now.

Leaving `captions` in the `toctree` leads to this issue in the mobile version
![screen shot 2017-05-19 at 2 09 42 pm](https://cloud.githubusercontent.com/assets/16314651/26267022/de0548f8-3c9c-11e7-8886-4c4b4bf947b3.png)


Also:
- removed `jupyter_alabaster_theme` import in conf.py
- updated copyright text to match jupyter.org website