### PR TITLE
Change widgetsnbextension back to using jupyter-js-widgets as the nbextension path

### DIFF
--- a/widgetsnbextension/setup.py
+++ b/widgetsnbextension/setup.py
@@ -201,7 +201,7 @@ setup_args = dict(
         'jsdeps': NPM,
     },
     data_files      = [(
-            'share/jupyter/nbextensions/jupyter-widgets', [
+            'share/jupyter/nbextensions/jupyter-js-widgets', [
                 'widgetsnbextension/static/extension.js',
                 'widgetsnbextension/static/extension.js.map'
         ]),

--- a/widgetsnbextension/widgetsnbextension/__init__.py
+++ b/widgetsnbextension/widgetsnbextension/__init__.py
@@ -21,6 +21,6 @@ def _jupyter_nbextension_paths():
     return [{
         'section': 'notebook',
         'src': 'static',
-        'dest': 'jupyter-widgets',
-        'require': 'jupyter-widgets/extension'
+        'dest': 'jupyter-js-widgets',
+        'require': 'jupyter-js-widgets/extension'
     }]


### PR DESCRIPTION
Our hardcoded hack in the notebook looks for this specific path, so we need to keep it for backwards compatibility.