### PR TITLE
Some more changes to the tutorials to reflect v7.0.0

### DIFF
--- a/docs/source/examples/Widget Basics.ipynb
+++ b/docs/source/examples/Widget Basics.ipynb
@@ -373,7 +373,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition to `value`, most widgets share `keys`, `description`, `disabled`, and `visible`.  To see the entire list of synchronized, stateful properties of any specific widget, you can query the `keys` property."
+    "In addition to `value`, most widgets share `keys`, `description`, and `disabled`.  To see the entire list of synchronized, stateful properties of any specific widget, you can query the `keys` property."
    ]
   },
   {

--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -81,8 +81,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
-    "    slider_color='white'\n",
+    "    readout_format='i'\n",
     ")"
    ]
   },
@@ -129,7 +128,6 @@
     "    orientation='horizontal',\n",
     "    readout=True,\n",
     "    readout_format='.1f',\n",
-    "    slider_color='white'\n",
     ")"
    ]
   },
@@ -172,7 +170,6 @@
     "    orientation='vertical',\n",
     "    readout=True,\n",
     "    readout_format='.1f',\n",
-    "    slider_color='white'\n",
     ")"
    ]
   },
@@ -215,8 +212,6 @@
     "    orientation='horizontal',\n",
     "    readout=True,\n",
     "    readout_format='i',\n",
-    "    slider_color='white',\n",
-    "    color='black'\n",
     ")"
    ]
   },
@@ -259,8 +254,6 @@
     "    orientation='horizontal',\n",
     "    readout=True,\n",
     "    readout_format='i',\n",
-    "    slider_color='white',\n",
-    "    color='black'\n",
     ")"
    ]
   },
@@ -689,7 +682,6 @@
     "    value='2',\n",
     "    description='Number:',\n",
     "    disabled=False,\n",
-    "    button_style='' # 'success', 'info', 'warning', 'danger' or ''\n",
     ")"
    ]
   },
@@ -925,8 +917,8 @@
     "    description='Speed:',\n",
     "    disabled=False,\n",
     "    button_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
-    "    tooltip='Description',\n",
-    "#     icon='check' \n",
+    "    tooltips=['Description of slow', 'Description of regular', 'Description of fast'],\n",
+    "#     icons=['check'] * 3\n",
     ")"
    ]
   },

--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -150,7 +150,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You may have noticed that the widget's length is shorter in presence of a description. This because the description is added *inside* of the widget's total length. You **cannot** change the width of the internal description field. If you need more flexibility to layout widgets and captions, you should use a combination with the `Label` widgets arranged in a layout."
+    "You may have noticed that long descriptions are truncated. This is because the description length is, by default, fixed."
    ]
   },
   {
@@ -169,7 +169,42 @@
     }
    ],
    "source": [
-    "from ipywidgets import HBox, Label, IntSlider\n",
+    "from ipywidgets import IntSlider\n",
+    "\n",
+    "IntSlider(description='A too long description')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can set the length of the description are to match the description, the widget's length is shorter in presence of a description. This because the description is added *inside* of the widget's total length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "style = {'description_width': 'initial'}\n",
+    "IntSlider(description='A too long description', style=style)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you need more flexibility to layout widgets and captions, you should use a combination with the `Label` widgets arranged in a layout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import HBox, Label\n",
     "\n",
     "HBox([Label('A too long description'), IntSlider()])"
    ]

--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -431,7 +431,7 @@
     "\n",
     "### The VBox and HBox helpers\n",
     "\n",
-    "The `VBox` and `HBox` helper provide simple defaults to arrange child widgets in Vertical and Horizontal boxes.\n",
+    "The `VBox` and `HBox` helper classes provide simple defaults to arrange child widgets in Vertical and Horizontal boxes. They are roughly equivalent to:\n",
     "\n",
     "```Python\n",
     "def VBox(*pargs, **kwargs):\n",

--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -701,6 +701,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can get a list of the styles for a widget with the `keys` property."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b1.style.keys"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Just like the `layout` attribute, widget styles can be assigned to other widgets."
    ]
   },

--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -178,7 +178,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can set the length of the description are to match the description, the widget's length is shorter in presence of a description. This because the description is added *inside* of the widget's total length."
+    "You can change the length of the description to fit the description text. However, this will make the widget itself shorter. You can change both by adjusting the description width and the widget width using the widget's style."
    ]
   },
   {
@@ -195,7 +195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you need more flexibility to layout widgets and captions, you should use a combination with the `Label` widgets arranged in a layout."
+    "If you need more flexibility to lay out widgets and descriptions, you can use Label widgets directly."
    ]
   },
   {
@@ -431,7 +431,7 @@
     "\n",
     "### The VBox and HBox helpers\n",
     "\n",
-    "The `VBox` and `HBox` helper classes provide simple defaults to arrange child widgets in Vertical and Horizontal boxes. They are roughly equivalent to:\n",
+    "The `VBox` and `HBox` helper classes provide simple defaults to arrange child widgets in vertical and horizontal boxes. They are roughly equivalent to:\n",
     "\n",
     "```Python\n",
     "def VBox(*pargs, **kwargs):\n",
@@ -701,7 +701,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can get a list of the styles for a widget with the `keys` property."
+    "You can get a list of the style attributes for a widget with the `keys` property."
    ]
   },
   {


### PR DESCRIPTION
This makes a few more changes to the tutorials, primarily:

+ removing some style-related attributes in the initializers in the `Widget List` notebook that don't function (e.g. `slider_color`).
+ Updating the description of `description` in `Widget Styling` to reflect the changes in v7.