### PR TITLE
Fix accordion styling so that it works with nested accordions

### DIFF
--- a/jupyter-widgets-controls/css/widgets-base.css
+++ b/jupyter-widgets-controls/css/widgets-base.css
@@ -961,7 +961,7 @@
     color: var(--jp-ui-font-color1);
 }
 
-.p-Collapse-open .p-Collapse-header {
+.p-Collapse-open > .p-Collapse-header {
     background-color: var(--jp-layout-color1);
     color: var(--jp-ui-font-color0);
     cursor: default;
@@ -978,7 +978,7 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
-.p-Collapse-open .p-Collapse-header::before {
+.p-Collapse-open > .p-Collapse-header::before {
     content: '\f0d7\00A0'; /* caret-down, non-breaking space */
 }
 


### PR DESCRIPTION
This makes a minor change to the CSS for accordions so that the styling is appropriate when accordions are nested.

## Before:

![accordion-stuff](https://user-images.githubusercontent.com/1147167/26903340-5da72d4c-4ba2-11e7-9573-a7d6c9dbd313.png)

## After:

![accordion-stuff](https://user-images.githubusercontent.com/1147167/26903350-6985671e-4ba2-11e7-873f-60970595a117.png)
