### PR TITLE
Naming fix for the htmlmanager

### DIFF
--- a/jupyter-widgets-htmlmanager/src/htmlmanager.ts
+++ b/jupyter-widgets-htmlmanager/src/htmlmanager.ts
@@ -6,11 +6,11 @@ import * as widgets from 'jupyter-js-widgets';
 import * as PhosphorWidget from '@phosphor/widgets';
 
 export
-class EmbedManager extends widgets.ManagerBase<HTMLElement> {
+class HTMLManager extends widgets.ManagerBase<HTMLElement> {
 
     /**
      * Display the specified view. Element where the view is displayed
-     * is specified in the `options` argument.
+     * is specified in the `options.el` argument.
      */
     display_view(msg, view, options) {
         return Promise.resolve(view).then(function(view) {

--- a/jupyter-widgets-htmlmanager/src/index.ts
+++ b/jupyter-widgets-htmlmanager/src/index.ts
@@ -2,4 +2,4 @@
 // Distributed under the terms of the Modified BSD License.
 
 export * from "./embed-helper";
-export * from "./embed-manager";
+export * from "./htmlmanager";


### PR DESCRIPTION
Follow-up to #1394.