### PR TITLE
Add more explanation to description of links

### DIFF
--- a/docs/source/examples/Widget Events.ipynb
+++ b/docs/source/examples/Widget Events.ipynb
@@ -577,11 +577,11 @@
    "source": [
     "### The difference between linking in the kernel and linking in the client\n",
     "\n",
-    "Linking in the kernel means linking via python. For one slider to track another, when one slider is adjusted the browser must send a message to the kernel (python in this case), the kernel updates the other slider, which sends a message back to the browser to move the other slider. If the kernel is not running (as in a static web page) then the controls will not be linked.\n",
+    "Linking in the kernel means linking via python. If two sliders are linked in the kernel, when one slider is changed the browser sends a message to the kernel (python in this case) updating the changed slider, the link widget in the kernel then propagates the change to the other slider object in the kernel, and then the other slider's kernel object sends a message to the browser to update the other slider's views in the browser. If the kernel is not running (as in a static web page), then the controls will not be linked.\n",
     "\n",
-    "Linking on the client side means contructing the linnk in Javascript. When one slider is changed, Javascript running in the browser changes the value of the other slider, without communicating with the kernel at all.\n",
+    "Linking using jslink (i.e., on the browser side) means contructing the link in Javascript. When one slider is changed, Javascript running in the browser changes the value of the other slider in the browser, without needing to communicate with the kernel at all. If the sliders are attached to kernel objects, each slider will update their kernel-side objects independently.\n",
     "\n",
-    "To see the difference between the two, go to the [static version of this page in the ipywidgets documentation](http://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Events.html) and try out the sliders near the bottom. The ones linked in the kernel with `link` and `dlink` are no longer linked, but the ones linked in the client with `jslink` and `jsdlink` are still linked."
+    "To see the difference between the two, go to the [static version of this page in the ipywidgets documentation](http://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Events.html) and try out the sliders near the bottom. The ones linked in the kernel with `link` and `dlink` are no longer linked, but the ones linked in the browser with `jslink` and `jsdlink` are still linked."
    ]
   },
   {

--- a/docs/source/examples/Widget Events.ipynb
+++ b/docs/source/examples/Widget Events.ipynb
@@ -573,6 +573,19 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The difference between linking in the kernel and linking in the client\n",
+    "\n",
+    "Linking in the kernel means linking via python. For one slider to track another, when one slider is adjusted the browser must send a message to the kernel (python in this case), the kernel updates the other slider, which sends a message back to the browser to move the other slider. If the kernel is not running (as in a static web page) then the controls will not be linked.\n",
+    "\n",
+    "Linking on the client side means contructing the linnk in Javascript. When one slider is changed, Javascript running in the browser changes the value of the other slider, without communicating with the kernel at all.\n",
+    "\n",
+    "To see the difference between the two, go to the [static version of this page in the ipywidgets documentation](http://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Events.html) and try out the sliders near the bottom. The ones linked in the kernel with `link` and `dlink` are no longer linked, but the ones linked in the client with `jslink` and `jsdlink` are still linked."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "nbsphinx": "hidden"
    },


### PR DESCRIPTION
This adds just a bit at the end of the `Widget Events` notebook explaining the difference between kernel and client-side links, and includes a link to the static version of the page, which nicely illustrates the difference between the two kins of links.