### PR TITLE
Explain selected_index for tab and accordion

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -1578,6 +1578,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accordion and Tab use `selected_index`, not value\n",
+    "\n",
+    "Unlike the rest of the widgets discussed earlier, the container widgets `Accordion` and `Tab` update their `selected_index` attribute when the user changes which accordion or tab is selected. That means that you can both see what the user is doing *and* programmatically set what the user sees by setting the value of `selected_index`.\n",
+    "\n",
+    "Setting `selected_index = -1` (or any value outside the range of available accordions or tabs) closes all of the accordions or deselects all tabs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "nbsphinx": "hidden"
    },


### PR DESCRIPTION
This fixes #1386 by adding an explanation of `selected_index` to the `Widget List` notebook.