### PR TITLE
Migration guide for custom widget libraries

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -35,7 +35,7 @@ Major user-visible changes in ipywidgets 7.0 include:
 - Using function annotations to specify interact controls for a function is now deprecated and will be removed in a future version of ipywidgets. ([#1292](https://github.com/jupyter-widgets/ipywidgets/pull/1292))
 
 
-Major changes developers should be aware of include:
+Major changes developers should be aware of include (see also the [migration guide](./migration_guides.html) if you are a library developer):
 
 - Custom serializers in either Python or Javascript can now return a structure which contains binary buffers. If a binary buffer is in the serialized data structure, the message will be synced in binary, which is much more efficient. ([#1194](https://github.com/jupyter-widgets/ipywidgets/pull/1194))
 - On the python/kernel side:

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -35,7 +35,7 @@ Major user-visible changes in ipywidgets 7.0 include:
 - Using function annotations to specify interact controls for a function is now deprecated and will be removed in a future version of ipywidgets. ([#1292](https://github.com/jupyter-widgets/ipywidgets/pull/1292))
 
 
-Major changes developers should be aware of include (see also the [migration guide](./migration_guides.html) if you are a library developer):
+If you are developing a custom widget or widget manager, here are some major changes that may affect you. The [migration guide](./migration_guides.html) also walks through how to upgrade a custom widget.
 
 - Custom serializers in either Python or Javascript can now return a structure which contains binary buffers. If a binary buffer is in the serialized data structure, the message will be synced in binary, which is much more efficient. ([#1194](https://github.com/jupyter-widgets/ipywidgets/pull/1194))
 - On the python/kernel side:

--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -13,13 +13,15 @@ For example migrations, see these PRs:
 
 To avoid tying your development cycle to ipywidgets, we recommend starting
 the migration on a branch and keeping that branch open until ipywidgets 7.0
-is released. We also recommend testing the migration in a new notebook, rather
+is released. 
+
+We also recommend testing the migration in a completely new notebook, rather
 than one that contains widgets that you instantiated with ipywidgets 6.0.
 
 ### Updating setup.py
 
 Start by updating the dependency in your `setup.py` to the latest beta. To
-find out the version number, go to the [releases
+find the correct version number, go to the [releases
 page](https://github.com/jupyter-widgets/ipywidgets/releases) on Github and
 cycle through the tags until you see a tag called `7.0.0bx` or `7.0.0rcx`.
 
@@ -65,7 +67,7 @@ errors about missing `jupyter-js-widgets` dependencies. You need to replace
 every import of `jupyter-js-widgets` with an import of
 `@jupyter-widgets/base` (or, possibly, an import of `@jupyter-widgets/controls`).
 
-Your imports should now look like one of the following:
+Your imports should now look like one of the following (depending on how you normally import other modules):
 
 ```javascript
 widgets = require('@jupyter-widgets/base')

--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -10,6 +10,7 @@ Migrating from 6.0 to 7.0
 For example migrations, see these PRs:
  - [ipyleaflet](https://github.com/ellisonbg/ipyleaflet/pull/66)
  - [jupyter-gmaps](https://github.com/pbugnion/gmaps/pull/166)
+ - bqplot: [PR #458](https://github.com/bloomberg/bqplot/pull/458), [PR #497](https://github.com/bloomberg/bqplot/pull/497) and [PR #501](https://github.com/bloomberg/bqplot/pull/501)
 
 To avoid tying your development cycle to ipywidgets, we recommend starting
 the migration on a branch and keeping that branch open until ipywidgets 7.0

--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -29,7 +29,7 @@ cycle through the tags until you see a tag called `7.0.0bx` or `7.0.0rcx`.
 
 Next, we should update the JavaScript dependencies. The most important change
 for widget developers is that the JavaScript package for jupyter-widgets has
-been split between `@jupyter-widgets/base` and `@jupyter-widgets/control`: 
+been split between `@jupyter-widgets/base` and `@jupyter-widgets/controls`: 
  - `@jupyter-widgets/base` contains the base widget classes and the layout
 classes 
  - `@jupyter-widgets/controls` contains the widget classes for the
@@ -81,6 +81,13 @@ require(['@jupyter-widgets/base'], function(widgets) {
 ```javascript
 import * as widgets from '@jupyter-widgets/base'
 ```
+
+### Updating the notebook extension
+
+The notebook extension (normally called `js/src/extension.js`) required
+defining `jupyter-js-widgets` in the configuration for `requirejs`. This is 
+now no longer needed. See the [cookiecutter template](https://github.com/jupyter-widgets/widget-cookiecutter/blob/master/%7B%7Bcookiecutter.github_project_name%7D%7D/js/src/extension.js)
+for an example of what the new `requirejs` configuration looks like.
 
 ### Updating the Python code
 

--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -84,10 +84,11 @@ import * as widgets from '@jupyter-widgets/base'
 
 ### Updating the notebook extension
 
-The notebook extension (normally called `js/src/extension.js`) required
-defining `jupyter-js-widgets` in the configuration for `requirejs`. This is 
-now no longer needed. See the [cookiecutter template](https://github.com/jupyter-widgets/widget-cookiecutter/blob/master/%7B%7Bcookiecutter.github_project_name%7D%7D/js/src/extension.js)
-for an example of what the new `requirejs` configuration looks like.
+Previously, the notebook extension (normally `js/src/extension.js`) required
+defining `jupyter-js-widgets` in the configuration for `requirejs`. This is
+no longer needed. See the [cookiecutter
+template](https://github.com/jupyter-widgets/widget-cookiecutter/blob/master/%7B%7Bcookiecutter.github_project_name%7D%7D/js/src/extension.js)
+for an example of the correct `requirejs` configuration.
 
 ### Updating the Python code
 

--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -1,10 +1,11 @@
 Migrating custom widget libraries
----------------------------------
+=================================
 
 These are migration guides aimed specifically at developers of third-party
 widgets.
 
-### Migrating from 6.0 to 7.0
+Migrating from 6.0 to 7.0
+-------------------------
 
 For example migrations, see these PRs:
  - [ipyleaflet](https://github.com/ellisonbg/ipyleaflet/pull/66)
@@ -15,14 +16,14 @@ the migration on a branch and keeping that branch open until ipywidgets 7.0
 is released. We also recommend testing the migration in a new notebook, rather
 than one that contains widgets that you instantiated with ipywidgets 6.0.
 
-1. Updating setup.py
+### Updating setup.py
 
 Start by updating the dependency in your `setup.py` to the latest beta. To
 find out the version number, go to the [releases
 page](https://github.com/jupyter-widgets/ipywidgets/releases) on Github and
 cycle through the tags until you see a tag called `7.0.0bx` or `7.0.0rcx`.
 
-2. Updating package.json
+### Updating package.json
 
 Next, we should update the JavaScript dependencies. The most important change
 for widget developers is that the JavaScript package for jupyter-widgets has
@@ -40,7 +41,7 @@ cycle through the tags until you see a tag called
 `@jupyter-widgets/controls` if you think you have a dependency on it (e.g. if
 you create widgets that inherit from `VBox` or `HBox` or another user-facing widget).
 
-3. Updating Webpack configuration
+### Updating Webpack configuration
 
 If you use Webpack to build the client-side library, your Webpack
 configuration file (probably at `js/webpack.config.json`) declares
@@ -57,7 +58,7 @@ both packages in the array.
 
 The [cookiecutter template](https://github.com/jupyter-widgets/widget-cookiecutter/blob/master/%7B%7Bcookiecutter.github_project_name%7D%7D/js/webpack.config.js) provides a sample configuration.
 
-4. Updating the client-side code
+### Updating the client-side code
 
 If you now build the client-side code of your library, you will get many
 errors about missing `jupyter-js-widgets` dependencies. You need to replace
@@ -79,7 +80,7 @@ require(['@jupyter-widgets/base'], function(widgets) {
 import * as widgets from '@jupyter-widgets/base'
 ```
 
-5. Updating the Python code
+### Updating the Python code
 
 All widgets need to declare the following six traitlets:
 
@@ -105,7 +106,7 @@ JavaScript bundle when embedding widgets. The embed manager will look for the
 bundle at `https://unpkg.com/<module-name>@<module-version>/dist/index.js`
 when it finds a widget.
 
-6. Updating links
+### Updating links
 
 If your code or your documentation references the link for the jupyter-widgets script
 that loads widgets embedded outside the notebook, 

--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -1,0 +1,112 @@
+Migrating custom widget libraries
+---------------------------------
+
+These are migration guides aimed specifically at developers of third-party
+widgets.
+
+### Migrating from 6.0 to 7.0
+
+For example migrations, see these PRs:
+ - [ipyleaflet](https://github.com/ellisonbg/ipyleaflet/pull/66)
+ - [jupyter-gmaps](https://github.com/pbugnion/gmaps/pull/166)
+
+To avoid tying your development cycle to ipywidgets, we recommend starting
+the migration on a branch and keeping that branch open until ipywidgets 7.0
+is released. We also recommend testing the migration in a new notebook, rather
+than one that contains widgets that you instantiated with ipywidgets 6.0.
+
+1. Updating setup.py
+
+Start by updating the dependency in your `setup.py` to the latest beta. To
+find out the version number, go to the [releases
+page](https://github.com/jupyter-widgets/ipywidgets/releases) on Github and
+cycle through the tags until you see a tag called `7.0.0bx` or `7.0.0rcx`.
+
+2. Updating package.json
+
+Next, we should update the JavaScript dependencies. The most important change
+for widget developers is that the JavaScript package for jupyter-widgets has
+been split between `@jupyter-widgets/base` and `@jupyter-widgets/control`: 
+ - `@jupyter-widgets/base` contains the base widget classes and the layout
+classes 
+ - `@jupyter-widgets/controls` contains the widget classes for the
+user-facing widgets.
+
+In your `package.json`, remove `jupyter-js-widgets` from your dependencies
+and add `@jupyter-widgets/base`. To find the correct version, go to the
+[releases page](https://github.com/jupyter-widgets/ipywidgets/releases) and
+cycle through the tags until you see a tag called
+`@jupyter-widgets/base@<version>`. Do the same for
+`@jupyter-widgets/controls` if you think you have a dependency on it (e.g. if
+you create widgets that inherit from `VBox` or `HBox` or another user-facing widget).
+
+3. Updating Webpack configuration
+
+If you use Webpack to build the client-side library, your Webpack
+configuration file (probably at `js/webpack.config.json`) declares
+`jupyter-js-widgets` as an external dependency. You will need to change this
+in both the bundle for the notebook and the embeddable bundle. If you just
+need `@jupyter-widgets/base`, your external dependencies would be:
+
+```json
+externals: ['@jupyter-widgets/base']
+```
+
+If you need both `@jupyter-widgets/base` and `@jupyter-widgets/controls`, include
+both packages in the array.
+
+The [cookiecutter template](https://github.com/jupyter-widgets/widget-cookiecutter/blob/master/%7B%7Bcookiecutter.github_project_name%7D%7D/js/webpack.config.js) provides a sample configuration.
+
+4. Updating the client-side code
+
+If you now build the client-side code of your library, you will get many
+errors about missing `jupyter-js-widgets` dependencies. You need to replace
+every import of `jupyter-js-widgets` with an import of
+`@jupyter-widgets/base` (or, possibly, an import of `@jupyter-widgets/controls`).
+
+Your imports should now look like one of the following:
+
+```javascript
+widgets = require('@jupyter-widgets/base')
+```
+
+```javascript
+require(['@jupyter-widgets/base'], function(widgets) {
+})
+```
+
+```javascript
+import * as widgets from '@jupyter-widgets/base'
+```
+
+5. Updating the Python code
+
+All widgets need to declare the following six traitlets:
+
+```py
+class ExampleWidget(widgets.Widget):
+    _model_name = Unicode('name of model in JS')
+    _view_name = Unicode('name of view in JS')
+    _model_module = Unicode('name your JS package')
+    _view_module = Unicode('name your JS package')
+    _model_module_version = Unicode('version of your JS bundle')
+    _view_module_version = Unicode('version of your JS bundle')
+```
+
+It is likely that your widgets already declared a `_model_name`,
+`_view_name`, `_model_module` and `_view_module`. The `_model_module` and
+`_view_module` should be the name of your package on NPM (the value of the
+`name` field in your `package.json`). The `_model_module_version` and
+`_view_module_version` should be the version of your JavaScript client (the
+values of the `version` field in your `package.json`).
+
+The `_model_module_version` and `_view_module_version` are used to find your
+JavaScript bundle when embedding widgets. The embed manager will look for the
+bundle at `https://unpkg.com/<module-name>@<module-version>/dist/index.js`
+when it finds a widget.
+
+6. Updating links
+
+If your code or your documentation references the link for the jupyter-widgets script
+that loads widgets embedded outside the notebook, 
+this has changed to `https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed.js`.

--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -19,7 +19,7 @@ is released.
 We also recommend testing the migration in a completely new notebook, rather
 than one that contains widgets that you instantiated with ipywidgets 6.0.
 
-### Updating setup.py
+### Updating setup.py
 
 Start by updating the dependency in your `setup.py` to the latest beta. To
 find the correct version number, go to the [releases
@@ -83,7 +83,7 @@ require(['@jupyter-widgets/base'], function(widgets) {
 import * as widgets from '@jupyter-widgets/base'
 ```
 
-### Updating the notebook extension
+### Updating the notebook extension
 
 Previously, the notebook extension (normally `js/src/extension.js`) required
 defining `jupyter-js-widgets` in the configuration for `requirejs`. This is

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -16,4 +16,5 @@ User Guide
   examples/Widget Asynchronous.ipynb
   embedding.md
   contributing.md
+  migration_guides.md
   changelog.md


### PR DESCRIPTION
Several developers of custom widget libraries have expressed concerns about the migration to jupyter-widgets 7. This aims to provide a step-by-step guide to the migration for custom widget developers.

At the moment, this is strongly based on the migration for `jupyter-gmaps`, but I want to try and migrate other libraries to validate it (and figure out what's missing).

I included this as a new top-level entry in the user guide, but this could also go somewhere else if more appropriate.