### PR TITLE
Upgrade webpack and add a way to give the path for assets

### DIFF
--- a/examples/web-tmpnb/package.json
+++ b/examples/web-tmpnb/package.json
@@ -28,13 +28,13 @@
     "fs-extra": "^0.30.0",
     "json-loader": "^0.5.4",
     "postcss": "^6.0.2",
-    "postcss-cssnext": "^2.11.0",
+    "postcss-cssnext": "^3.0.2",
     "postcss-import": "^10.0.0",
-    "postcss-loader": "^1.3.2",
+    "postcss-loader": "^2.0.6",
     "rimraf": "^2.6.1",
     "style-loader": "^0.18.1",
     "typescript": "~2.4.1",
     "url-loader": "^0.5.9",
-    "webpack": "^1.12.12"
+    "webpack": "^3.5.5"
   }
 }

--- a/examples/web-tmpnb/webpack.config.js
+++ b/examples/web-tmpnb/webpack.config.js
@@ -1,28 +1,35 @@
+var path = require('path');
+
 module.exports = {
     entry: './lib/index.js',
     output: {
         filename: 'index.built.js',
-        path: './built/',
+        path: path.resolve(__dirname, './built/'),
         publicPath: 'built/'
     },
     module: {
-        loaders: [
-            { test: /\.css$/, loader: "style-loader!css-loader!postcss-loader" },
-            { test: /\.json$/, loader: "json-loader" },
+        rules: [
+            { test: /\.css$/, use: [
+                'style-loader',
+                'css-loader',
+                {
+                    loader: 'postcss-loader',
+                    options: {
+                        plugins: [
+                            require('postcss-import'),
+                            require('postcss-cssnext')
+                        ]
+                    }
+                }
+            ]},
             // jquery-ui loads some images
-            { test: /\.(jpg|png|gif)$/, loader: "file" },
+            { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
             // required to load font-awesome
-            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
-            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
-            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
-        ]
+            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/octet-stream' },
+            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
+            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=image/svg+xml' }
+              ]
     },
-    postcss: function () {
-        return [
-            require('postcss-import'),
-            require('postcss-cssnext')
-        ];
-    }
 };

--- a/examples/web-tmpnb/webpack.config.js
+++ b/examples/web-tmpnb/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
     entry: './lib/index.js',
     output: {
         filename: 'index.built.js',
-        path: path.resolve(__dirname, './built/'),
+        path: path.resolve(__dirname, 'built'),
         publicPath: 'built/'
     },
     module: {

--- a/examples/web1/karma.config.js
+++ b/examples/web1/karma.config.js
@@ -48,7 +48,7 @@ module.exports = function(config) {
         // level of logging
         // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
         logLevel: config.LOG_INFO,
-
+        browserNoActivityTimeout: 30000,
 
         // enable / disable watching file and executing tests whenever any file changes
         autoWatch: false,

--- a/examples/web1/package.json
+++ b/examples/web1/package.json
@@ -32,6 +32,6 @@
     "karma-webpack": "^2.0.3",
     "mocha": "^3.3.0",
     "style-loader": "^0.18.1",
-    "webpack": "^1.12.12"
+    "webpack": "^3.5.5"
   }
 }

--- a/examples/web1/webpack.config.js
+++ b/examples/web1/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: './index.js',
   output: {
       filename: 'index.built.js',
-      path: path.resolve(__dirname, './built/'),
+      path: path.resolve(__dirname, 'built'),
       publicPath: 'built/'
   },
   module: {

--- a/examples/web1/webpack.config.js
+++ b/examples/web1/webpack.config.js
@@ -1,16 +1,17 @@
+var path = require('path');
+
 module.exports = {
   entry: './index.js',
   output: {
       filename: 'index.built.js',
-      path: './built/',
+      path: path.resolve(__dirname, './built/'),
       publicPath: 'built/'
   },
   module: {
-    loaders: [
+    rules: [
       { test: /\.css$/, loader: "style-loader!css-loader" },
-      { test: /\.json$/, loader: "json-loader" },
       // jquery-ui loads some images
-      { test: /\.(jpg|png|gif)$/, loader: "file" },
+      { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
     ]
   },
 }

--- a/examples/web2/package.json
+++ b/examples/web2/package.json
@@ -24,6 +24,6 @@
     "json-loader": "^0.5.4",
     "style-loader": "^0.18.1",
     "url-loader": "^0.5.9",
-    "webpack": "^1.12.12"
+    "webpack": "^3.5.5"
   }
 }

--- a/examples/web2/webpack.config.js
+++ b/examples/web2/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
     entry: './index.js',
     output: {
         filename: 'index.built.js',
-        path: path.resolve(__dirname, './built/'),
+        path: path.resolve(__dirname, 'built'),
         publicPath: 'built/'
     },
     module: {

--- a/examples/web2/webpack.config.js
+++ b/examples/web2/webpack.config.js
@@ -1,22 +1,23 @@
+var path = require('path');
+
 module.exports = {
     entry: './index.js',
     output: {
         filename: 'index.built.js',
-        path: './built/',
+        path: path.resolve(__dirname, './built/'),
         publicPath: 'built/'
     },
     module: {
-        loaders: [
+        rules: [
             { test: /\.css$/, loader: "style-loader!css-loader" },
-            { test: /\.json$/, loader: "json-loader" },
             // jquery-ui loads some images
-            { test: /\.(jpg|png|gif)$/, loader: "file" },
+            { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
             // required to load font-awesome
-            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
-            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
-            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
-        ]
+            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/octet-stream' },
+            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
+            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=image/svg+xml' }
+              ]
     },
 };

--- a/examples/web3/package.json
+++ b/examples/web3/package.json
@@ -30,13 +30,13 @@
     "fs-extra": "^0.30.0",
     "json-loader": "^0.5.4",
     "postcss": "^6.0.2",
-    "postcss-cssnext": "^2.11.0",
+    "postcss-cssnext": "^3.0.2",
     "postcss-import": "^10.0.0",
-    "postcss-loader": "^1.3.2",
+    "postcss-loader": "^2.0.6",
     "rimraf": "^2.6.1",
     "style-loader": "^0.18.1",
     "typescript": "~2.4.1",
     "url-loader": "^0.5.9",
-    "webpack": "^1.12.12"
+    "webpack": "^3.5.5"
   }
 }

--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -1,45 +1,48 @@
-var postcss = require('postcss');
-
-var postcssHandler = function() {
-    return [
-        postcss.plugin('delete-tilde', function() {
-            return function (css) {
-                css.walkAtRules('import', function(rule) {
-                    rule.params = rule.params.replace('~', '');
-                });
-            };
-        }),
-        postcss.plugin('prepend', function() {
-            return function(css) {
-                css.prepend("@import '@jupyter-widgets/controls/css/labvariables.css';")
-            }
-        }),
-        require('postcss-import')(),
-        require('postcss-cssnext')()
-    ];
-}
-
+const postcss = require('postcss');
+var path = require('path');
 
 module.exports = {
     entry: './lib/index.js',
     output: {
         filename: 'index.built.js',
-        path: './built/',
+        path: path.resolve(__dirname, './built/'),
         publicPath: 'built/'
     },
     module: {
-        loaders: [
-            { test: /\.css$/, loader: "style-loader!css-loader!postcss-loader" },
-            { test: /\.json$/, loader: "json-loader" },
+        rules: [
+            { test: /\.css$/, use: [
+                'style-loader',
+                'css-loader',
+                {
+                    loader: 'postcss-loader',
+                    options: {
+                        plugins: [
+                            postcss.plugin('delete-tilde', function() {
+                                return function (css) {
+                                    css.walkAtRules('import', function(rule) {
+                                        rule.params = rule.params.replace('~', '');
+                                    });
+                                };
+                            }),
+                            postcss.plugin('prepend', function() {
+                                return function(css) {
+                                    css.prepend("@import '@jupyter-widgets/controls/css/labvariables.css';")
+                                }
+                            }),
+                            require('postcss-import')(),
+                            require('postcss-cssnext')()
+                        ]
+                    }
+                }
+            ]},
             // jquery-ui loads some images
-            { test: /\.(jpg|png|gif)$/, loader: "file" },
+            { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
             // required to load font-awesome
-            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
-            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
-            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
-        ]
+            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/octet-stream' },
+            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
+            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=image/svg+xml' }
+              ]
     },
-    postcss: postcssHandler,
 };

--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
     entry: './lib/index.js',
     output: {
         filename: 'index.built.js',
-        path: path.resolve(__dirname, './built/'),
+        path: path.resolve(__dirname, 'built'),
         publicPath: 'built/'
     },
     module: {

--- a/examples/web4/package.json
+++ b/examples/web4/package.json
@@ -21,6 +21,6 @@
     "file-loader": "^0.11.2",
     "style-loader": "^0.18.1",
     "url-loader": "^0.5.9",
-    "webpack": "^1.12.12"
+    "webpack": "^3.5.5"
   }
 }

--- a/examples/web4/webpack.config.js
+++ b/examples/web4/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
     entry: './index.js',
     output: {
         filename: 'index.built.js',
-        path: path.resolve(__dirname, './built/'),
+        path: path.resolve(__dirname, 'built'),
         publicPath: 'built/'
     },
     module: {

--- a/examples/web4/webpack.config.js
+++ b/examples/web4/webpack.config.js
@@ -1,22 +1,23 @@
+var path = require('path');
+
 module.exports = {
     entry: './index.js',
     output: {
         filename: 'index.built.js',
-        path: './built/',
+        path: path.resolve(__dirname, './built/'),
         publicPath: 'built/'
     },
     module: {
-        loaders: [
+        rules: [
             { test: /\.css$/, loader: "style-loader!css-loader" },
-            { test: /\.json$/, loader: "json-loader" },
             // jquery-ui loads some images
-            { test: /\.(jpg|png|gif)$/, loader: "file" },
+            { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
             // required to load font-awesome
-            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
-            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
-            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
-        ]
+            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/octet-stream' },
+            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
+            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=image/svg+xml' }
+              ]
     },
 };

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -51,7 +51,7 @@
     "sinon": "^2.1.0",
     "sinon-chai": "^2.11.0",
     "typescript": "~2.4.1",
-    "webpack": "^1.12.12"
+    "webpack": "^3.5.5"
   },
   "dependencies": {
     "@jupyter-widgets/schema": "^0.3.0-beta.7",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -53,17 +53,17 @@
     "karma-webpack": "^2.0.3",
     "mocha": "^3.3.0",
     "npm-run-all": "^1.5.1",
-    "postcss-cli": "^2.6.0",
-    "postcss-cssnext": "^2.11.0",
+    "postcss-cli": "^4.1.0",
+    "postcss-cssnext": "^3.0.2",
     "postcss-import": "^10.0.0",
-    "postcss-loader": "^1.3.2",
+    "postcss-loader": "^2.0.6",
     "rimraf": "^2.6.1",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.11.0",
     "style-loader": "^0.18.1",
     "typescript": "~2.4.1",
     "url-loader": "^0.5.9",
-    "webpack": "^1.12.12"
+    "webpack": "^3.5.5"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^0.6.11",

--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -59,13 +59,13 @@
     "karma-mocha-reporter": "^2.2.3",
     "mocha": "^3.3.0",
     "postcss": "^6.0.2",
-    "postcss-cssnext": "^2.11.0",
+    "postcss-cssnext": "^3.0.2",
     "postcss-import": "^10.0.0",
-    "postcss-loader": "^1.3.2",
+    "postcss-loader": "^2.0.6",
     "rimraf": "^2.6.1",
     "style-loader": "^0.18.1",
     "typescript": "~2.4.1",
     "url-loader": "^0.5.9",
-    "webpack": "^1.12.12"
+    "webpack": "^3.5.5"
   }
 }

--- a/packages/html-manager/src/libembed-amd.ts
+++ b/packages/html-manager/src/libembed-amd.ts
@@ -20,7 +20,7 @@ let requirePromise = function(pkg: string | string[]): Promise<any> {
 }
 
 function requireLoader(moduleName: string, moduleVersion: string) {
-    return requirePromise([`${moduleName}.js`]).catch((err) => {
+    return requirePromise([`${moduleName}`]).catch((err) => {
         let failedId = err.requireModules && err.requireModules[0];
         if (failedId) {
             console.log(`Falling back to unpkg.com for ${moduleName}@${moduleVersion}`);

--- a/packages/html-manager/src/libembed.ts
+++ b/packages/html-manager/src/libembed.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+declare var  __webpack_public_path__:string;
+__webpack_public_path__ = (window as any).__jupyter_widgets_assets_path__ || __webpack_public_path__;
+
 import 'font-awesome/css/font-awesome.css';
 import '@phosphor/widgets/style/index.css';
 import '@jupyter-widgets/controls/css/widgets.built.css';

--- a/packages/html-manager/test/webpack.conf.js
+++ b/packages/html-manager/test/webpack.conf.js
@@ -4,7 +4,7 @@ var postcss = require('postcss');
 module.exports = {
     entry: './test/build/index.js',
     output: {
-        path: __dirname + "/build",
+        path: path.resolve(__dirname, "build"),
         filename: "bundle.js",
         publicPath: "./build/"
     },

--- a/packages/html-manager/test/webpack.conf.js
+++ b/packages/html-manager/test/webpack.conf.js
@@ -10,30 +10,40 @@ module.exports = {
     },
     bail: true,
     module: {
-        loaders: [
-            { test: /\.css$/, loader: 'style-loader!css-loader!postcss-loader' },
-            { test: /\.md$/, loader: 'raw-loader'},
-            { test: /\.html$/, loader: "file?name=[name].[ext]" },
-            { test: /\.ipynb$/, loader: 'json-loader' },
-            { test: /\.json$/, loader: 'json-loader' },
-        ],
-    },
-    postcss: () => {
-        return [
-            postcss.plugin('delete-tilde', () => {
-                return function (css) {
-                    css.walkAtRules('import', (rule) => {
-                        rule.params = rule.params.replace('~', '');
-                    });
-                };
-            }),
-            postcss.plugin('prepend', () => {
-                return (css) => {
-                    css.prepend(`@import '@jupyter-widgets/controls/css/labvariables.css';`)
+        rules: [
+            { test: /\.css$/, use: [
+                'style-loader',
+                'css-loader',
+                {
+                    loader: 'postcss-loader',
+                    options: {
+                        plugins: [
+                            postcss.plugin('delete-tilde', function() {
+                                return function (css) {
+                                    css.walkAtRules('import', function(rule) {
+                                        rule.params = rule.params.replace('~', '');
+                                    });
+                                };
+                            }),
+                            postcss.plugin('prepend', function() {
+                                return function(css) {
+                                    css.prepend("@import '@jupyter-widgets/controls/css/labvariables.css';")
+                                }
+                            }),
+                            require('postcss-import')(),
+                            require('postcss-cssnext')()
+                        ]
+                    }
                 }
-            }),
-            require('postcss-import')(),
-            require('postcss-cssnext')()
-        ];
-    }
+            ]},
+            // jquery-ui loads some images
+            { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
+            // required to load font-awesome
+            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/octet-stream' },
+            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
+            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=image/svg+xml' }
+        ]
+    },
 }

--- a/packages/html-manager/webpack.config.js
+++ b/packages/html-manager/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = [
     entry: './lib/embed.js',
     output: {
         filename : 'embed.js',
-        path: path.resolve(__dirname, './dist'),
+        path: path.resolve(__dirname, 'dist'),
         publicPath: publicPath,
     },
     devtool: 'source-map',
@@ -62,7 +62,7 @@ module.exports = [
     entry: './lib/embed-amd-render.js',
     output: {
         filename : 'embed-amd-render.js',
-        path: path.resolve(__dirname, './dist/amd'),
+        path: path.resolve(__dirname, 'dist', 'amd'),
         publicPath: publicPath,
     },
     module: { rules: rules },
@@ -72,7 +72,7 @@ module.exports = [
     output: {
         library: '@jupyter-widgets/html-manager/dist/libembed-amd',
         filename : 'libembed-amd.js',
-        path: path.resolve(__dirname, './dist/amd'),
+        path: path.resolve(__dirname, 'dist', 'amd'),
         publicPath: publicPath,
         libraryTarget: 'amd'
     },
@@ -83,7 +83,7 @@ module.exports = [
     output: {
         library: '@jupyter-widgets/html-manager',
         filename : 'index.js',
-        path: path.resolve(__dirname, './dist/amd'),
+        path: path.resolve(__dirname, 'dist', 'amd'),
         publicPath: publicPath,
         libraryTarget: 'amd',
     },
@@ -95,7 +95,7 @@ module.exports = [
     output: {
         library: '@jupyter-widgets/base',
         filename : 'base.js',
-        path: path.resolve(__dirname, './dist/amd'),
+        path: path.resolve(__dirname, 'dist', 'amd'),
         publicPath: publicPath,
         libraryTarget: 'amd',
     },
@@ -106,7 +106,7 @@ module.exports = [
     output: {
         library: '@jupyter-widgets/controls',
         filename : 'controls.js',
-        path: path.resolve(__dirname, './dist/amd'),
+        path: path.resolve(__dirname, 'dist', 'amd'),
         publicPath: publicPath,
         libraryTarget: 'amd'
     },

--- a/packages/html-manager/webpack.config.js
+++ b/packages/html-manager/webpack.config.js
@@ -3,41 +3,47 @@
 
 // Here we generate the /dist files that allow widget embedding
 
+var path = require('path');
+
 var version = require('./package.json').version;
 
 var postcss = require('postcss');
 
-var postcssHandler = function() {
-    return [
-        postcss.plugin('delete-tilde', function() {
-            return function (css) {
-                css.walkAtRules('import', function(rule) {
-                    rule.params = rule.params.replace('~', '');
-                });
-            };
-        }),
-        postcss.plugin('prepend', function() {
-            return function(css) {
-                css.prepend("@import '@jupyter-widgets/controls/css/labvariables.css';")
+var rules = [
+    { test: /\.css$/, use: [
+        'style-loader',
+        'css-loader',
+        {
+            loader: 'postcss-loader',
+            options: {
+                plugins: [
+                    postcss.plugin('delete-tilde', function() {
+                        return function (css) {
+                            css.walkAtRules('import', function(rule) {
+                                rule.params = rule.params.replace('~', '');
+                            });
+                        };
+                    }),
+                    postcss.plugin('prepend', function() {
+                        return function(css) {
+                            css.prepend("@import '@jupyter-widgets/controls/css/labvariables.css';")
+                        }
+                    }),
+                    require('postcss-import')(),
+                    require('postcss-cssnext')()
+                ]
             }
-        }),
-        require('postcss-import')(),
-        require('postcss-cssnext')()
-    ];
-}
-
-var loaders = [
-            { test: /\.css$/, loader: "style-loader!css-loader!postcss-loader" },
-            { test: /\.json$/, loader: "json-loader" },
-            // jquery-ui loads some images
-            { test: /\.(jpg|png|gif)$/, loader: "file" },
-            // required to load font-awesome
-            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
-            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
-            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
-        ];
+        }
+    ]},
+    // jquery-ui loads some images
+    { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
+    // required to load font-awesome
+    { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+    { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+    { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/octet-stream' },
+    { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
+    { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=image/svg+xml' }
+];
 
 var publicPath = 'https://unpkg.com/@jupyter-widgets/html-manager@' + version + '/dist/';
 
@@ -46,46 +52,42 @@ module.exports = [
     entry: './lib/embed.js',
     output: {
         filename : 'embed.js',
-        path: './dist',
+        path: path.resolve(__dirname, './dist'),
         publicPath: publicPath,
     },
     devtool: 'source-map',
-    module: { loaders: loaders },
-    postcss: postcssHandler
+    module: { rules: rules },
 },
 {// script that renders widgets using the amd embedding and can render third-party custom widgets
     entry: './lib/embed-amd-render.js',
     output: {
         filename : 'embed-amd-render.js',
-        path: './dist/amd',
+        path: path.resolve(__dirname, './dist/amd'),
         publicPath: publicPath,
     },
-    module: { loaders: loaders },
-    postcss: postcssHandler
+    module: { rules: rules },
 },
 {// embed library that depends on requirejs, and can load third-party widgets dynamically
     entry: './lib/libembed-amd.js',
     output: {
         library: '@jupyter-widgets/html-manager/dist/libembed-amd',
         filename : 'libembed-amd.js',
-        path: './dist/amd',
+        path: path.resolve(__dirname, './dist/amd'),
         publicPath: publicPath,
         libraryTarget: 'amd'
     },
-    module: { loaders: loaders },
-    postcss: postcssHandler
+    module: { rules: rules },
 },
 {// @jupyter-widgets/html-manager
     entry: './lib/index.js',
     output: {
         library: '@jupyter-widgets/html-manager',
         filename : 'index.js',
-        path: './dist/amd',
+        path: path.resolve(__dirname, './dist/amd'),
         publicPath: publicPath,
         libraryTarget: 'amd',
     },
-    module: { loaders: loaders },
-    postcss: postcssHandler,
+    module: { rules: rules },
     externals: ['@jupyter-widgets/base', '@jupyter-widgets/controls']
 },
 {// @jupyter-widgets/base
@@ -93,24 +95,22 @@ module.exports = [
     output: {
         library: '@jupyter-widgets/base',
         filename : 'base.js',
-        path: './dist/amd',
+        path: path.resolve(__dirname, './dist/amd'),
         publicPath: publicPath,
         libraryTarget: 'amd',
     },
-    module: { loaders: loaders },
-    postcss: postcssHandler
+    module: { rules: rules },
 },
 {// @jupyter-widgets/controls
     entry: '@jupyter-widgets/controls/lib/index',
     output: {
         library: '@jupyter-widgets/controls',
         filename : 'controls.js',
-        path: './dist/amd',
+        path: path.resolve(__dirname, './dist/amd'),
         publicPath: publicPath,
         libraryTarget: 'amd'
     },
-    module: { loaders: loaders },
-    postcss: postcssHandler,
+    module: { rules: rules },
     externals: ['@jupyter-widgets/base']
 }
 ];

--- a/widgetsnbextension/package.json
+++ b/widgetsnbextension/package.json
@@ -33,11 +33,11 @@
   "devDependencies": {
     "css-loader": "^0.28.4",
     "json-loader": "^0.5.4",
-    "postcss-cssnext": "^2.11.0",
+    "postcss-cssnext": "^3.0.2",
     "postcss-import": "^10.0.0",
-    "postcss-loader": "^1.3.2",
+    "postcss-loader": "^2.0.6",
     "rimraf": "^2.6.1",
     "style-loader": "^0.18.1",
-    "webpack": "^1.12.12"
+    "webpack": "^3.5.5"
   }
 }

--- a/widgetsnbextension/webpack.config.js
+++ b/widgetsnbextension/webpack.config.js
@@ -3,7 +3,7 @@ module.exports = {
     entry: './src/extension.js',
     output: {
         filename: 'extension.js',
-        path: path.resolve(__dirname, './widgetsnbextension/static'),
+        path: path.resolve(__dirname, 'widgetsnbextension', 'static'),
         libraryTarget: 'amd'
     },
     devtool: 'source-map',

--- a/widgetsnbextension/webpack.config.js
+++ b/widgetsnbextension/webpack.config.js
@@ -3,28 +3,33 @@ module.exports = {
     entry: './src/extension.js',
     output: {
         filename: 'extension.js',
-        path: './widgetsnbextension/static',
+        path: path.resolve(__dirname, './widgetsnbextension/static'),
         libraryTarget: 'amd'
     },
     devtool: 'source-map',
     module: {
-        loaders: [
-            { test: /\.css$/, loader: "style-loader!css-loader!postcss-loader" },
-            { test: /\.json$/, loader: "json-loader" },
+        rules: [
+            { test: /\.css$/, use: [
+                'style-loader',
+                'css-loader',
+                {
+                    loader: 'postcss-loader',
+                    options: {
+                        plugins: [
+                            require('postcss-import'),
+                            require('postcss-cssnext')
+                        ]
+                    }
+                }
+            ]},
             // jquery-ui loads some images
-            { test: /\.(jpg|png|gif)$/, loader: "file" },
+            { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
             // required to load font-awesome
-            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
-            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
-            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
-        ]
+            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/font-woff' },
+            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=application/octet-stream' },
+            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
+            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, use: 'url-loader?limit=10000&mimetype=image/svg+xml' }
+              ]
     },
-    postcss: function () {
-        return [
-            require('postcss-import'),
-            require('postcss-cssnext')
-        ]
-    }
 };


### PR DESCRIPTION
Here's how to use the new `__jupyter_widgets_assets_path__` to give the location of assets, like the fontawesome font:

```html
<script>
        window.__jupyter_widgets_assets_path__ = './dist/';
</script>
<script src="./dist/embed.js" crossorigin="anonymous"></script>
```
This provides a workaround for #1650.