### PR TITLE
[WIP] Avoid error initializing output widget in notebook when comm is missing

### DIFF
--- a/widgetsnbextension/src/widget_output.js
+++ b/widgetsnbextension/src/widget_output.js
@@ -21,9 +21,10 @@ var OutputModel = outputBase.OutputModel.extend({
 
     initialize: function(attributes, options) {
         OutputModel.__super__.initialize.apply(this, arguments);
-        this.kernel = this.comm.kernel;
         this.listenTo(this, 'change:msg_id', this.reset_msg_id);
-        if (this.kernel) {
+
+        if (this.comm && this.comm.kernel) {
+            this.kernel = this.comm.kernel;
             this.kernel.set_callbacks_for_msg(this.model_id, this.callbacks(), false);
         }
 


### PR DESCRIPTION
Prior to this commit, the output widget would crash the extension if there was no comm available when it was instantiated. This might happen if the kernel is halted and the page is reloaded. See issue #1598.

Now it just displays a 'disconnected' sign like the other widgets:

<img width="397" alt="screen shot 2017-08-09 at 07 47 33" src="https://user-images.githubusercontent.com/1392879/29108578-81d00caa-7cd7-11e7-874d-b4691f92cbab.png">

Missing:
 - [ ] unit tests