### PR TITLE
Fix dev-install.sh problem 

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -42,6 +42,10 @@ set -e
 
 nbExtFlags="--sys-prefix $1"
 
+cd jupyter-widgets-base
+npm install
+cd ..
+
 cd jupyter-widgets-controls
 npm install
 cd ..


### PR DESCRIPTION
I was seeing [install errors](https://gist.github.com/mwcraig/351a08420e7a2099103a2cb3d2c20515) on a machine with no node stuff installed. Installing `jupyter-widgets-base` before the remaining items seems to fix the problem.