### PR TITLE
Mailmap changes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -13,6 +13,7 @@ Brian E. Granger <ellisonbg@gmail.com> Brian Granger
 Brian E. Granger <ellisonbg@gmail.com> Brian Granger <>
 Brian E. Granger <ellisonbg@gmail.com> bgranger <>
 Brian E. Granger <ellisonbg@gmail.com> bgranger <bgranger@red>
+Charnpreet Singh <csingh02@calpoly.edu> charnpreetsingh <csingh02@calpoly.edu>
 Christoph Gohlke <cgohlke@uci.edu> cgohlke <cgohlke@uci.edu>
 Cyrille Rossant <cyrille.rossant@gmail.com> rossant <rossant@github>
 Damián Avila <damianavila82@yahoo.com.ar> damianavila <damianavila82@yahoo.com.ar>
@@ -79,6 +80,7 @@ Juergen Hasch <python@elbonia.de> juhasch <python@elbonia.de>
 Juergen Hasch <python@elbonia.de> juhasch <hasch@VMBOX.fritz.box>
 Julia Evans <julia@jvns.ca> Julia Evans <julia@stripe.com>
 Kester Tong <kestert@google.com> KesterTong <kestert@google.com>
+Kiko Correoso <kikocorreoso@gmail.com> kikocorreoso <kikocorreoso@gmail.com>
 Kyle Kelley <rgbkrk@gmail.com> Kyle Kelley <kyle.kelley@rackspace.com>
 Kyle Kelley <rgbkrk@gmail.com> rgbkrk <rgbkrk@gmail.com>
 Laurent Dufréchou <laurent.dufrechou@gmail.com> <laurent.dufrechou@gmail.com>
@@ -90,6 +92,8 @@ Laurent Dufréchou <laurent.dufrechou@gmail.com> laurent.dufrechou@gmail.com <>
 Laurent Dufréchou <laurent.dufrechou@gmail.com> ldufrechou <ldufrechou@PEP>
 Lorena Pantano <lorena.pantano@gmail.com> Lorena <lorena.pantano@gmail.com>
 Luis Pedro Coelho <luis@luispedro.org> Luis Pedro Coelho <lpc@cmu.edu>
+Luke Zoltan Kelley <lzkelley@gmail.com> Luke <lzkelley@gmail.com>
+Maarten Breddels <maartenbreddels@gmail.com> maartenbreddels <maartenbreddels@gmail.com>
 Marc Molla <marcmolla@gmail.com> marcmolla <marcmolla@gmail.com>
 Martín Gaitán <gaitan@gmail.com> Martín Gaitán <gaitan@phasety.com>
 Matthias Bussonnier <bussonniermatthias@gmail.com> Matthias BUSSONNIER <bussonniermatthias@gmail.com>
@@ -112,6 +116,7 @@ Pietro Berkes <pberkes@enthought.com> Pietro Berkes <pietro.berkes@googlemail.co
 Piti Ongmongkolkul <piti118@gmail.com> piti118 <piti118@gmail.com>
 Prabhu Ramachandran <prabhu@enthought.com> Prabhu Ramachandran <>
 Puneeth Chaganti <punchagan@gmail.com> Puneeth Chaganti <punchagan@muse-amuse.in>
+Rick Teachey <ricky@teachey.org> Ricyteach <ricky@teachey.org>
 Robert Kern <robert.kern@gmail.com> rkern <>
 Robert Kern <robert.kern@gmail.com> Robert Kern <rkern@enthought.com>
 Robert Kern <robert.kern@gmail.com> Robert Kern <rkern@Sacrilege.local>

--- a/docs/source/dev_release.md
+++ b/docs/source/dev_release.md
@@ -42,3 +42,38 @@ twine upload dist/*
 ### Push changes back
 
 commit and tag (ipywidgets) release
+
+
+Release Notes
+=============
+
+Here is an example of the release statistics for ipywidgets 7.0.
+
+It has been 157 days since the last release. In this release, we closed [127 issues](https://github.com/jupyter-widgets/ipywidgets/issues?q=is%3Aissue+is%3Aclosed+milestone%3A7.0) and [216 pull requests](https://github.com/jupyter-widgets/ipywidgets/pulls?q=is%3Apr+milestone%3A7.0+is%3Aclosed) with [1069](https://github.com/jupyter-widgets/ipywidgets/compare/6.0.0...7.0.0) commits, of which 851 are not merges.
+
+Here are some commands used to generate some of the statistics above.
+
+```
+# merges since in 6.0.0, but not 7.0.0, which is a rough list of merged PRs
+git log --merges 6.0.0...master --pretty=oneline
+
+# To really make sure we get all PRs, we could write a program that
+# pulled all of the PRs, examined a commit in each one, and did
+# `git tag --contains <commit number>` to see if that PR commit is included
+# in a previous release.
+
+# issues closed with no milestone in the time period
+# is:issue is:closed closed:"2016-07-14 .. 2017-02-28"
+
+# date of 6.0.0 tag
+git show -s --format=%cd --date=short 6.0.0^{commit}
+
+# Non-merge commits in 7.0.0 not in any 6.x release
+git log --pretty=oneline --no-merges ^6.0.0 master | wc -l
+
+# Authors of non-merge commits
+git shortlog -s  6.0.0..master --no-merges | cut -c8- | sort -f
+
+# New committers: authors unique in the 6.0.0..7.0.0 logs, but not in the 6.0.0 log
+comm -23 <(git shortlog -s -n 6.0.0..master --no-merges | cut -c8- | sort) <(git shortlog -s -n 6.0.0 --no-merges | cut -c8- | sort) | sort -f
+```

--- a/docs/source/dev_testing.md
+++ b/docs/source/dev_testing.md
@@ -7,6 +7,6 @@ To run the Python tests:
 
 To run the Javascript tests:
 
-    cd jupyter-widgets-controls; npm run test
+    npm run test
 
 This will run the test suite using `karma` with 'debug' level logging.


### PR DESCRIPTION
This adds some entries to the mailmap to have more complete names, and also adds some stats for the release. This accomplishes part of #1570.

CCing some people who now have mailmap entries: @charnpreetsingh, @Ricyteach, @lzkelley, @maartenbreddels - please let me know if you would like me to remove the mailmap entry, and stick with the name specified in the commits.

CC @kikocorreoso - do you want to us to include a more complete name in the mailmap (and hence in the release notes)?