### PR TITLE
Add repr strings for widgets

### DIFF
--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -36,3 +36,9 @@ class DOMWidget(Widget):
         if className in self._dom_classes:
             self._dom_classes = [c for c in self._dom_classes if c != className]
         return self
+
+    def _repr_keys(self):
+        # We also need to include _dom_classes in repr for reproducibility
+        yield from super(DOMWidget, self)._repr_keys()
+        if self._dom_classes:
+            yield '_dom_classes'

--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -39,6 +39,7 @@ class DOMWidget(Widget):
 
     def _repr_keys(self):
         # We also need to include _dom_classes in repr for reproducibility
-        yield from super(DOMWidget, self)._repr_keys()
+        for key in super(DOMWidget, self)._repr_keys():
+            yield key
         if self._dom_classes:
             yield '_dom_classes'

--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -38,8 +38,13 @@ class DOMWidget(Widget):
         return self
 
     def _repr_keys(self):
-        # We also need to include _dom_classes in repr for reproducibility
         for key in super(DOMWidget, self)._repr_keys():
+            # Exclude layout if it had the default value
+            if key == 'layout':
+                value = getattr(self, key)
+                if repr(value) == '%s()' % value.__class__.__name__:
+                    continue
             yield key
+        # We also need to include _dom_classes in repr for reproducibility
         if self._dom_classes:
             yield '_dom_classes'

--- a/ipywidgets/widgets/valuewidget.py
+++ b/ipywidgets/widgets/valuewidget.py
@@ -18,3 +18,10 @@ class ValueWidget(Widget):
         to process the raw value ``self.value``.
         """
         return self.value
+
+    def _repr_keys(self):
+        # Ensure value key comes first, and is always present
+        yield 'value'
+        for key in super(ValueWidget, self)._repr_keys():
+            if key != 'value':
+                yield key

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -284,7 +284,7 @@ class Widget(LoggingHasTraits):
         """Returns the full state for a widget manager for embedding
 
         :param drop_defaults: when True, it will not include default value
-        :param widgets: list with widgets to include in the state (or all widgets when None) 
+        :param widgets: list with widgets to include in the state (or all widgets when None)
         :return:
         """
         state = {}
@@ -540,6 +540,18 @@ class Widget(LoggingHasTraits):
                 # Send new state to front-end
                 self.send_state(key=name)
         super(Widget, self).notify_change(change)
+
+    def __repr__(self):
+        class_name = self.__class__.__name__
+        traits = self.traits()
+        signature_entires = []
+        for key in self.keys():
+            value = getattr(self, key)
+            if key[0] == '_' or self._compare(value, traits[key].default_value):
+                continue
+            signature_entires.append('%s=%r' % (key, value))
+        signature = ', '.join(signature_entires)
+        return '%s(%s)' % (class_name, signature)
 
     #-------------------------------------------------------------------------
     # Support methods

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -664,7 +664,7 @@ class Widget(LoggingHasTraits):
     def _repr_keys(self):
         traits = self.traits()
         for key in sorted(self.keys):
-            # Exculde traits that start with an underscore
+            # Exclude traits that start with an underscore
             if key[0] == '_':
                 continue
             # Exclude traits who are equal to their default value

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -542,16 +542,7 @@ class Widget(LoggingHasTraits):
         super(Widget, self).notify_change(change)
 
     def __repr__(self):
-        class_name = self.__class__.__name__
-        traits = self.traits()
-        signature_entires = []
-        for key in self.keys():
-            value = getattr(self, key)
-            if key[0] == '_' or self._compare(value, traits[key].default_value):
-                continue
-            signature_entires.append('%s=%r' % (key, value))
-        signature = ', '.join(signature_entires)
-        return '%s(%s)' % (class_name, signature)
+        return self._gen_repr_from_keys(self._repr_keys())
 
     #-------------------------------------------------------------------------
     # Support methods
@@ -667,3 +658,18 @@ class Widget(LoggingHasTraits):
         """Sends a message to the model in the front-end."""
         if self.comm is not None and self.comm.kernel is not None:
             self.comm.send(data=msg, buffers=buffers)
+
+    def _repr_keys(self):
+        traits = self.traits()
+        for key in sorted(self.keys):
+            if key[0] == '_' or self._compare(getattr(self, key), traits[key].default_value):
+                continue
+            yield key
+
+    def _gen_repr_from_keys(self, keys):
+        class_name = self.__class__.__name__
+        signature = ', '.join(
+            '%s=%r' % (key, getattr(self, key))
+            for key in keys
+        )
+        return '%s(%s)' % (class_name, signature)

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -12,7 +12,9 @@ import sys
 from IPython.core.getipython import get_ipython
 from ipykernel.comm import Comm
 from traitlets.utils.importstring import import_item
-from traitlets import HasTraits, Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default
+from traitlets import (
+    HasTraits, Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default, Container,
+    Undefined)
 from ipython_genutils.py3compat import string_types, PY3
 from IPython.display import display
 
@@ -662,7 +664,18 @@ class Widget(LoggingHasTraits):
     def _repr_keys(self):
         traits = self.traits()
         for key in sorted(self.keys):
-            if key[0] == '_' or self._compare(getattr(self, key), traits[key].default_value):
+            # Exculde traits that start with an underscore
+            if key[0] == '_':
+                continue
+            # Exclude traits who are equal to their default value
+            value = getattr(self, key)
+            trait = traits[key]
+            if self._compare(value, trait.default_value):
+                continue
+            elif (isinstance(trait, (Container, Dict)) and
+                  trait.default_value == Undefined and
+                  len(value) == 0):
+                # Empty container, and dynamic default will be empty
                 continue
             yield key
 

--- a/ipywidgets/widgets/widget_description.py
+++ b/ipywidgets/widgets/widget_description.py
@@ -21,3 +21,12 @@ class DescriptionWidget(DOMWidget, CoreWidget):
     _model_name = Unicode('DescriptionModel').tag(sync=True)
     description = Unicode('', help="Description of the control.").tag(sync=True)
     style = InstanceDict(DescriptionStyle, help="Styling customizations").tag(sync=True, **widget_serialization)
+
+    def _repr_keys(self):
+        for key in super(DescriptionWidget, self)._repr_keys():
+            # Exclude style if it had the default value
+            if key == 'style':
+                value = getattr(self, key)
+                if repr(value) == '%s()' % value.__class__.__name__:
+                    continue
+            yield key

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -11,6 +11,7 @@ try:
     from itertools import izip
 except ImportError:  #python3.x
     izip = zip
+from itertools import chain
 
 from .widget_description import DescriptionWidget
 from .valuewidget import ValueWidget
@@ -153,6 +154,15 @@ class _Selection(DescriptionWidget, ValueWidget, CoreWidget):
         if self.index != index:
             self.index = index
 
+    def _repr_keys(self):
+        keys = super(_Selection, self)._repr_keys()
+        # Include options manually, as it isn't marked as synced:
+        for key in sorted(chain(keys, ('options',))):
+            if key == 'index' and self.index == 0:
+                # Index 0 is default when there are options
+                continue
+            yield key
+
 
 class _MultipleSelection(DescriptionWidget, ValueWidget, CoreWidget):
     """Base class for multiple Selection widgets
@@ -255,6 +265,12 @@ class _MultipleSelection(DescriptionWidget, ValueWidget, CoreWidget):
         index = tuple(self._options_labels.index(i) for i in change.new)
         if self.index != index:
             self.index = index
+
+    def _repr_keys(self):
+        keys = super(_MultipleSelection, self)._repr_keys()
+        # Include options manually, as it isn't marked as synced:
+        for key in sorted(chain(keys, ('options',))):
+            yield key
 
 
 @register

--- a/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/ipywidgets/widgets/widget_selectioncontainer.py
@@ -49,6 +49,12 @@ class _SelectionContainer(Box, CoreWidget):
         else:
             return None
 
+    def _repr_keys(self):
+        # We also need to include _titles in repr for reproducibility
+        yield from super(_SelectionContainer, self)._repr_keys()
+        if self._titles:
+            yield '_titles'
+
 
 @register
 class Accordion(_SelectionContainer):

--- a/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/ipywidgets/widgets/widget_selectioncontainer.py
@@ -51,7 +51,8 @@ class _SelectionContainer(Box, CoreWidget):
 
     def _repr_keys(self):
         # We also need to include _titles in repr for reproducibility
-        yield from super(_SelectionContainer, self)._repr_keys()
+        for key in super(_SelectionContainer, self)._repr_keys():
+            yield key
         if self._titles:
             yield '_titles'
 

--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -111,3 +111,8 @@ class Password(Text):
     """Single line textbox widget."""
     _view_name = Unicode('PasswordView').tag(sync=True)
     _model_name = Unicode('PasswordModel').tag(sync=True)
+
+    def _repr_keys(self):
+        # Don't include password value in repr!
+        super_keys = super(Password, self)._repr_keys()
+        yield from (key for key in super_keys if key != 'value')

--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -115,4 +115,6 @@ class Password(Text):
     def _repr_keys(self):
         # Don't include password value in repr!
         super_keys = super(Password, self)._repr_keys()
-        yield from (key for key in super_keys if key != 'value')
+        for key in super_keys:
+            if key != 'value':
+                yield key


### PR DESCRIPTION
Add a base repr that is a constructor call with the following keyword arguments:
 - All traits with `sync=True` (via `self.keys`), except:
   - When trait name start with an underscore.
   - When value is equal to the default value.

Also adds a few overriden versions as appropriate.