### PR TITLE
Missing CSS in notebook extension

### DIFF
--- a/widgetsnbextension/package.json
+++ b/widgetsnbextension/package.json
@@ -26,6 +26,7 @@
     "@phosphor/widgets": "^1.2.0",
     "backbone": "^1.2.3",
     "jupyter-js-widgets": "3.0.0-alpha.6",
+    "@jupyter-widgets/base": "^0.1.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/widgetsnbextension/src/extension.js
+++ b/widgetsnbextension/src/extension.js
@@ -134,7 +134,7 @@ function load_ipython_extension () {
             "notebook/js/outputarea"
         ], function(Jupyter, events, outputarea) {
             require("@phosphor/widgets/style/index.css")
-            require("jupyter-widgets-base/css/index.css");
+            require("@jupyter-widgets/base/css/index.css");
             require('jupyter-js-widgets/css/widgets.css');
             register_events(Jupyter, events, outputarea);
             resolve();


### PR DESCRIPTION
At the moment, `npm i` in `widgetsnbextension` fails on master with the error:

```
ERROR in ./src/extension.js
Module not found: Error: Cannot resolve module 'jupyter-widgets-base/css/index.css' in /Users/pascal/oss/ipywidgets/widgetsnbextension/src
 @ ./src/extension.js 137:12-57
```

It looks like the wrong path was to the CSS is used by accident? Anyway, this PR fixes it.