### PR TITLE
instantiate IPython when testing _ipython_display_

### DIFF
--- a/ipywidgets/widgets/tests/test_widget.py
+++ b/ipywidgets/widgets/tests/test_widget.py
@@ -3,16 +3,22 @@
 
 """Test Widget."""
 
-from IPython.utils.capture import capture_output
+from IPython.core.interactiveshell import InteractiveShell
 from IPython.display import display
+from IPython.utils.capture import capture_output
 
 from ..widget import Widget
 
 
 def test_no_widget_view():
+    # ensure IPython shell is instantiated
+    # otherwise display() just calls print
+    shell = InteractiveShell.instance()
+
     with capture_output() as cap:
         w = Widget()
         display(w)
-    assert len(cap.outputs) == 0
-    assert len(cap.stdout) == 0
-    assert len(cap.stderr) == 0
+
+    assert cap.outputs == [], repr(cap.outputs)
+    assert cap.stdout == '', repr(cap.stdout)
+    assert cap.stderr == '', repr(cap.stderr)


### PR DESCRIPTION
if IPython isn't instantiated, display calls print (IPython master)