### PR TITLE
Revert the widget-box centering.

### DIFF
--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -90,7 +90,6 @@
 .widget-box {
     box-sizing: border-box;
     display: flex;
-    align-items: center;
     margin: 0;
     overflow: auto;
 }


### PR DESCRIPTION
Often we use a box to tile widgets, and expect the widgets to line up along the start of the box.

See #1538, where this change was made.

We'll need to figure out another way to get things to work nicely in bigger boxes - we depend on easily being able to tile widgets too much to make this change at this level.