### PR TITLE
Delete reference to es6-promise.

### DIFF
--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -39,7 +39,6 @@
     "@types/node": "^8.0.1",
     "chai": "^4.0.0",
     "css-loader": "^0.28.4",
-    "es6-promise": "^4.1.0",
     "expect.js": "^0.3.1",
     "file-loader": "^0.11.2",
     "istanbul-instrumenter-loader": "^2.0.0",

--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -47,7 +47,6 @@
     "@types/requirejs": "^2.1.28",
     "chai": "^4.0.0",
     "css-loader": "^0.28.4",
-    "es6-promise": "^4.1.0",
     "file-loader": "^0.11.2",
     "json-loader": "^0.5.4",
     "karma": "^1.6.0",

--- a/packages/html-manager/src/embed-webpack.ts
+++ b/packages/html-manager/src/embed-webpack.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// ES6 Promise polyfill
-(require('es6-promise') as any).polyfill();
-
 const version = (require('../package.json') as any).version;
 
 import 'font-awesome/css/font-awesome.css';


### PR DESCRIPTION
This was causing problems with the html embed script being loaded via a script tag on a page with require defined - require complained about an anonymous module (see http://requirejs.org/docs/errors.html#mismatch). Basically, since es6-promise tries to detect if require is defined, it can mess up things if it is inside of a webpack bundle inside of a script tag.

So instead, we’ll just require that the page support promises (or include the polyfill if needed).