### PR TITLE
Fix widgets inside of output widgets in JupyterLab.

### DIFF
--- a/packages/jupyterlab-manager/src/output.ts
+++ b/packages/jupyterlab-manager/src/output.ts
@@ -43,7 +43,8 @@ class OutputModel extends outputBase.OutputModel {
 
   initialize(attributes: any, options: any) {
     super.initialize(attributes, options)
-    this._outputs = new OutputAreaModel();
+    // The output area model is trusted since widgets are only rendered in trusted contexts.
+    this._outputs = new OutputAreaModel({trusted: true});
     this.listenTo(this, 'change:msg_id', this.reset_msg_id);
     this.widget_manager.context.session.kernelChanged.connect((sender, kernel) => {
       this._msgHook.dispose();


### PR DESCRIPTION
Before this change, we'd have

<img width="631" alt="screen shot 2017-07-24 at 1 29 55 pm" src="https://user-images.githubusercontent.com/192614/28535962-37eb4006-7074-11e7-8faa-177c6a41ced3.png">
