### PR TITLE
Change the embedded youtube video to the scipy 2017 widgets tutorial.

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -859,7 +859,7 @@
    "source": [
     "from IPython.display import YouTubeVideo\n",
     "with out:\n",
-    "    display(YouTubeVideo('cWDdd5KKhts'))"
+    "    display(YouTubeVideo('eWzY2nGfkXk'))"
    ]
   },
   {


### PR DESCRIPTION
As @mwcraig points out, the previous cheeseshop sketch ends with a gunshot to the head. This example is also relevant and having it embedded in the notebook provides exposure to more resources for the user.