### PR TITLE
Set the title on the appropriate widget in the accordion.

### DIFF
--- a/packages/controls/src/phosphor/accordion.ts
+++ b/packages/controls/src/phosphor/accordion.ts
@@ -238,6 +238,7 @@ class Accordion extends Panel {
    * @param widget - The widget to add to the accordion.
    *
    * @returns The Collapse widget wrapping the added widget.
+   *
    * #### Notes
    * The widget will be wrapped in a CollapsedWidget.
    */

--- a/packages/controls/src/widget_selectioncontainer.ts
+++ b/packages/controls/src/widget_selectioncontainer.ts
@@ -166,11 +166,11 @@ class AccordionView extends DOMWidgetView {
      * Set header titles
      */
     update_titles() {
-        let widgets = this.pWidget.widgets;
+        let collapsed = this.pWidget.collapseWidgets;
         let titles = this.model.get('_titles');
-        for (let i = 0; i < widgets.length; i++) {
+        for (let i = 0; i < collapsed.length; i++) {
             if (titles[i] !== void 0) {
-                widgets[i].title.label = titles[i];
+                collapsed[i].widget.title.label = titles[i];
             }
         }
     }


### PR DESCRIPTION
Fixes #1516

The problem was that we were setting the title on the collapsed widget, not on the original widget.