### PR TITLE
ENH: Give a clearer error for widget js.

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -758,7 +758,7 @@ _FALLBACK_HTML_TEMPLATE = """\
 <p>Failed to display Jupyter Widget of type <code>{widget_type}</code>.</p>
 <p>
   If you're reading this message in Jupyter Notebook or JupyterLab, it probably means that
-  the widgets Javascript library is either not installed or not enabled. See
+  the widgets JavaScript library is either not installed or not enabled. See
   the <a href=https://ipywidgets.readthedocs.io/en/latest/user_install.html>Jupyter Widgets Documentation</a>
   for setup instructions.
 </p>

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -757,10 +757,11 @@ class Widget(LoggingHasTraits):
 _FALLBACK_HTML_TEMPLATE = """\
 <p>Failed to display Jupyter Widget of type <code>{widget_type}</code>.</p>
 <p>
-  If you're reading this message in Jupyter Notebook or JupyterLab, it probably means that
-  the widgets JavaScript library is either not installed or not enabled. See
-  the <a href=https://ipywidgets.readthedocs.io/en/latest/user_install.html>Jupyter Widgets Documentation</a>
-  for setup instructions.
+  If you're reading this message in Jupyter Notebook or JupyterLab, it may mean
+  that the widgets JavaScript is still loading. If this message persists, it
+  likely means that the widgets JavaScript library is either not installed or
+  not enabled. See the <a href=https://ipywidgets.readthedocs.io/en/latest/user_install.html>Jupyter
+  Widgets Documentation</a> for setup instructions.
 </p>
 <p>
   If you're reading this message in another notebook frontend (e.g. a static

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -707,7 +707,8 @@ class Widget(LoggingHasTraits):
             # and the currently registered mimetypes at
             # http://www.iana.org/assignments/media-types/media-types.xhtml.
             data = {
-                'text/plain': "A Jupyter Widget",
+                'text/plain': repr(self),
+                'text/html': self._fallback_html(),
                 'application/vnd.jupyter.widget-view+json': {
                     'version_major': 2,
                     'version_minor': 0,
@@ -748,3 +749,22 @@ class Widget(LoggingHasTraits):
             for key in keys
         )
         return '%s(%s)' % (class_name, signature)
+
+    def _fallback_html(self):
+        return _FALLBACK_HTML_TEMPLATE.format(widget_type=type(self).__name__)
+
+
+_FALLBACK_HTML_TEMPLATE = """\
+<p>Failed to display Jupyter Widget of type <code>{widget_type}</code>.</p>
+<p>
+  If you're reading this message in Jupyter Notebook or JupyterLab, it probably means that
+  the widgets Javascript library is either not installed or not enabled. See
+  the <a href=http://ipywidgets.readthedocs.io/en/latest/user_install.html>Jupyter Widgets Documentation</a>
+  for setup instructions.
+</p>
+<p>
+  If you're reading this message in another notebook frontend (e.g. a static
+  rendering on GitHub or <a href="https://nbviewer.jupyter.org/">NBViewer</a>),
+  it may mean that your frontend doesn't currently support widgets.
+</p>
+"""

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -759,7 +759,7 @@ _FALLBACK_HTML_TEMPLATE = """\
 <p>
   If you're reading this message in Jupyter Notebook or JupyterLab, it probably means that
   the widgets Javascript library is either not installed or not enabled. See
-  the <a href=http://ipywidgets.readthedocs.io/en/latest/user_install.html>Jupyter Widgets Documentation</a>
+  the <a href=https://ipywidgets.readthedocs.io/en/latest/user_install.html>Jupyter Widgets Documentation</a>
   for setup instructions.
 </p>
 <p>


### PR DESCRIPTION
Adds a new 'text/html' entry in the mimebundle for widgets, which points
users to the installation instructions in the widgets docs.