### PR TITLE
Resolve instead of return Promise

### DIFF
--- a/packages/html-manager/src/htmlmanager.ts
+++ b/packages/html-manager/src/htmlmanager.ts
@@ -72,7 +72,7 @@ class HTMLManager extends base.ManagerBase<HTMLElement> {
             } else if (this.loader !== undefined) {
                 resolve(this.loader(moduleName, moduleVersion))
             } else {
-                resolve(Promise.reject(`Could not load module ${moduleName}@${moduleVersion}`))
+                reject(`Could not load module ${moduleName}@${moduleVersion}`);
             }
         }).then((module) => {
             if (module[className]) {

--- a/packages/html-manager/src/htmlmanager.ts
+++ b/packages/html-manager/src/htmlmanager.ts
@@ -70,9 +70,9 @@ class HTMLManager extends base.ManagerBase<HTMLElement> {
             } else if (moduleName === '@jupyter-widgets/output') {
                 resolve(outputWidgets);
             } else if (this.loader !== undefined) {
-                return this.loader(moduleName, moduleVersion);
+                resolve(this.loader(moduleName, moduleVersion))
             } else {
-                return Promise.reject(`Could not load module ${moduleName}@${moduleVersion}`)
+                resolve(Promise.reject(`Could not load module ${moduleName}@${moduleVersion}`))
             }
         }).then((module) => {
             if (module[className]) {


### PR DESCRIPTION
followup of jupyter-widgets/ipywidgets#1630
```javascript
var p = new Promise((resolve, reject) => {
    return Promise.resolve(1) // this does not resolve
}).then((value) => {
    console.log('got value', value)
})

var p = new Promise((resolve, reject) => {
    resolve(Promise.resolve(1)) // should be this or maybe .then(resolve, reject) ?
}).then((value) => {
    console.log('got value', value)
})
```
Is this pattern maybe present in more places?