### PR TITLE
Comparing the json representation should handle idiosyncracies of python->json datastructures

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -17,6 +17,7 @@ from traitlets import (
     Undefined)
 from ipython_genutils.py3compat import string_types, PY3
 from IPython.display import display
+from json import loads as jsonloads, dumps as jsondumps
 
 from base64 import standard_b64decode, standard_b64encode
 
@@ -595,8 +596,11 @@ class Widget(LoggingHasTraits):
     def _should_send_property(self, key, value):
         """Check the property lock (property_lock)"""
         to_json = self.trait_metadata(key, 'to_json', self._trait_to_json)
+        # A roundtrip conversion through json in the comparison takes care of
+        # idiosyncracies of how python data structures map to json, for example
+        # tuples get converted to lists.
         if (key in self._property_lock
-            and to_json(value, self) == self._property_lock[key]):
+            and jsonloads(jsondumps(to_json(value, self))) == self._property_lock[key]):
             return False
         elif self._holding_sync:
             self._states_to_send.add(key)


### PR DESCRIPTION
The output widget is suffering from a problem in how we check for what messages to send back to the server. In the default from_json at https://github.com/jupyter-widgets/ipywidgets/blob/4ffa003d18e54d14d1c33dcc71b4282f7fa60996/ipywidgets/widgets/widget.py#L650, we just return the object. However, since outputs are in a tuple, but the incoming json is a list, the comparison at https://github.com/jupyter-widgets/ipywidgets/blob/4ffa003d18e54d14d1c33dcc71b4282f7fa60996/ipywidgets/widgets/widget.py#L599 always fails. The problem is that the roundtrip from python -> json -> python changes tuples into lists. Basically, this problem means that the output is cleared and reset multiple times, causing flicker.

See #1522

CC @maartenbreddels 