### PR TITLE
[WIP] Traitlets Default Validation

### DIFF
--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -46,9 +46,9 @@ class _BoundedFloat(_Float):
     def _validate_min(self, proposal):
         """Enforce min <= value <= max"""
         min = proposal['value']
-        if min > self.max:
+        if self.has_trait_value("max") and min > self.max:
             raise TraitError('Setting min > max')
-        if min > self.value:
+        if self.has_trait_value("value") and min > self.value:
             self.value = min
         return min
 
@@ -56,9 +56,9 @@ class _BoundedFloat(_Float):
     def _validate_max(self, proposal):
         """Enforce min <= value <= max"""
         max = proposal['value']
-        if max < self.min:
+        if self.has_trait_value("min") and max < self.min:
             raise TraitError('setting max < min')
-        if max < self.value:
+        if self.has_trait_value("value") and max < self.value:
             self.value = max
         return max
 

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -109,9 +109,9 @@ class _BoundedInt(_Int):
     def _validate_min(self, proposal):
         """Enforce min <= value <= max"""
         min = proposal['value']
-        if min > self.max:
+        if self.has_trait_value("min") and min > self.max:
             raise TraitError('setting min > max')
-        if min > self.value:
+        if self.has_trait_value("value") and min > self.value:
             self.value = min
         return min
 
@@ -119,9 +119,9 @@ class _BoundedInt(_Int):
     def _validate_max(self, proposal):
         """Enforce min <= value <= max"""
         max = proposal['value']
-        if max < self.min:
+        if self.has_trait_value("max") and max < self.min:
             raise TraitError('setting max < min')
-        if max < self.value:
+        if self.has_trait_value("value") and max < self.value:
             self.value = max
         return max
 

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'ipython>=4.0.0',
     'ipykernel>=4.5.1',
-    'traitlets>=4.3.1',
+    'traitlets>=5.0.0',
     # Requiring nbformat to specify bugfix version which is not required by
     # notebook.
     'nbformat>=4.2.0',


### PR DESCRIPTION
Beginning with version 5.0 traitlets **may or may not** cross-validate its default values. The code below is currently valid, but if/when they are cross-validated, infinite recursion would result due to the circular validation dependency between `min` and `max`:

```python
class MaxMin(HasTraits):

    min = Int()
    max = Int()

    @validate('min')
    def _validate_min(self, proposal):
        """Enforce min <= value <= max"""
        minimum = proposal['value']
        if minimum > self.max:
            raise TraitError('setting min > max')
        return minimum

    @validate('max')
    def _validate_max(self, proposal):
        """Enforce min <= value <= max"""
        maximum = proposal['value']
        if maximum < self.min:
            raise TraitError('setting max < min')
        return maximum
```

https://github.com/ipython/traitlets/pull/413