### PR TITLE
Update a few css and docs issues

### DIFF
--- a/docs/source/examples/Export As (nbconvert).ipynb
+++ b/docs/source/examples/Export As (nbconvert).ipynb
@@ -14,7 +14,7 @@
     "from traitlets import Unicode\n",
     "\n",
     "# nbconvert related imports\n",
-    "from nbconvert import get_export_names, export_by_name\n",
+    "from nbconvert import get_export_names, export, get_exporter\n",
     "from nbconvert.writers import FilesWriter\n",
     "from nbformat import read, NO_CONVERT\n",
     "from nbconvert.utils.exceptions import ConversionException"
@@ -140,7 +140,7 @@
    "source": [
     "file_writer = FilesWriter()\n",
     "\n",
-    "def export(name, nb):\n",
+    "def export_nb(name, nb):\n",
     "    \n",
     "    # Get a unique key for the notebook and set it in the resources object.\n",
     "    notebook_name = name[:name.rfind('.')]\n",
@@ -150,7 +150,7 @@
     "\n",
     "    # Try to export\n",
     "    try:\n",
-    "        output, resources = export_by_name(exporter_names.value, nb)\n",
+    "        output, resources = export(get_exporter(exporter_names.value), nb)\n",
     "    except ConversionException as e:\n",
     "        download_link.value = \"<br>Could not export notebook!\"\n",
     "    else:\n",
@@ -161,7 +161,7 @@
     "        \n",
     "def handle_export(widget):\n",
     "    with open(filename, 'r') as f:\n",
-    "        export(filename, read(f, NO_CONVERT))\n",
+    "        export_nb(filename, read(f, NO_CONVERT))\n",
     "        \n",
     "export_button.on_click(handle_export)"
    ]

--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -259,7 +259,7 @@
 /* Widget Label Styling */
 
 /* Override Bootstrap label css */
-.jupyter-widgets label.widget-label {
+.jupyter-widgets label {
     margin-bottom: initial;
 }
 

--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -374,7 +374,6 @@
 }
 
 .widget-valid i:before {
-    height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
     margin-right: var(--jp-widgets-inline-margin);
     margin-left: var(--jp-widgets-inline-margin);


### PR DESCRIPTION
Running through the docs one last time, I noticed three issues, fixed here:

1. the export example notebook uses a deprecated nbconvert function
2. the checkbox label had a bootstrap margin, so there was a scrollbar with hbox
3. the valid widget icon was 35px high, so it also had a scrollbar in an hbox

