### PR TITLE
Export the Jupyter Widgets model specification version for the controls.

### DIFF
--- a/packages/controls/src/index.ts
+++ b/packages/controls/src/index.ts
@@ -19,3 +19,6 @@ export * from "./widget_description";
 
 export
 const version = (require('../package.json') as any).version;
+
+export
+const JUPYTER_WIDGETS_VERSION = '3.0.0';


### PR DESCRIPTION
The JLab plugin needs a version for the model spec.