### PR TITLE
Update calls from `logging.warn()` to `warning()`

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -149,7 +149,7 @@ class CallbackDispatcher(LoggingHasTraits):
             except Exception as e:
                 ip = get_ipython()
                 if ip is None:
-                    self.log.warn("Exception in callback %s: %s", callback, e, exc_info=True)
+                    self.log.warning("Exception in callback %s: %s", callback, e, exc_info=True)
                 else:
                     ip.showtraceback()
             else:
@@ -180,7 +180,7 @@ def _show_traceback(method):
         except Exception as e:
             ip = get_ipython()
             if ip is None:
-                self.log.warn("Exception in widget method %s: %s", method, e, exc_info=True)
+                self.log.warning("Exception in widget method %s: %s", method, e, exc_info=True)
             else:
                 ip.showtraceback()
     return m


### PR DESCRIPTION
[The `logging.warn()` method is deprecated in favor of `logging.warning()`](https://docs.python.org/3/library/logging.html#logging.Logger.warning).  Update these calls to avoid deprecation warnings.

e.g.

```
/Users/lzkelley/anaconda3/lib/python3.5/site-packages/ipywidgets/widgets/widget.py in _ipython_display_(self, **kwargs)
    502             # widget front-end is what is expected.
    503             if validated is None:
--> 504                 loud_error('Widget Javascript not detected.  It may not be '
    505                            'installed or enabled properly.')
    506             elif not validated:

/Users/lzkelley/anaconda3/lib/python3.5/site-packages/ipywidgets/widgets/widget.py in loud_error(message)
    492         """Called when `IPython.display.display` is called on the widget."""
    493         def loud_error(message):
--> 494             self.log.warn(message)
    495             sys.stderr.write('%s\n' % message)
    496 

/Users/lzkelley/anaconda3/lib/python3.5/logging/__init__.py in warn(self, msg, *args, **kwargs)
   1294     def warn(self, msg, *args, **kwargs):
   1295         warnings.warn("The 'warn' method is deprecated, "
-> 1296             "use 'warning' instead", DeprecationWarning, 2)
   1297         self.warning(msg, *args, **kwargs)
   1298 

DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```