### PR TITLE
Use output base class in html-manager output widget

### DIFF
--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@jupyter-widgets/base": "^0.4.0",
     "@jupyter-widgets/controls": "^0.4.0",
+    "@jupyter-widgets/output": "^0.1.1",
     "@jupyter-widgets/schema": "^0.3.0-beta.3",
     "@jupyterlab/outputarea": "^0.7.0",
     "@jupyterlab/rendermime": "^0.7.0",

--- a/packages/html-manager/src/htmlmanager.ts
+++ b/packages/html-manager/src/htmlmanager.ts
@@ -58,7 +58,7 @@ class HTMLManager extends widgets.ManagerBase<HTMLElement> {
             if (moduleName === '@jupyter-widgets/controls') {
                 resolve(widgets);
             } else if (moduleName === '@jupyter-widgets/base') {
-                resolve(base)
+                resolve(base);
             } else if (moduleName === '@jupyter-widgets/output') {
                 resolve(outputWidgets);
             } else {

--- a/packages/html-manager/src/htmlmanager.ts
+++ b/packages/html-manager/src/htmlmanager.ts
@@ -3,6 +3,7 @@
 
 import * as widgets from '@jupyter-widgets/controls';
 import * as base from '@jupyter-widgets/base';
+import * as outputWidgets from './output';
 
 import * as PhosphorWidget from '@phosphor/widgets';
 
@@ -55,9 +56,11 @@ class HTMLManager extends widgets.ManagerBase<HTMLElement> {
             // copies on the page. If we ever separate the widgets from the
             // base manager, we should get rid of this special case.
             if (moduleName === '@jupyter-widgets/controls') {
-                resolve({ ...widgets, OutputModel, OutputView });
+                resolve(widgets);
             } else if (moduleName === '@jupyter-widgets/base') {
                 resolve(base)
+            } else if (moduleName === '@jupyter-widgets/output') {
+                resolve(outputWidgets);
             } else {
                 var fallback = function(err) {
                     let failedId = err.requireModules && err.requireModules[0];

--- a/packages/html-manager/src/output.ts
+++ b/packages/html-manager/src/output.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { DOMWidgetModel, DOMWidgetView } from '@jupyter-widgets/controls';
+import * as outputBase from '@jupyter-widgets/output';
 
 import { Panel, Widget } from '@phosphor/widgets';
 
@@ -13,12 +13,10 @@ import * as $ from 'jquery';
 
 import '../css/output.css';
 
-export class OutputModel extends DOMWidgetModel {
+export class OutputModel extends outputBase.OutputModel {
     defaults() {
         return {
             ...super.defaults(),
-            _model_name: 'OutputModel',
-            _view_name: 'OutputView',
             msg_id: ''
         }
     }
@@ -38,7 +36,7 @@ export class OutputModel extends DOMWidgetModel {
     widget_manager: HTMLManager;
 }
 
-export class OutputView extends DOMWidgetView {
+export class OutputView extends outputBase.OutputView {
     _createElement(tagName: string) {
         this.pWidget = new Panel();
         return this.pWidget.node;

--- a/packages/html-manager/test/src/output_test.ts
+++ b/packages/html-manager/test/src/output_test.ts
@@ -19,7 +19,7 @@ const newWidget = async (modelState) => {
     const modelCreate: widgets.ModelOptions = {
         model_name: 'OutputModel',
         model_id: modelId,
-        model_module: '@jupyter-widgets/controls',
+        model_module: '@jupyter-widgets/output',
         model_module_version: '*'
     }
     const model = await manager.new_model(modelCreate, modelState);
@@ -34,7 +34,7 @@ describe('text output', () => {
     let view;
     const textValue = 'this-is-a-test\n'
     const modelState = {
-        _view_module: '@jupyter-widgets/controls',
+        _view_module: '@jupyter-widgets/output',
         outputs: [
             {
                 "output_type": "stream",
@@ -65,7 +65,7 @@ describe('data output', () => {
 
     // Pandas dataframe
     const modelState = {
-        _view_module: '@jupyter-widgets/controls',
+        _view_module: '@jupyter-widgets/output',
         outputs: [
             {
                 "output_type": "display_data",
@@ -93,7 +93,7 @@ describe('data output', () => {
 describe('widget output', () => {
     let view;
     const modelState = {
-        _view_module: "@jupyter-widgets/controls",
+        _view_module: "@jupyter-widgets/output",
         outputs: [
             {
                 "output_type": "display_data",
@@ -156,7 +156,7 @@ describe('widget output', () => {
         const modelCreate: widgets.ModelOptions = {
             model_name: 'OutputModel',
             model_id: modelId,
-            model_module: '@jupyter-widgets/controls',
+            model_module: '@jupyter-widgets/output',
             model_module_version: '*'
         }
         const model = await manager.new_model(modelCreate, modelState);
@@ -204,12 +204,12 @@ describe('custom mimetypes', () => {
         const modelCreate: widgets.ModelOptions = {
             model_name: 'OutputModel',
             model_id: modelId,
-            model_module: '@jupyter-widgets/controls',
+            model_module: '@jupyter-widgets/output',
             model_module_version: '*'
         };
 
         const modelState = {
-            _view_module: '@jupyter-widgets/controls',
+            _view_module: '@jupyter-widgets/output',
             outputs: [
                 {
                     output_type: 'display_data',

--- a/packages/jupyterlab-manager/src/output.ts
+++ b/packages/jupyterlab-manager/src/output.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import * as outputWidget from '@jupyter-widgets/output';
+import * as outputBase from '@jupyter-widgets/output';
 
 import {
   IDisposable
@@ -32,7 +32,7 @@ import * as $ from 'jquery';
 
 
 export
-class OutputModel extends outputWidget.OutputModel {
+class OutputModel extends outputBase.OutputModel {
   defaults() {
     return _.extend(super.defaults(), {
       msg_id: ''
@@ -99,7 +99,7 @@ class OutputModel extends outputWidget.OutputModel {
 
 
 export
-class OutputView extends outputWidget.OutputView {
+class OutputView extends outputBase.OutputView {
 
     _createElement(tagName: string) {
         this.pWidget = new Panel();

--- a/widgetsnbextension/src/widget_output.js
+++ b/widgetsnbextension/src/widget_output.js
@@ -5,7 +5,7 @@
 // This widget is strongly coupled to the notebook because of the outputarea
 // dependency.
 var widgets = require("@jupyter-widgets/controls");
-var outputWidgets = require("@jupyter-widgets/output");
+var outputBase = require("@jupyter-widgets/output");
 var _ = require("underscore");
 require('./widget_output.css');
 
@@ -13,8 +13,8 @@ var outputArea = new Promise(function(resolve, reject) {
         requirejs(["notebook/js/outputarea"], resolve, reject)
 });
 
-var OutputModel = outputWidgets.OutputModel.extend({
-    defaults: _.extend({}, outputWidgets.OutputModel.prototype.defaults(), {
+var OutputModel = outputBase.OutputModel.extend({
+    defaults: _.extend({}, outputBase.OutputModel.prototype.defaults(), {
         msg_id: "",
         outputs: []
     }),
@@ -99,7 +99,7 @@ var OutputModel = outputWidgets.OutputModel.extend({
 
 });
 
-var OutputView = outputWidgets.OutputView.extend({
+var OutputView = outputBase.OutputView.extend({
     render: function(){
         var that = this;
         this.el.classList.add('jupyter-widgets-output-area');


### PR DESCRIPTION
Prior to this PR, the output class in the html-manager still inherited from controls, and the manager did not recognize the output module. Now fixed.

This PR also renames references to the output module as `outputBase`, rather than `outputWidget` -- this avoids confusion with the local implementation of the output widget, which we also load as `outputWidget`.