### PR TITLE
Allow falsy view info other than undefined

### DIFF
--- a/packages/base/src/manager-base.ts
+++ b/packages/base/src/manager-base.ts
@@ -248,7 +248,7 @@ abstract class ManagerBase<T> {
         let commPromise;
         // we check to make sure the view information is provided, to help catch
         // backwards incompatibility errors.
-        if (!options.view_name || !options.view_module || !options.view_module_version) {
+        if (_.contains([options.view_name, options.view_module, options.view_module_version], undefined)) {
             return Promise.reject("new_widget(...) must be given view information in the options.");
         }
         // If no comm is provided, a new comm is opened for the jupyter.widget


### PR DESCRIPTION
Adjust the widget manager's view info check to allow falsy values other than undefined. This should be the case as `None`/`null` and empty strings (for the version) are allowed values (which indicates that the widget does not have a view).