### PR TITLE
Clean up some details in tutorial notebooks

### DIFF
--- a/docs/source/examples/Using Interact.ipynb
+++ b/docs/source/examples/Using Interact.ipynb
@@ -392,7 +392,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The widget is a `Box`, which is a container for other widgets."
+    "The widget is an `interactive`, a subclass of `VBox`, which is a container for other widgets."
    ]
   },
   {
@@ -408,7 +408,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The children of the `Box` are two integer-valued sliders produced by the widget abbreviations above."
+    "The children of the `interactive` are two integer-valued sliders and an output widget, produced by the widget abbreviations above."
    ]
   },
   {
@@ -629,7 +629,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/examples/Widget Basics.ipynb
+++ b/docs/source/examples/Widget Basics.ipynb
@@ -473,7 +473,7 @@
     }
    },
    "source": [
-    "If you need to display the same value two different ways, you'll have to use two different widgets.  Instead of attempting to manually synchronize the values of the two widgets, you can use the `link`  or `jslink` function to link two properties together (the difference between these is discussed in [Widget Events](Widget Events.ipynb).  Below, the values of two widgets are linked together."
+    "If you need to display the same value two different ways, you'll have to use two different widgets.  Instead of attempting to manually synchronize the values of the two widgets, you can use the `link`  or `jslink` function to link two properties together (the difference between these is discussed in [Widget Events](Widget Events.ipynb)).  Below, the values of two widgets are linked together."
    ]
   },
   {

--- a/docs/source/examples/Widget Basics.ipynb
+++ b/docs/source/examples/Widget Basics.ipynb
@@ -74,9 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import ipywidgets as widgets"
@@ -97,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Widgets have their own display `repr` which allows them to be displayed using IPython's display framework.  Constructing and returning an `IntSlider` automatically displays the widget (as seen below).  Widgets are displayed inside the widget area, which sits between the code cell and output.  You can hide all of the widgets in the widget area by clicking the grey *x* in the margin."
+    "Widgets have their own display `repr` which allows them to be displayed using IPython's display framework.  Constructing and returning an `IntSlider` automatically displays the widget (as seen below).  Widgets are displayed inside the widget area, which sits between the code cell and output."
    ]
   },
   {
@@ -108,8 +106,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c03a95010f6e43b1a4a675f35738b25b"
-      }
+       "model_id": "c8386b49dcf84a9b87ed3d19ea96c5c2",
+       "version_major": "2",
+       "version_minor": "0"
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -145,8 +148,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4e0f151a4e894b0ba6f722e7bb7f63b7"
-      }
+       "model_id": "e1986a09ec0d433f81f34d86bd77e713",
+       "version_major": "2",
+       "version_minor": "0"
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -184,8 +192,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4e0f151a4e894b0ba6f722e7bb7f63b7"
-      }
+       "model_id": "e1986a09ec0d433f81f34d86bd77e713",
+       "version_major": "2",
+       "version_minor": "0"
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -241,8 +254,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4e0f151a4e894b0ba6f722e7bb7f63b7"
-      }
+       "model_id": "e1986a09ec0d433f81f34d86bd77e713",
+       "version_major": "2",
+       "version_minor": "0"
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -255,9 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "w.close()"
@@ -289,8 +305,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "08bc674dd9f640cfb6e454d7110a3040"
-      }
+       "model_id": "d8bd1715609245f4b86a35fb960f5bb1",
+       "version_major": "2",
+       "version_minor": "0"
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -331,9 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "w.value = 100"
@@ -365,27 +384,27 @@
     {
      "data": {
       "text/plain": [
-       "['readout_format',\n",
-       " 'description',\n",
-       " 'readout',\n",
-       " '_model_module_version',\n",
-       " 'min',\n",
+       "['_dom_classes',\n",
        " '_model_module',\n",
-       " '_range',\n",
+       " '_model_module_version',\n",
+       " '_model_name',\n",
+       " '_view_count',\n",
        " '_view_module',\n",
-       " 'layout',\n",
+       " '_view_module_version',\n",
        " '_view_name',\n",
        " 'continuous_update',\n",
+       " 'description',\n",
+       " 'disabled',\n",
+       " 'layout',\n",
+       " 'max',\n",
+       " 'min',\n",
        " 'msg_throttle',\n",
        " 'orientation',\n",
+       " 'readout',\n",
+       " 'readout_format',\n",
        " 'step',\n",
-       " 'max',\n",
-       " '_dom_classes',\n",
-       " '_model_name',\n",
        " 'style',\n",
-       " '_view_module_version',\n",
-       " 'value',\n",
-       " 'disabled']"
+       " 'value']"
       ]
      },
      "execution_count": 10,
@@ -423,8 +442,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1da8f905bd384e92a5eac56d370e01a5"
-      }
+       "model_id": "ea03bb4c1a3649f3b2e62a159874e498",
+       "version_major": "2",
+       "version_minor": "0"
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -460,8 +484,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b96613d040d14482b6f3c8227412a74e"
-      }
+       "model_id": "65288ab8bd2c404da7a3405f6a858339",
+       "version_major": "2",
+       "version_minor": "0"
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -469,8 +498,13 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "62506dabc348497e9e3f904446466e7d"
-      }
+       "model_id": "097a490c3f7e45d68fe9579f8e3ce7e3",
+       "version_major": "2",
+       "version_minor": "0"
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
      },
      "metadata": {},
      "output_type": "display_data"
@@ -505,9 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# mylink.unlink()"

--- a/docs/source/examples/Widget Basics.ipynb
+++ b/docs/source/examples/Widget Basics.ipynb
@@ -3,8 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "nbsphinx": "hidden"
    },
    "source": [
@@ -13,20 +11,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Simple Widget Introduction"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## What are widgets?"
    ]
@@ -34,8 +26,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -46,10 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## What can they be used for?"
    ]
@@ -57,8 +44,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -70,10 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Using widgets  "
    ]
@@ -81,8 +63,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -95,20 +75,16 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
-    "from ipywidgets import *"
+    "import ipywidgets as widgets"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -119,10 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Widgets have their own display `repr` which allows them to be displayed using IPython's display framework.  Constructing and returning an `IntSlider` automatically displays the widget (as seen below).  Widgets are displayed inside the widget area, which sits between the code cell and output.  You can hide all of the widgets in the widget area by clicking the grey *x* in the margin."
    ]
@@ -130,11 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -147,14 +116,12 @@
     }
    ],
    "source": [
-    "IntSlider()"
+    "widgets.IntSlider()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -165,10 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "You can also explicitly display the widget using `display(...)`."
    ]
@@ -176,11 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -194,15 +154,13 @@
    ],
    "source": [
     "from IPython.display import display\n",
-    "w = IntSlider()\n",
+    "w = widgets.IntSlider()\n",
     "display(w)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -213,10 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "If you display the same widget twice, the displayed instances in the front-end will remain in sync with each other.  Try dragging the slider below and watch the slider above."
    ]
@@ -224,11 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -246,10 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Why does displaying the same widget twice work?"
    ]
@@ -257,8 +205,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -272,8 +218,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -284,10 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "You can close a widget by calling its `close()` method."
    ]
@@ -295,11 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -319,9 +256,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -330,10 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Widget properties"
    ]
@@ -341,8 +273,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -354,11 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -371,18 +297,14 @@
     }
    ],
    "source": [
-    "w = IntSlider()\n",
+    "w = widgets.IntSlider()\n",
     "display(w)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -401,10 +323,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Similarly, to set a widget's value, you can set its `value` property."
    ]
@@ -413,9 +332,7 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -425,8 +342,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -437,10 +352,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "In addition to `value`, most widgets share `keys`, `description`, `disabled`, and `visible`.  To see the entire list of synchronized, stateful properties of any specific widget, you can query the `keys` property."
    ]
@@ -448,11 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -491,10 +399,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Shorthand for setting the initial values of widget properties"
    ]
@@ -502,8 +407,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -515,11 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -532,15 +431,12 @@
     }
    ],
    "source": [
-    "Text(value='Hello World!', disabled=True)"
+    "widgets.Text(value='Hello World!', disabled=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Linking two similar widgets"
    ]
@@ -548,24 +444,18 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
    },
    "source": [
-    "If you need to display the same value two different ways, you'll have to use two different widgets.  Instead of attempting to manually synchronize the values of the two widgets, you can use the `traitlet` `link` function to link two properties together.  Below, the values of two widgets are linked together."
+    "If you need to display the same value two different ways, you'll have to use two different widgets.  Instead of attempting to manually synchronize the values of the two widgets, you can use the `link`  or `jslink` function to link two properties together (the difference between these is discussed in [Widget Events](Widget Events.ipynb).  Below, the values of two widgets are linked together."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -587,19 +477,16 @@
     }
    ],
    "source": [
-    "a = FloatText()\n",
-    "b = FloatSlider()\n",
+    "a = widgets.FloatText()\n",
+    "b = widgets.FloatSlider()\n",
     "display(a,b)\n",
     "\n",
-    "mylink = jslink((a, 'value'), (b, 'value'))"
+    "mylink = widgets.jslink((a, 'value'), (b, 'value'))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Unlinking widgets"
    ]
@@ -607,8 +494,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -621,9 +506,7 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -633,8 +516,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "nbsphinx": "hidden"
    },
    "source": [
@@ -658,7 +539,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/examples/Widget Events.ipynb
+++ b/docs/source/examples/Widget Events.ipynb
@@ -3,8 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "nbsphinx": "hidden"
    },
    "source": [
@@ -14,8 +12,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -26,10 +22,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Special events"
    ]
@@ -38,9 +31,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -49,10 +40,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `Button` is not used to represent a data type.  Instead the button widget is used to handle mouse clicks.  The `on_click` method of the `Button` can be used to register function to be called when the button is clicked.  The doc string of the `on_click` can be seen below."
    ]
@@ -60,11 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -91,8 +75,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -103,10 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Since button clicks are stateless, they are transmitted from the front-end to the back-end using custom messages.  By using the `on_click` method, a button that prints a message when it has been clicked is shown below."
    ]
@@ -114,11 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -144,8 +119,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -156,10 +129,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `Text` widget also has a special `on_submit` event.  The `on_submit` event fires when the user hits return."
    ]
@@ -167,11 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -196,8 +162,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -208,10 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Widget properties are IPython traitlets and traitlets are eventful.  To handle  changes, the `observe` method of the widget can be used to register a callback.  The doc string for `observe` can be seen below."
    ]
@@ -219,11 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -264,8 +221,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -276,10 +231,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Mentioned in the doc string, the callback registered must have the signature `handler(change)` where `change` is a dictionary holding the information about the change. \n",
     "\n",
@@ -289,11 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -317,30 +265,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Linking Widgets"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Often, you may want to simply link widget attributes together. Synchronization of attributes can be done in a simpler way than by using bare traitlets events. "
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Linking traitlets attributes in the kernel\n",
     "\n",
@@ -351,9 +290,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -363,11 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -408,11 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -452,10 +381,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Function `traitlets.link` and `traitlets.dlink` return a `Link` or `DLink` object. The link can be broken by calling the `unlink` method."
    ]
@@ -464,9 +390,7 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -476,16 +400,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Registering callbacks to trait changes in the kernel\n",
     "\n",
     "Since attributes of widgets on the Python side are traitlets, you can register handlers to the change events whenever the model gets updates from the front-end.\n",
     "\n",
-    "The handler passed to the decorator will be called with one change argument. The change object holds at least a `type` key and a `name` key, corresponding respectively to the type of notification and the name of the attribute that triggered the notification.\n",
+    "The handler passed to observe will be called with one change argument. The change object holds at least a `type` key and a `name` key, corresponding respectively to the type of notification and the name of the attribute that triggered the notification.\n",
     "\n",
     "Other keys may be passed depending on the value of `type`. In the case where type is `change`, we also have the following keys:\n",
     "\n",
@@ -498,11 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -539,20 +456,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Linking widgets attributes from the client side"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "When synchronizing traitlets attributes, you may experience a lag because of the latency due to the roundtrip to the server side. You can also directly link widget attributes in the browser using the link widgets, in either a unidirectional or a bidirectional fashion.\n",
     "\n",
@@ -562,11 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -607,11 +514,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -651,10 +554,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Function `widgets.jslink` returns a `Link` widget. The link can be broken by calling the `unlink` method."
    ]
@@ -663,9 +563,7 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -676,8 +574,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "nbsphinx": "hidden"
    },
    "source": [
@@ -707,7 +603,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -19,9 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import ipywidgets as widgets"
@@ -42,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are 8 widgets distributed with IPython that are designed to display numeric values.  Widgets exist for displaying integers and floats, both bounded and unbounded.  The integer widgets share a similar naming scheme to their floating point counterparts.  By replacing `Float` with `Int` in the widget name, you can find the Integer equivalent."
+    "There are 10 widgets distributed with IPython that are designed to display numeric values.  Widgets exist for displaying integers and floats, both bounded and unbounded.  The integer widgets share a similar naming scheme to their floating point counterparts.  By replacing `Float` with `Int` in the widget name, you can find the Integer equivalent."
    ]
   },
   {
@@ -60,7 +58,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "46e79f8bfdfa4e049e68202315a707eb",
+       "model_id": "aa70f246e6994c74b3d7d094c23f9417",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -107,7 +105,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "75d1c33654ea4a68b25673e56e33d373",
+       "model_id": "ffb03d2d3c6f4a4b867aa629d57ba44c",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -150,7 +148,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0afe6456742e4383828bdc35daa1e97d",
+       "model_id": "0595a2f7882f42f48bb6980d49a1f4de",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -193,7 +191,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f3a672f25d8b499bb04d255930809802",
+       "model_id": "84b88465391148e3b63390336b99f9a3",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -237,7 +235,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "afbd558ff1ff4b4ea341eb7ddea52c50",
+       "model_id": "de8d4c5924be413caa12bb6e37308ea1",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -281,7 +279,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "152dd1f1c9bf4450b5b9e13620b7f569",
+       "model_id": "1e43da11f4ae42fb8905be9ca60dc885",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -324,7 +322,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bffbc8e39fb14068966929a5d3f589d3",
+       "model_id": "793e65a50768436584da0eb70589761a",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -352,6 +350,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The numerical text boxes that impose some limit on the data (range, integer-only) impose that restriction when the user presses enter.\n",
+    "\n",
     "### BoundedIntText"
    ]
   },
@@ -363,7 +363,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4c645758febb4084a789ca79446b8d2e",
+       "model_id": "7b07da2c04f04373968b242caa3219c0",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -405,7 +405,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "57a75bbfafd54d67a6597ebcecc0b6e4",
+       "model_id": "f285e445a1c9419f901a5ed4d13b70c9",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -424,8 +424,7 @@
     "    max=10.0,\n",
     "    step=0.1,\n",
     "    description='Text:',\n",
-    "    disabled=False,\n",
-    "    color='black'\n",
+    "    disabled=False\n",
     ")"
    ]
   },
@@ -444,7 +443,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c3c6e87ff84c4f88b2fca3441cfa3b68",
+       "model_id": "24b50ba418cf455ab18198295e8d6ba7",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -483,7 +482,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aa6d89aef77d4a1c83ff789d7cf68ac8",
+       "model_id": "33d081d619944f76b2469d4c21234bf0",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -499,8 +498,7 @@
     "widgets.FloatText(\n",
     "    value=7.5,\n",
     "    description='Any:',\n",
-    "    disabled=False,\n",
-    "    color='black'\n",
+    "    disabled=False\n",
     ")"
    ]
   },
@@ -537,7 +535,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "72ff04bfd91446f6bca6e8a7833fc318",
+       "model_id": "28b8e705c4274bd6aff06ada027c6d34",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -579,7 +577,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "af0636f21558450289dcc1db84348b81",
+       "model_id": "758e562514b34b1988191c6a832e85d1",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -616,7 +614,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "78f1b4a895b544aca50f8af5e892a6eb",
+       "model_id": "a56a40c02c9a4a37b41c2c821442babc",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -651,7 +649,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are several widgets that can be used to display single selection lists, and two that can be used to select multiple values.  All inherit from the same base class.  You can specify the **enumeration of selectable options by passing a list** (options are either (label, value) pairs, or simply values for which the label is derived automatically).  You can **also specify the enumeration as a dictionary**, in which case the **keys will be used as the item displayed** in the list and the corresponding **value will be used** when an item is selected (in this case, since dictionaries are unordered, the displayed order of items in the widget is unspecified)."
+    "There are several widgets that can be used to display single selection lists, and two that can be used to select multiple values.  All inherit from the same base class.  You can specify the **enumeration of selectable options by passing a list** (options are either (label, value) pairs, or simply string values for which the label is derived automatically).  You can **also specify the enumeration as a dictionary**, in which case the **keys will be used as the item displayed** in the list and the corresponding **value will be used** when an item is selected (in this case, since dictionaries are unordered, the displayed order of items in the widget is unspecified)."
    ]
   },
   {
@@ -673,7 +671,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ff5c4c235b8e4034a408c544d07ceaec",
+       "model_id": "2cdad5c10ece4da181ca49171283349a",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -710,7 +708,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "146d0857f2f04759a6666aadb19cf518",
+       "model_id": "bd7d991670b0453eaee15f211d94559e",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -749,7 +747,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f98f078a91854ddaa12cf3f0c3844549",
+       "model_id": "2d5db835e3134d34822ce458e7a44930",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -789,7 +787,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "24e2e26692f64655baeb73440052a5eb",
+       "model_id": "d7626a9fe9554ceaa76908d91220413a",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -826,7 +824,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aa73ec95bdef42db911bb35336157edb",
+       "model_id": "b03d35bac0e143a98d59d16ae8c2d894",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -846,9 +844,7 @@
     "    disabled=False,\n",
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
-    "    readout=True,\n",
-    "#     readout_format='i',\n",
-    "#     slider_color='black'\n",
+    "    readout=True\n",
     ")"
    ]
   },
@@ -869,7 +865,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "53c3c496977649cc85ac7a61c1a9ca43",
+       "model_id": "f6e58d92be794976ae97ede224c177d7",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -911,7 +907,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "834170e4648c4ecb8924d989bcecbb0c",
+       "model_id": "33e83ae36efe455093b73af1be7fcc3b",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -950,7 +946,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "13ca70288f7b42589871c0d2620e8e84",
+       "model_id": "dcf3d8f1fad444e2a567314d9f4a33e1",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1009,7 +1005,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "367e8923a9f0495bb00a333f11bcc389",
+       "model_id": "89d538e1c91e4c189459714b1a364daa",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1045,7 +1041,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c9ecba3fc40c48269b62e7240efa7969",
+       "model_id": "b3db450d5e794e16bbf67cbde2aa5da6",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1076,7 +1072,7 @@
    "source": [
     "### Label\n",
     "\n",
-    "The `Label` widget is useful if you need to build a custom description next to a control."
+    "The `Label` widget is useful if you need to include static text in a larger widget. The label text may include $\\LaTeX$ (there is no longer a separate widget for it). The `Label` widget is frequently used to build a custom description next to a control."
    ]
   },
   {
@@ -1087,7 +1083,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5c337e49cab24c59b99733820fe89584",
+       "model_id": "3a99225366fc4dfc83498db0aeb7fbbf",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1100,10 +1096,7 @@
     }
    ],
    "source": [
-    "description = widgets.Label(value=\"My Control\")\n",
-    "# control could be any custom control\n",
-    "control = widgets.IntSlider()\n",
-    "widgets.HBox([description, control])"
+    "widgets.Label(value=\"Some text with an equation $E=mc^2$ and a character $\\mu$\")"
    ]
   },
   {
@@ -1121,7 +1114,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b48f12134f284ed39c10b0a5a2c53575",
+       "model_id": "6fba84ac61e040e3ba0bea70b011ee40",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1157,7 +1150,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6ac3826d8dea4e1e8f40119710356a84",
+       "model_id": "506ee690dc8845c8b5bffe57cbc8fd66",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1193,7 +1186,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a03638a11b114a79b77d72bd66277a0b",
+       "model_id": "7304a3cdfa594c75a41a5c2b6d59c41f",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1235,7 +1228,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2ac4bd2e365a469c998dd0a2425893ee",
+       "model_id": "f95d2f70bdb745f8a7069b9bae2e6f66",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1268,7 +1261,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Play` widget is useful to perform animations by iterating on a sequence of integers with a certain speed."
+    "The `Play` widget is useful to perform animations by iterating on a sequence of integers with a certain speed. The value of the slider below is linked to the player."
    ]
   },
   {
@@ -1279,7 +1272,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "40426ff192e84eb1a0f2fc1a48c8e6fb",
+       "model_id": "ee7fae7aa5414a9893a4907ab05d4db1",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1323,7 +1316,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1516779a4b4444519f9be44c961fa40d",
+       "model_id": "c8301e7523514342b0138cb0b7c10220",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1356,7 +1349,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c095914688034c9a9e8059511dbeb469",
+       "model_id": "c54cd9e313f24cc194a171af26dc458d",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1380,7 +1373,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Controller"
+    "## Controller\n",
+    "\n",
+    "The `Controller` allows a game controller to be used as an input device."
    ]
   },
   {
@@ -1391,7 +1386,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "20675b0c8b764967b9c3e920a82357da",
+       "model_id": "60fb140c31184b6098d5aecbf19f45e1",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1413,7 +1408,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Layout widgets"
+    "## Container/Layout widgets\n",
+    "\n",
+    "These widgets are used to hold other widgets, called children. Each has a `children` property that may be set either when the widget is created or later."
    ]
   },
   {
@@ -1421,6 +1418,31 @@
    "metadata": {},
    "source": [
     "### Box"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4af38fa805e3434390cfe8a63cd61066",
+       "version_major": "2",
+       "version_minor": "0"
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "items = [widgets.Label(str(i)) for i in range(4)]\n",
+    "widgets.Box(items)"
    ]
   },
   {
@@ -1432,13 +1454,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2766277c18bf46ce86afa9eaf7889ce9",
+       "model_id": "83d7d2d9f30d47c2a93d407135e1457e",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1464,13 +1486,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9a27c44e72f94d23b10b0ed60d0bae46",
+       "model_id": "ca65a09f8d97464aaaa15d9f08349a04",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1484,7 +1506,9 @@
    ],
    "source": [
     "items = [widgets.Label(str(i)) for i in range(4)]\n",
-    "widgets.HBox([widgets.VBox([items[0], items[1]]), widgets.VBox([items[2], items[3]])])"
+    "left_box = widgets.VBox([items[0], items[1]])\n",
+    "right_box = widgets.VBox([items[2], items[3]])\n",
+    "widgets.HBox([left_box, right_box])"
    ]
   },
   {
@@ -1496,13 +1520,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "01d3abc70d6c4121af3337427d359d81",
+       "model_id": "0237c507029946159aa745bdd9a02158",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1525,18 +1549,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Tabs"
+    "### Tabs\n",
+    "\n",
+    "In this example the children are set after the tab is created. Titles for the tabes are set in the same way they are for `Accordion`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0d33cb4df50940b59c704bb1d832c9b0",
+       "model_id": "1b031b634f424774bac5382323fc714a",
        "version_major": "2",
        "version_minor": "0"
       },
@@ -1549,9 +1575,11 @@
     }
    ],
    "source": [
-    "list = ['P0', 'P1', 'P2', 'P3', 'P4']\n",
-    "children = [widgets.Text(description=name) for name in list]\n",
-    "tab = widgets.Tab(children=children)\n",
+    "tab_contents = ['P0', 'P1', 'P2', 'P3', 'P4']\n",
+    "children = [widgets.Text(description=name) for name in tab_contents]\n",
+    "tab = widgets.Tab()\n",
+    "tab.children = children\n",
+    "_ = [tab.set_title(i, str(i)) for i, _ in enumerate(children)]\n",
     "tab"
    ]
   },
@@ -1581,7 +1609,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -1580,7 +1580,7 @@
     "tab = widgets.Tab()\n",
     "tab.children = children\n",
     "for i in range(len(children)):\n",
-    "    tab.set_title(i, str(i))\n"
+    "    tab.set_title(i, str(i))\n",
     "tab"
    ]
   },

--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -649,7 +649,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are several widgets that can be used to display single selection lists, and two that can be used to select multiple values.  All inherit from the same base class.  You can specify the **enumeration of selectable options by passing a list** (options are either (label, value) pairs, or simply string values for which the label is derived automatically).  You can **also specify the enumeration as a dictionary**, in which case the **keys will be used as the item displayed** in the list and the corresponding **value will be used** when an item is selected (in this case, since dictionaries are unordered, the displayed order of items in the widget is unspecified)."
+    "There are several widgets that can be used to display single selection lists, and two that can be used to select multiple values.  All inherit from the same base class.  You can specify the **enumeration of selectable options by passing a list** (options are either (label, value) pairs, or simply values for which the labels are derived by calling `str`).  You can **also specify the enumeration as a dictionary**, in which case the **keys will be used as the item displayed** in the list and the corresponding **value will be used** when an item is selected (in this case, since dictionaries are unordered, the displayed order of items in the widget is unspecified)."
    ]
   },
   {
@@ -983,7 +983,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are 4 widgets that can be used to display a string value.  Of those, the `Text` and `Textarea` widgets accept input.  The `Label` and `HTML` widgets display the string as either Label or HTML respectively, but do not accept input."
+    "There are several widgets that can be used to display a string value.  The `Text` and `Textarea` widgets accept input.  The `HTML` and `HTMLMath` widgets display a string as HTML (`HTMLMath` also renders math). The `Label` widget can be used to construct a custom control label."
    ]
   },
   {
@@ -1072,7 +1072,7 @@
    "source": [
     "### Label\n",
     "\n",
-    "The `Label` widget is useful if you need to include static text in a larger widget. The label text may include $\\LaTeX$ (there is no longer a separate widget for it). The `Label` widget is frequently used to build a custom description next to a control."
+    "The `Label` widget is useful if you need to build a custom description next to a control using similar styling to the built-in control descriptions."
    ]
   },
   {
@@ -1096,7 +1096,7 @@
     }
    ],
    "source": [
-    "widgets.Label(value=\"Some text with an equation $E=mc^2$ and a character $\\mu$\")"
+    "widgets.HBox([widgets.Label(value=\"The $m$ in $E=mc^2$:\"), widgets.FloatSlider()])"
    ]
   },
   {
@@ -1579,7 +1579,8 @@
     "children = [widgets.Text(description=name) for name in tab_contents]\n",
     "tab = widgets.Tab()\n",
     "tab.children = children\n",
-    "_ = [tab.set_title(i, str(i)) for i, _ in enumerate(children)]\n",
+    "for i in range(len(children)):\n",
+    "    tab.set_title(i, str(i))\n"
     "tab"
    ]
   },

--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Layout and Styling of Jupyter widgets\n",
     "\n",
@@ -14,10 +11,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## The `layout` attribute.\n",
     "\n",
@@ -84,20 +78,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Simple examples"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The following example shows how to resize a `Button` so that its views have a height of `80px` and a width of `50%` of the available space:"
    ]
@@ -105,11 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -131,10 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `layout` property can be shared between multiple widgets and assigned directly."
    ]
@@ -142,11 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -164,20 +141,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Description"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "You may have noticed that the widget's length is shorter in presence of a description. This because the description is added *inside* of the widget's total length. You **cannot** change the width of the internal description field. If you need more flexibility to layout widgets and captions, you should use a combination with the `Label` widgets arranged in a layout."
    ]
@@ -185,11 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -209,10 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Natural sizes, and arrangements using HBox and VBox\n",
     "\n",
@@ -229,11 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -250,26 +210,21 @@
     "\n",
     "words = ['correct', 'horse', 'battery', 'staple']\n",
     "items = [Button(description=w) for w in words]\n",
-    "\n",
-    "HBox([VBox([items[0], items[1]]), VBox([items[2], items[3]])])"
+    "left_box = VBox([items[0], items[1]])\n",
+    "right_box = VBox([items[2], items[3]])\n",
+    "HBox([left_box, right_box])"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Latex"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Widgets such as sliders and text inputs have a description attribute that can render Latex Equations. The `Label` widget also renders Latex equations."
    ]
@@ -278,9 +233,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -290,11 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -313,11 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -335,10 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Number formatting\n",
     "\n",
@@ -347,10 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## The Flexbox layout\n",
     "\n",
@@ -392,7 +331,7 @@
     "\n",
     "   This is a shorthand `flex-direction` and `flex-wrap` properties, which together define the flex container's main and cross axes. Default is `row nowrap`.\n",
     "\n",
-    "    - `flex-direction` (row | row-reverse | column | column-reverse)\n",
+    "    - `flex-direction` (column-reverse | column | row | row-reverse | )\n",
     "    \n",
     "      This establishes the main-axis, thus defining the direction flex items are placed in the flex container. Flexbox is (aside from optional wrapping) a single-direction layout concept. Think of flex items as primarily laying out either in horizontal rows or vertical columns.\n",
     "      ![Direction](./images/flex-direction1.svg)\n",
@@ -482,10 +421,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "**Four buttons in a VBox. Items stretch to the maximum width, in a vertical box taking `50%` of the available space.**"
    ]
@@ -493,11 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -529,10 +461,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "**Three buttons in an HBox. Items flex proportionaly to their weight.**"
    ]
@@ -540,11 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -576,10 +501,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "**A more advanced example: a reactive form.**\n",
     "\n",
@@ -589,11 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -636,10 +554,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "**A more advanced example: a carousel.**"
    ]
@@ -647,11 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -680,10 +591,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Predefined styles\n",
     "\n",
@@ -703,11 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -727,10 +631,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## The `style` attribute\n",
     "\n",
@@ -743,11 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -767,10 +664,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Just like the `layout` attribute, widget styles can be assigned to other widgets."
    ]
@@ -778,11 +672,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -802,10 +692,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Widget styling attributes are specific to each widget type."
    ]
@@ -813,11 +700,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -852,7 +735,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
This PR cleans up some (mostly) minor details in the tutorial notebooks. The only substantive change so far is in `Widget Basics`, where I replaced a glob-style import `from ipywidgets import *` with a the style used in the other notebooks `import ipywidgets as widgets`.

More coming soon, so this sin't ready for merge yet. Opening now in case some of the changes I'm seeing in these first couple of notebooks that I didn't intentionally make (like the deletions metadata from some of the cells) are some I need to worry about....