### PR TITLE
Fix invalid readout_format in docs

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -68,7 +68,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i'\n",
+    "    readout_format='d'\n",
     ")"
    ]
   },
@@ -153,7 +153,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
+    "    readout_format='d',\n",
     ")"
    ]
   },
@@ -180,7 +180,7 @@
     "    continuous_update=False,\n",
     "    orientation='horizontal',\n",
     "    readout=True,\n",
-    "    readout_format='i',\n",
+    "    readout_format='.1f',\n",
     ")"
    ]
   },


### PR DESCRIPTION
The widget list page currently displays a traceback because the readout_format
for some of the sliders is set to `'i'`, which is not a valid [d3 format](https://github.com/d3/d3-format#locale_format) (it's
also not a valid [Python format type](https://docs.python.org/3.4/library/string.html#format-specification-mini-language)).

Prior to PR #1550, this looked like it was working because d3-format doesn't throw
an exception when the wrong type gets passed in -- it just silently converts it
to the type `''`, corresponding to 'either decimal or exponent notation, but trim
insignificant zeros'.