### PR TITLE
Change html manager's embed to assume require is loaded on the page

### DIFF
--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -41,8 +41,7 @@
     "@jupyterlab/rendermime-interfaces": "^0.3.0",
     "@phosphor/widgets": "^1.2.0",
     "ajv": "^5.2.2",
-    "font-awesome": "^4.7.0",
-    "scriptjs": "^2.5.8"
+    "font-awesome": "^4.7.0"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.41",

--- a/packages/html-manager/src/embed-webpack.ts
+++ b/packages/html-manager/src/embed-webpack.ts
@@ -15,12 +15,12 @@ let scriptPromise = function(pkg: string | string[]) {
     });
 }
 
-// Element.prototype.matches polyfill
-if (Element && !Element.prototype.matches) {
-    let proto = Element.prototype as any;
-    proto.matches = proto.matchesSelector ||
-    proto.mozMatchesSelector || proto.msMatchesSelector ||
-    proto.oMatchesSelector || proto.webkitMatchesSelector;
+// Element.prototype.matches polyfill for IE
+// See https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
+if (!Element.prototype.matches) {
+    Element.prototype.matches =
+        Element.prototype.msMatchesSelector ||
+        Element.prototype.webkitMatchesSelector;
 }
 
 // WidgetModel is *just* used as a typing below

--- a/packages/html-manager/src/embed-webpack.ts
+++ b/packages/html-manager/src/embed-webpack.ts
@@ -7,11 +7,24 @@ import 'font-awesome/css/font-awesome.css';
 import '@phosphor/widgets/style/index.css';
 import '@jupyter-widgets/controls/css/widgets.built.css';
 
-let scriptPromise = function(pkg: string | string[]) {
+// WidgetModel is *just* used as a typing below
+import {
+    WidgetModel
+} from '@jupyter-widgets/base';
+
+/**
+ * Load a package using requirejs and return a promise
+ *
+ * @param pkg Package name or names to load
+ */
+let requirePromise = function(pkg: string | string[]) {
     return new Promise((resolve, reject) => {
-        // If requirejs is not on the page on page load, load it from cdn.
-        let scriptjs = require('scriptjs') as any;
-        scriptjs(pkg, resolve, reject);
+        let require = (window as any).require;
+        if (require === undefined) {
+            reject("Requirejs is needed to run the Jupyter Widgets html manager");
+        } else {
+            require(pkg, resolve, reject);
+        }
     });
 }
 
@@ -23,11 +36,6 @@ if (!Element.prototype.matches) {
         Element.prototype.webkitMatchesSelector;
 }
 
-// WidgetModel is *just* used as a typing below
-import {
-    WidgetModel
-} from '@jupyter-widgets/base';
-
 // Load json schema validator
 var Ajv = require('ajv');
 var widget_state_schema = require('@jupyter-widgets/schema').v2.state;
@@ -38,23 +46,15 @@ let model_validate = ajv.compile(widget_state_schema);
 let view_validate = ajv.compile(widget_view_schema);
 
 export
-let loadRequire = new Promise((resolve, reject) => {
-    if ((window as any).requirejs) {
-        resolve();
-    } else {
-        // If requirejs is not on the page on page load, load it from cdn.
-        resolve(scriptPromise('https://unpkg.com/requirejs/require.js'));
-    }
-}).then(() => {
-    // Load the base, controls, and html manager amd modules
+function loadManager() {
     let toLoad = ['base.js', 'controls.js', 'index.js'];
-    return scriptPromise(toLoad.map(f => `https://unpkg.com/@jupyter-widgets/html-manager@${version}/dist/${f}`));
-});
+    return requirePromise(toLoad.map(f => `https://unpkg.com/@jupyter-widgets/html-manager@${version}/dist/${f}`));
+};
 
 // `LoadInlineWidget` is the main function called on load of the web page. All
 // it does is ensure requirejs is on the page and call `renderInlineWidgets`
 function loadInlineWidgets(event) {
-    loadRequire.then(() => {
+    loadManager().then(() => {
         renderInlineWidgets(event);
     });
 }

--- a/packages/html-manager/src/index.ts
+++ b/packages/html-manager/src/index.ts
@@ -3,3 +3,6 @@
 
 export * from "./embed-helper";
 export * from "./htmlmanager";
+
+export
+const version = (require('../package.json') as any).version;

--- a/widgetsnbextension/package.json
+++ b/widgetsnbextension/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@jupyter-widgets/base": "^0.6.8",
     "@jupyter-widgets/controls": "^0.6.14",
+    "@jupyter-widgets/html-manager": "^0.6.6",
     "@jupyter-widgets/output": "^0.3.8",
     "@phosphor/messaging": "^1.2.0",
     "@phosphor/widgets": "^1.2.0",

--- a/widgetsnbextension/src/embed_widgets.js
+++ b/widgetsnbextension/src/embed_widgets.js
@@ -5,6 +5,10 @@
 
 var VIEW_MIME_TYPE = "application/vnd.jupyter.widget-view+json"
 
+import {
+    version
+} from '@jupyter-widgets/html-manager';
+
 var embed_widgets = function() {
     return new Promise(function(resolve) {
         requirejs(['base/js/namespace', 'base/js/dialog', '@jupyter-widgets/controls'], function(Jupyter, dialog, widgets) {
@@ -13,12 +17,7 @@ var embed_widgets = function() {
                 'drop_defaults': true
             }).then(function(state) {
                 var data = JSON.stringify(state, null, '    ');
-                // TODO: This always points to the latest version of
-                // the html-manager.
-                // A better strategy would be to point to a version
-                // of the html-manager that has been tested with this
-                // release of jupyter-widgets/controls.
-                var value = '<script src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed.js"></script>\n' +
+                var value = '<script src="https://unpkg.com/@jupyter-widgets/html-manager@^${version}/dist/embed.js"></script>\n' +
                             '<script type="application/vnd.jupyter.widget-state+json">\n' + data + '\n</script>';
 
                 var views = [];

--- a/widgetsnbextension/src/embed_widgets.js
+++ b/widgetsnbextension/src/embed_widgets.js
@@ -5,9 +5,7 @@
 
 var VIEW_MIME_TYPE = "application/vnd.jupyter.widget-view+json"
 
-import {
-    version
-} from '@jupyter-widgets/html-manager';
+var htmlManagerVersion = require("@jupyter-widgets/html-manager/package.json").version;
 
 var embed_widgets = function() {
     return new Promise(function(resolve) {
@@ -17,8 +15,11 @@ var embed_widgets = function() {
                 'drop_defaults': true
             }).then(function(state) {
                 var data = JSON.stringify(state, null, '    ');
-                var value = '<script src="https://unpkg.com/@jupyter-widgets/html-manager@^${version}/dist/embed.js"></script>\n' +
-                            '<script type="application/vnd.jupyter.widget-state+json">\n' + data + '\n</script>';
+                var value = ('<html><head>\n\n'+
+                '<!-- Load require.js. Delete this if your page already loads require.js -->\n' +
+                    '<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js" integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA=" crossorigin="anonymous"></script>\n\n' +
+                '<script src="https://unpkg.com/@jupyter-widgets/html-manager@^'+htmlManagerVersion+'/dist/embed.js"></script>\n' +
+                            '<script type="application/vnd.jupyter.widget-state+json">\n' + data + '\n</script>\n</head>\n<body>\n');
 
                 var views = [];
                 var cells = Jupyter.notebook.get_cells();
@@ -36,7 +37,7 @@ var embed_widgets = function() {
                     }
                 })
                 value += views.join('\n');
-
+                value += '\n\n</body>\n</html>\n';
                 var content = document.createElement('textarea');
                 content.setAttribute('readonly', 'true');
                 content.style.width = '100%';


### PR DESCRIPTION
It causes lots of problems to load require on a page (see #1591). Here we change the embed script to assume that require is already loaded on the page.