### PR TITLE
Expose API on jlab extension

### DIFF
--- a/packages/jupyterlab-manager/src/plugin.ts
+++ b/packages/jupyterlab-manager/src/plugin.ts
@@ -56,7 +56,7 @@ const INBWidgetExtension = new Token<INBWidgetExtension>('jupyter.extensions.nbW
  * The type of the provided value of the plugin in JupyterLab.
  */
 export
-interface INBWidgetExtension extends DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel>{
+interface INBWidgetExtension extends DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
   /**
    * Register a widget module.
    */

--- a/packages/jupyterlab-manager/src/plugin.ts
+++ b/packages/jupyterlab-manager/src/plugin.ts
@@ -56,7 +56,12 @@ const INBWidgetExtension = new Token<INBWidgetExtension>('jupyter.extensions.nbW
  * The type of the provided value of the plugin in JupyterLab.
  */
 export
-type INBWidgetExtension = DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel>;
+interface INBWidgetExtension extends DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel>{
+  /**
+   * Register a widget module.
+   */
+  registerWidget(data: WidgetManager.IWidgetData): void;
+}
 
 
 export


### PR DESCRIPTION
Exposes the `registerWidget` function on the extension interface, so that the correct typings are declared and exported.

Fixes #1607.