### PR TITLE
Flush any inline matplotlib figures in interact functions for backwards compatibility

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -30,6 +30,26 @@ from collections import Iterable, Mapping
 
 empty = Parameter.empty
 
+try:
+    import matplotlib as mpl
+    from ipykernel.pylab.backend_inline import flush_figures
+except ImportError:
+    mpl = None
+
+def show_inline_matplotlib_plots():
+    """Show matplotlib plots immediately if using the inline backend.
+
+    With ipywidgets 6.0, matplotlib plots don't work well with interact when
+    using the inline backend that comes with ipykernel. Basically, the inline
+    backend only shows the plot after the entire cell executes, which does not
+    play well with drawing plots inside of an interact function. See
+    https://github.com/jupyter-widgets/ipywidgets/issues/1181/ and
+    https://github.com/ipython/ipython/issues/10376 for more details. This
+    function displays any matplotlib plots if the backend is the inline backend.
+    """
+    if mpl is not None and mpl.get_backend() == 'module://ipykernel.pylab.backend_inline':
+        flush_figures()
+
 def interactive_output(f, controls):
     """Connect widget controls to a function.
 
@@ -42,8 +62,10 @@ def interactive_output(f, controls):
     def observer(change):
         out.clear_output()
         kwargs = {k:v.value for k,v in controls.items()}
+        show_inline_matplotlib_plots()
         with out:
             f(**kwargs)
+            show_inline_matplotlib_plots()
     for k,w in controls.items():
         w.observe(observer, 'value')
     observer(None)
@@ -209,6 +231,7 @@ class interactive(VBox):
         if self.manual:
             self.manual_button.disabled = True
         try:
+            show_inline_matplotlib_plots()
             with self.out:
                 if self.clear_output:
                     clear_output(wait=True)
@@ -216,6 +239,7 @@ class interactive(VBox):
                     value = widget.get_interact_value()
                     self.kwargs[widget._kwarg] = value
                 self.result = self.f(**self.kwargs)
+                show_inline_matplotlib_plots()
                 if self.auto_display and self.result is not None:
                     display(self.result)
         except Exception as e:

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -68,6 +68,7 @@ def interactive_output(f, controls):
             show_inline_matplotlib_plots()
     for k,w in controls.items():
         w.observe(observer, 'value')
+    show_inline_matplotlib_plots()
     observer(None)
     return out
 
@@ -518,6 +519,7 @@ class _InteractFactory(object):
             # so wrap in a lambda
             f = lambda *args, **kwargs: __interact_f(*args, **kwargs)
             f.widget = w
+        show_inline_matplotlib_plots()
         display(w)
         return f
 


### PR DESCRIPTION
Fixes #1181

This should work now as it did in widgets 5.x:

```python
%matplotlib inline
import matplotlib.pyplot as plt

@interact(n=(1,10))
def f(n):
    for i in range(n):
        plt.plot([1,2,3,4],[i,2*i,3*i,-4*i])
```
This implements the flush_figures workaround mentioned in ipython/ipython#10376.

See also #1457

CC @ellisonbg, @minrk.