### PR TITLE
Fix embed resolution issues

### DIFF
--- a/jupyter-widgets-base/test/src/tsconfig.json
+++ b/jupyter-widgets-base/test/src/tsconfig.json
@@ -3,7 +3,7 @@
     //"noImplicitAny": true,
     "noEmitOnError": true,
     "module": "commonjs",
-    "lib": ["dom", "es5", "es2015.promise"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
     "types": ["mocha"],
     "moduleResolution": "node",
     "target": "ES5",

--- a/jupyter-widgets-htmlmanager/package.json
+++ b/jupyter-widgets-htmlmanager/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@phosphor/widgets": "^1.2.0",
     "font-awesome": "^4.7.0",
-    "@jupyter-widgets/controls": "file:../jupyter-widgets-controls",
+    "@jupyter-widgets/controls": "^0.3.0",
     "scriptjs": "^2.5.8"
   },
   "devDependencies": {

--- a/jupyter-widgets-htmlmanager/package.json
+++ b/jupyter-widgets-htmlmanager/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@phosphor/widgets": "^1.2.0",
     "font-awesome": "^4.7.0",
-    "@jupyter-widgets/controls": "^0.1.0",
+    "@jupyter-widgets/controls": "file:../jupyter-widgets-controls",
     "scriptjs": "^2.5.8"
   },
   "devDependencies": {

--- a/jupyter-widgets-htmlmanager/package.json
+++ b/jupyter-widgets-htmlmanager/package.json
@@ -31,6 +31,7 @@
     "@phosphor/widgets": "^1.2.0",
     "font-awesome": "^4.7.0",
     "@jupyter-widgets/controls": "^0.3.0",
+    "@jupyter-widgets/base": "^0.3.0",
     "scriptjs": "^2.5.8"
   },
   "devDependencies": {

--- a/jupyter-widgets-htmlmanager/src/htmlmanager.ts
+++ b/jupyter-widgets-htmlmanager/src/htmlmanager.ts
@@ -5,6 +5,10 @@ import * as widgets from '@jupyter-widgets/controls';
 
 import * as PhosphorWidget from '@phosphor/widgets';
 
+const coreWidgetModules: Array<string> = [
+    '@jupyter-widgets/controls', '@jupyter-widgets/base'
+];
+
 export
 class HTMLManager extends widgets.ManagerBase<HTMLElement> {
 
@@ -45,7 +49,7 @@ class HTMLManager extends widgets.ManagerBase<HTMLElement> {
      */
     protected loadClass(className: string, moduleName: string, moduleVersion: string) {
         return new Promise(function(resolve, reject) {
-            if (moduleName === '@jupyter-widgets/controls') {
+            if (coreWidgetModules.indexOf(moduleName) >= 0) {
                 // Shortcut resolving the standard widgets so we don't load two
                 // copies on the page. If we ever separate the widgets from the
                 // base manager, we should get rid of this special case.

--- a/jupyter-widgets-htmlmanager/src/htmlmanager.ts
+++ b/jupyter-widgets-htmlmanager/src/htmlmanager.ts
@@ -2,12 +2,9 @@
 // Distributed under the terms of the Modified BSD License.
 
 import * as widgets from '@jupyter-widgets/controls';
+import * as base from '@jupyter-widgets/base';
 
 import * as PhosphorWidget from '@phosphor/widgets';
-
-const coreWidgetModules: Array<string> = [
-    '@jupyter-widgets/controls', '@jupyter-widgets/base'
-];
 
 export
 class HTMLManager extends widgets.ManagerBase<HTMLElement> {
@@ -49,11 +46,13 @@ class HTMLManager extends widgets.ManagerBase<HTMLElement> {
      */
     protected loadClass(className: string, moduleName: string, moduleVersion: string) {
         return new Promise(function(resolve, reject) {
-            if (coreWidgetModules.indexOf(moduleName) >= 0) {
-                // Shortcut resolving the standard widgets so we don't load two
-                // copies on the page. If we ever separate the widgets from the
-                // base manager, we should get rid of this special case.
+            // Shortcuts resolving the standard widgets so we don't load two
+            // copies on the page. If we ever separate the widgets from the
+            // base manager, we should get rid of this special case.
+            if (moduleName === '@jupyter-widgets/controls') {
                 resolve(widgets);
+            } else if (moduleName === '@jupyter-widgets/base') {
+                resolve(base)
             } else {
                 var fallback = function(err) {
                     let failedId = err.requireModules && err.requireModules[0];

--- a/jupyter-widgets-htmlmanager/src/tsconfig.json
+++ b/jupyter-widgets-htmlmanager/src/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     //"noImplicitAny": true,
-    "lib": ["dom", "es5", "es2015.promise"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
     "types": ["requirejs"],
     "noEmitOnError": true,
     "module": "commonjs",

--- a/widgetsnbextension/src/embed_widgets.js
+++ b/widgetsnbextension/src/embed_widgets.js
@@ -13,9 +13,11 @@ var embed_widgets = function() {
                 'drop_defaults': true
             }).then(function(state) {
                 var data = JSON.stringify(state, null, '    ');
-                // TODO: This does not work right now - we don't know what
-                // version of @jupyter-widgets/controls is included in what version of
-                // embed-jupyter-widgets.
+                // TODO: This always points to the latest version of
+                // the htmlmanager.
+                // A better strategy would be to point to a version
+                // of the htmlmanager that has been tested with this
+                // release of jupyter-widgets/controls.
                 var value = '<script src="https://unpkg.com/@jupyter-widgets/htmlmanager@*/dist/index.js"></script>\n' +
                             '<script type="application/vnd.jupyter.widget-state+json">\n' + data + '\n</script>';
 

--- a/widgetsnbextension/src/embed_widgets.js
+++ b/widgetsnbextension/src/embed_widgets.js
@@ -16,7 +16,7 @@ var embed_widgets = function() {
                 // TODO: This does not work right now - we don't know what
                 // version of @jupyter-widgets/controls is included in what version of
                 // embed-jupyter-widgets.
-                var value = '<script src="https://unpkg.com/embed-jupyter-widgets@~' + widgets.version + '/dist/embed.js"></script>\n' +
+                var value = '<script src="https://unpkg.com/@jupyter-widgets/htmlmanager@*/dist/index.js"></script>\n' +
                             '<script type="application/vnd.jupyter.widget-state+json">\n' + data + '\n</script>';
 
                 var views = [];


### PR DESCRIPTION
As noted in issue #1427 , the htmlmanager on master suffers from the following issues:
 - it goes to unpkg to fetch widgets in `@jupyter-widgets/base`. Since it already depends on `@jupyter-widgets/base`, it might as well just provide the widgets directly (like it does with widgets in `@jupyter-widgets/controls`.
 - the embed link is stale.

This PR tries to address these issues, but:
 - at the moment, we need to depend on `@jupyter-widgets/controls` master, not the released version. The fix for this is to cut a new release of `/controls`.
 - the script tag for the htmlmanager that we put in the *Widgets > Embed widgets* modal points to the latest version of the htmlmanager, instead of a fixed version. We could hard-code the version we want in `embed_widgets.js`?