### PR TITLE
Add __repr__ to Widget for testing/debugging

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -247,6 +247,34 @@ class Widget(LoggingHasTraits):
     # widget_types is a registry of widgets by module, version, and name:
     widget_types = WidgetRegistry()
 
+    def __repr__(self):
+        """
+        Textual representation of this widget, mainly used for testing
+        and debugging.
+        """
+        # List of attributes to show with default values. The attribute
+        # is printed if it exists and its value is not equal to this
+        # default value.
+        attributes = [("value", None),
+                      ("min", None),
+                      ("max", None),
+                      ("step", None),
+                      ("options", None),
+                      ("description", ""),
+                      ("children", [])]
+        r = ""
+        for (attr, default) in attributes:
+            try:
+                v = getattr(self, attr)
+            except AttributeError:
+                continue
+            if default == v:
+                continue
+            if r:
+                r += ", "
+            r += attr + "=" + repr(v)
+        return "%s(%s)" % (type(self).__name__, r)
+
     @staticmethod
     def on_widget_constructed(callback):
         """Registers a callback to be called when a widget is constructed.


### PR DESCRIPTION
Originally by @jdemeyer and is currently being used in Sage 7.6+ to help with debugging and testing.

Source: https://git.sagemath.org/sage.git/tree/build/pkgs/ipywidgets/patches/widget_repr.patch?h=develop
