### PR TITLE
Fix the examples

### DIFF
--- a/examples/web-tmpnb/README.md
+++ b/examples/web-tmpnb/README.md
@@ -1,11 +1,14 @@
-# Using jupyter-js-widgets in non-notebook, web context + tmpnb backend
+# Using Jupyter Widgets in non-notebook, web context with a tmpnb backend
+
+This example does not work with ipywidgets 7 yet, since tmpnb has not been
+upgraded yet to ipywidgets 7.
 
 ## Description
 
-This directory is an example project that shows how to use `jupyter-js-widgets`
-and `ipywidgets` in a web context other than the notebook. This example makes
-use of the `tmpnb` service to spawn a new transient Jupyter notebook server from
-which it then requests a Python kernel.
+This directory is an example project that shows how to use Jupyter widgets in a
+web context other than the notebook. This example makes use of the `tmpnb`
+service to spawn a new transient Jupyter notebook server from which it then
+requests a Python kernel.
 
 This example also displays a read-only text area containing the code
 provided in the `widget_code.json`, which we used to generate the widget state.
@@ -16,5 +19,4 @@ provided in the `widget_code.json`, which we used to generate the widget state.
 2. Run `npm run build:examples` in the root directory.
 3. Change to this directory
 4. Run `npm run host`
-5. In a new terminal run `python -m notebook --no-browser --NotebookApp.allow_origin="*"`
-6. In a web browser, navigate to `http://localhost:8080/` (or the address specified by the `npm run host` command)
+5. In a web browser, navigate to `http://localhost:8080/` (or the address specified by the `npm run host` command)

--- a/examples/web3/README.md
+++ b/examples/web3/README.md
@@ -17,5 +17,5 @@ provided in the `widget_code.json`, which we used to generate the widget state.
 2. Run `npm run build:examples` in the root directory.
 3. Change to this directory
 4. Run `npm run host`
-5. In a new terminal run `python -m notebook --no-browser --NotebookApp.allow_origin="*" --NotebookApp.disable_check_xsrf=True --NotebookApp.token=''`
+5. In a new terminal run `python -m notebook --no-browser --NotebookApp.allow_origin="*" --NotebookApp.disable_check_xsrf=True --NotebookApp.token=''`. **WARNING: This starts an insecure Jupyter notebook server. Do not do this in production.**
 6. In a web browser, navigate to `http://localhost:8080/` (or the address specified by the `npm run host` command)

--- a/examples/web3/index.html
+++ b/examples/web3/index.html
@@ -35,7 +35,7 @@
         </style>
     </head>
     <body>
-        <div class="jupyter-js-widgets-example">
+        <div class="jupyter-widgets-example">
             <div class="inputarea"></div>
             <div class="widgetarea"></div>
         </div>

--- a/examples/web3/package.json
+++ b/examples/web3/package.json
@@ -3,7 +3,7 @@
   "name": "@jupyter-widgets/example-web3",
   "version": "2.0.0-16",
   "description": "Project that tests the ability to npm install jupyter-js-widgets within an npm project.",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "clean": "rimraf lib && rimraf built",
     "build": "npm run clean && tsc --project src && node scripts/copyfiles.js && webpack",
@@ -16,6 +16,7 @@
   "dependencies": {
     "@jupyter-widgets/base": "^0.6.6",
     "@jupyter-widgets/controls": "^0.6.10",
+    "@jupyter-widgets/html-manager": "^0.6.0",
     "@jupyterlab/services": "^0.48.0",
     "@types/codemirror": "0.0.33",
     "codemirror": "^5.9.0",

--- a/examples/web3/src/manager.ts
+++ b/examples/web3/src/manager.ts
@@ -10,6 +10,10 @@ import {
   Kernel
 } from '@jupyterlab/services';
 
+import {
+    HTMLManager
+} from '@jupyter-widgets/html-manager';
+
 import './widgets.css';
 
 let requirePromise = function(module: string): Promise<any> {
@@ -22,7 +26,7 @@ let requirePromise = function(module: string): Promise<any> {
 }
 
 export
-class WidgetManager extends base.ManagerBase<HTMLElement> {
+class WidgetManager extends HTMLManager {
     constructor(kernel: Kernel.IKernelConnection, el: HTMLElement) {
         super();
         this.kernel = kernel;
@@ -51,35 +55,6 @@ class WidgetManager extends base.ManagerBase<HTMLElement> {
             });
             return view;
         });
-    }
-
-    /**
-     * Load a class and return a promise to the loaded object.
-     */
-    protected async loadClass(className: string, moduleName: string, moduleVersion: string): Promise<any> {
-        let module: any;
-        if (moduleName === '@jupyter-widgets/controls') {
-            module = controls;
-        } else if (moduleName === '@jupyter-widgets/base') {
-            module = base;
-        } else {
-            try {
-                module = await requirePromise(`${moduleName}.js`);
-            } catch(err) {
-                let failedId = err.requireModules && err.requireModules[0];
-                if (failedId) {
-                    console.log(`Falling back to unpkg.com for ${moduleName}@${moduleVersion}`);
-                    module = await requirePromise(`https://unpkg.com/${moduleName}@${moduleVersion}/dist/index.js`);
-                } else {
-                    throw err;
-                }
-            }
-        }
-
-        if (module[className] === void 0) {
-            throw new Error(`Class ${className} not found in module ${moduleName}@${moduleVersion}`);
-        }
-        return module[className];
     }
 
     /**

--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -1,3 +1,25 @@
+let postcss = require('postcss');
+
+let postcssHandler = () => {
+    return [
+        postcss.plugin('delete-tilde', () => {
+            return function (css) {
+                css.walkAtRules('import', (rule) => {
+                    rule.params = rule.params.replace('~', '');
+                });
+            };
+        }),
+        postcss.plugin('prepend', () => {
+            return (css) => {
+                css.prepend(`@import '@jupyter-widgets/controls/css/labvariables.css';`)
+            }
+        }),
+        require('postcss-import')(),
+        require('postcss-cssnext')()
+    ];
+}
+
+
 module.exports = {
     entry: './lib/index.js',
     output: {
@@ -19,10 +41,5 @@ module.exports = {
             { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
         ]
     },
-    postcss: function () {
-        return [
-            require('postcss-import'),
-            require('postcss-cssnext')
-        ];
-    }
+    postcss: postcssHandler,
 };

--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.0",
   "description": "Standalone package for rendering Jupyter widgets outside notebooks",
   "main": "lib/index.js",
-  "typings": "lib/index.t.js",
+  "typings": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/jupyter-widgets/ipywidgets.git"

--- a/packages/html-manager/src/htmlmanager.ts
+++ b/packages/html-manager/src/htmlmanager.ts
@@ -49,7 +49,7 @@ class HTMLManager extends base.ManagerBase<HTMLElement> {
     /**
      * Placeholder implementation for _create_comm.
      */
-    _create_comm() {
+    _create_comm(comm_target_name: string, model_id: string, data?: any, metadata?: any): Promise<any> {
         return Promise.resolve({
             on_close: () => {},
             on_msg: () => {},


### PR DESCRIPTION
tmpnb will need to be upgraded to ipywidgets 7 before we can proceed with fixing the tmpnb example. Or we can switch to binder to load a specific kernel configuration (see https://github.com/jupyterhub/binderhub/issues/13).

Fixes #1473.