### PR TITLE
Add traitlet for validating number format

### DIFF
--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -5,7 +5,7 @@ from .widget import Widget, CallbackDispatcher, register, widget_serialization
 from .domwidget import DOMWidget
 from .valuewidget import ValueWidget
 
-from .trait_types import Color, Datetime
+from .trait_types import Color, Datetime, NumberFormat
 
 from .widget_core import CoreWidget
 from .widget_bool import Checkbox, ToggleButton, Valid

--- a/ipywidgets/widgets/tests/test_traits.py
+++ b/ipywidgets/widgets/tests/test_traits.py
@@ -21,7 +21,10 @@ class NumberFormatTrait(HasTraits):
 class TestNumberFormat(TraitTestBase):
     obj = NumberFormatTrait()
 
-    _good_values = ['.2f']
+    _good_values = [
+        '.2f', '.0%', '($.2f', '+20', '.^20', '.2s', '#x', ',.2r', ',.2R',
+        ' .2f', '.2'
+    ]
     _bad_values = [52]
 
 

--- a/ipywidgets/widgets/tests/test_traits.py
+++ b/ipywidgets/widgets/tests/test_traits.py
@@ -8,9 +8,21 @@ import datetime as dt
 from unittest import TestCase
 from traitlets import HasTraits
 from traitlets.tests.test_traitlets import TraitTestBase
-from ipywidgets import Color
+
+from ipywidgets import Color, NumberFormat
 from ipywidgets.widgets.widget import _remove_buffers, _put_buffers
 from ipywidgets.widgets.trait_types import date_serialization
+
+
+class NumberFormatTrait(HasTraits):
+    value = NumberFormat(".3f")
+
+
+class TestNumberFormat(TraitTestBase):
+    obj = NumberFormatTrait()
+
+    _good_values = ['.2f']
+    _bad_values = [52]
 
 
 class ColorTrait(HasTraits):

--- a/ipywidgets/widgets/tests/test_traits.py
+++ b/ipywidgets/widgets/tests/test_traits.py
@@ -22,10 +22,10 @@ class TestNumberFormat(TraitTestBase):
     obj = NumberFormatTrait()
 
     _good_values = [
-        '.2f', '.0%', '($.2f', '+20', '.^20', '.2s', '#x', ',.2r', ',.2R',
+        '.2f', '.0%', '($.2f', '+20', '.^20', '.2s', '#x', ',.2r',
         ' .2f', '.2', ''
     ]
-    _bad_values = [52, 'broken']
+    _bad_values = [52, False, 'broken', '..2f', '.2a']
 
 
 class ColorTrait(HasTraits):

--- a/ipywidgets/widgets/tests/test_traits.py
+++ b/ipywidgets/widgets/tests/test_traits.py
@@ -23,9 +23,9 @@ class TestNumberFormat(TraitTestBase):
 
     _good_values = [
         '.2f', '.0%', '($.2f', '+20', '.^20', '.2s', '#x', ',.2r', ',.2R',
-        ' .2f', '.2'
+        ' .2f', '.2', ''
     ]
-    _bad_values = [52]
+    _bad_values = [52, 'broken']
 
 
 class ColorTrait(HasTraits):

--- a/ipywidgets/widgets/tests/test_widget_float.py
+++ b/ipywidgets/widgets/tests/test_widget_float.py
@@ -1,3 +1,5 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from unittest import TestCase
 

--- a/ipywidgets/widgets/tests/test_widget_float.py
+++ b/ipywidgets/widgets/tests/test_widget_float.py
@@ -1,0 +1,20 @@
+
+from unittest import TestCase
+
+from traitlets import TraitError
+
+from ipywidgets import FloatSlider
+
+
+class TestFloatSlider(TestCase):
+
+    def test_construction(self):
+        FloatSlider()
+
+    def test_construction_readout_format(self):
+        slider = FloatSlider(readout_format='$.1f')
+        assert slider.get_state()['readout_format'] == '$.1f'
+
+    def test_construction_invalid_readout_format(self):
+        with self.assertRaises(TraitError):
+            FloatSlider(readout_format='broken')

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -143,6 +143,10 @@ class InstanceDict(traitlets.Instance):
 
 
 _number_format_re = re.compile('^(?:(.)?([<>=^]))?([+\-\( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?([a-z%])?$', re.I)
+_number_format_types = {
+    'e', 'f', 'g', 'r', 's', '%', 'p', 'b', 'o', 'd', 'x',
+    'X', 'c', ''
+}
 
 
 class NumberFormat(traitlets.Unicode):
@@ -155,6 +159,16 @@ class NumberFormat(traitlets.Unicode):
 
     def validate(self, obj, value):
         value = super(NumberFormat, self).validate(obj, value)
-        if _number_format_re.match(value) is None:
+        re_match = _number_format_re.match(value)
+        if re_match is None:
             self.error(obj, value)
+        else:
+            format_type = re_match.group(9)
+            print format_type
+            if format_type is None:
+                return value
+            elif format_type in _number_format_types:
+                return value
+            else:
+                self.error(obj, value)
         return value

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -143,7 +143,12 @@ class InstanceDict(traitlets.Instance):
                           **(self.default_kwargs or {}))
 
 
+# The regexp is taken
+# from https://github.com/d3/d3-format/blob/master/src/formatSpecifier.js
 _number_format_re = re.compile('^(?:(.)?([<>=^]))?([+\-\( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?([a-z%])?$', re.I)
+
+# The valid types are taken from
+# https://github.com/d3/d3-format/blob/master/src/formatTypes.js
 _number_format_types = {
     'e', 'f', 'g', 'r', 's', '%', 'p', 'b', 'o', 'd', 'x',
     'X', 'c', ''

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -155,7 +155,7 @@ class NumberFormat(traitlets.Unicode):
 
     This traitlet holds a string that can be passed to the
     `d3-format <https://github.com/d3/d3-format>`_ JavaScript library.
-    The format allowed is similar to the Python format specifier.
+    The format allowed is similar to the Python format specifier (PEP 3101).
     """
     info_text = 'a valid number format'
     default_value = traitlets.Undefined

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -9,6 +9,7 @@ import re
 import traitlets
 import datetime as dt
 
+
 _color_names = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred ', 'indigo ', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen']
 _color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
 
@@ -154,7 +155,7 @@ class NumberFormat(traitlets.Unicode):
     TODO
     """
 
-    info_text = 'A valid number format'
+    info_text = 'a valid number format'
     default_value = traitlets.Undefined
 
     def validate(self, obj, value):
@@ -164,11 +165,14 @@ class NumberFormat(traitlets.Unicode):
             self.error(obj, value)
         else:
             format_type = re_match.group(9)
-            print format_type
             if format_type is None:
                 return value
             elif format_type in _number_format_types:
                 return value
             else:
-                self.error(obj, value)
-        return value
+                raise traitlets.TraitError(
+                    'The type specifier of a NumberFormat trait must '
+                    'be one of {}, but a value of \'{}\' was '
+                    'specified.'.format(
+                        list(_number_format_types), format_type)
+                )

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -151,10 +151,12 @@ _number_format_types = {
 
 
 class NumberFormat(traitlets.Unicode):
-    """
-    TODO
-    """
+    """A string holding a number format specifier, e.g. '.3f'
 
+    This traitlet holds a string that can be passed to the
+    `d3-format <https://github.com/d3/d3-format>`_ JavaScript library.
+    The format allowed is similar to the Python format specifier.
+    """
     info_text = 'a valid number format'
     default_value = traitlets.Undefined
 

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -142,9 +142,19 @@ class InstanceDict(traitlets.Instance):
                           **(self.default_kwargs or {}))
 
 
+_number_format_re = re.compile('^(?:(.)?([<>=^]))?([+\-\( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?([a-z%])?$', re.I)
+
+
 class NumberFormat(traitlets.Unicode):
     """
     TODO
     """
+
+    info_text = 'A valid number format'
+    default_value = traitlets.Undefined
+
     def validate(self, obj, value):
-        return super(NumberFormat, self).validate(obj, value)
+        value = super(NumberFormat, self).validate(obj, value)
+        if _number_format_re.match(value) is None:
+            self.error(obj, value)
+        return value

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -9,7 +9,7 @@ import re
 import traitlets
 import datetime as dt
 
-_color_names = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred ', 'indigo ', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen'] 
+_color_names = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred ', 'indigo ', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen']
 _color_re = re.compile(r'#[a-fA-F0-9]{3}(?:[a-fA-F0-9]{3})?$')
 
 
@@ -61,8 +61,8 @@ def datetime_to_json(pydt, manager):
             year=pydt.year,
             month=pydt.month - 1,  # Months are 0-based indices in JS
             date=pydt.day,
-            hours=pydt.hour,       # Hours, Minutes, Seconds and Milliseconds are
-            minutes=pydt.minute,   # plural in JS
+            hours=pydt.hour,       # Hours, Minutes, Seconds and Milliseconds
+            minutes=pydt.minute,   # are plural in JS
             seconds=pydt.second,
             milliseconds=pydt.microsecond / 1000
         )
@@ -87,6 +87,7 @@ datetime_serialization = {
     'from_json': datetime_from_json,
     'to_json': datetime_to_json
 }
+
 
 def date_to_json(pydate, manager):
     """Serialize a Python date object.
@@ -123,10 +124,12 @@ date_serialization = {
 
 class InstanceDict(traitlets.Instance):
     """An instance trait which coerces a dict to an instance.
-    
-    This lets the instance be specified as a dict, which is used to initialize the instance.
-    
-    Also, we default to a trivial instance, even if args and kwargs is not specified."""
+
+    This lets the instance be specified as a dict, which is used
+    to initialize the instance.
+
+    Also, we default to a trivial instance, even if args and kwargs
+    is not specified."""
 
     def validate(self, obj, value):
         if isinstance(value, dict):

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -140,3 +140,11 @@ class InstanceDict(traitlets.Instance):
     def make_dynamic_default(self):
         return self.klass(*(self.default_args or ()),
                           **(self.default_kwargs or {}))
+
+
+class NumberFormat(traitlets.Unicode):
+    """
+    TODO
+    """
+    def validate(self, obj, value):
+        return super(NumberFormat, self).validate(obj, value)

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -10,7 +10,7 @@ from traitlets import (
     Instance, Unicode, CFloat, Bool, CaselessStrEnum, Tuple, TraitError, validate, default
 )
 from .widget_description import DescriptionWidget
-from .trait_types import InstanceDict
+from .trait_types import InstanceDict, NumberFormat
 from .valuewidget import ValueWidget
 from .widget import register, widget_serialization
 from .widget_core import CoreWidget
@@ -129,7 +129,8 @@ class FloatSlider(_BoundedFloat):
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.").tag(sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.").tag(sync=True)
-    readout_format = Unicode('.2f', help="Format for the readout").tag(sync=True)
+    readout_format = NumberFormat(
+        '.2f', help="Format for the readout").tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
 
@@ -265,7 +266,8 @@ class FloatRangeSlider(_BoundedFloatRange):
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.").tag(sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.").tag(sync=True)
-    readout_format = Unicode('.2f', help="Format for the readout").tag(sync=True)
+    readout_format = NumberFormat(
+        '.2f', help="Format for the readout").tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is sliding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
 

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -11,7 +11,7 @@ from .valuewidget import ValueWidget
 from .widget import register, widget_serialization
 from .widget_core import CoreWidget
 from traitlets import Instance
-from .trait_types import Color, InstanceDict
+from .trait_types import Color, InstanceDict, NumberFormat
 from traitlets import (
     Unicode, CInt, Bool, CaselessStrEnum, Tuple, TraitError, default, validate
 )
@@ -157,7 +157,8 @@ class IntSlider(_BoundedInt):
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.").tag(sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.").tag(sync=True)
-    readout_format = Unicode('d', help="Format for the readout").tag(sync=True)
+    readout_format = NumberFormat(
+        'd', help="Format for the readout").tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
 
@@ -282,7 +283,8 @@ class IntRangeSlider(_BoundedIntRange):
     orientation = CaselessStrEnum(values=['horizontal', 'vertical'],
         default_value='horizontal', help="Vertical or horizontal.").tag(sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.").tag(sync=True)
-    readout_format = Unicode('d', help="Format for the readout").tag(sync=True)
+    readout_format = NumberFormat(
+        'd', help="Format for the readout").tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is sliding the slider.").tag(sync=True)
     style = InstanceDict(SliderStyle, help="Slider style customizations.").tag(sync=True, **widget_serialization)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)


### PR DESCRIPTION
Prior to this PR, the `readout_format` trait was validated as a unicode in the `{Float,Int}{,Range}Slider` widgets. If the format was not a valid d3 format, this lead to an exception being thrown client-side, but that exception wasn't visible to the user. This lead to issue #1544 .

This PR adds a trait that validates that the format string is correctly formatted. The code for this PR is very much inspired by the [format specifier parsing code](https://github.com/d3/d3-format/blob/master/src/formatSpecifier.js) in d3-format.

```python
>>> import ipywidgets as widgets
>>> widgets.FloatSlider(readout_format='..3f')
# [...] stack trace

TraitError: The 'readout_format' trait of a FloatSlider instance must be a valid number format, but a value of u'..3f' <type 'unicode'> was specified.
```