### PR TITLE
Add traits to Image widget for mouse position and clicks

### DIFF
--- a/ipywidgets/widgets/widget_image.py
+++ b/ipywidgets/widgets/widget_image.py
@@ -12,7 +12,7 @@ from .widget_core import CoreWidget
 from .domwidget import DOMWidget
 from .valuewidget import ValueWidget
 from .widget import register
-from traitlets import Unicode, CUnicode, Bytes, observe
+from traitlets import Unicode, CUnicode, Bytes, observe, Float
 
 
 @register
@@ -32,3 +32,5 @@ class Image(DOMWidget, ValueWidget, CoreWidget):
     width = CUnicode(help="Width of the image in pixels.").tag(sync=True)
     height = CUnicode(help="Height of the image in pixels.").tag(sync=True)
     value = Bytes(help="The image data as a byte string.").tag(sync=True)
+    x_click = Float(help="x position of most recent mouse click in pixels").tag(sync=True)
+    y_click = Float(help="y position of most recent mouse click in pixels").tag(sync=True)

--- a/ipywidgets/widgets/widget_image.py
+++ b/ipywidgets/widgets/widget_image.py
@@ -34,3 +34,5 @@ class Image(DOMWidget, ValueWidget, CoreWidget):
     value = Bytes(help="The image data as a byte string.").tag(sync=True)
     x_click = Float(help="x position of most recent mouse click in pixels").tag(sync=True)
     y_click = Float(help="y position of most recent mouse click in pixels").tag(sync=True)
+    x_mouse = Float(help="x position of pointer in pixels").tag(sync=True)
+    y_mouse = Float(help="y position of pointer in pixels").tag(sync=True)

--- a/packages/controls/src/widget_image.ts
+++ b/packages/controls/src/widget_image.ts
@@ -23,6 +23,8 @@ class ImageModel extends CoreDOMWidgetModel {
             value: new Uint8Array(0),
             x_click: 0,
             y_click: 0,
+            x_mouse: 0,
+            y_mouse: 0
         });
     }
 }
@@ -80,6 +82,7 @@ class ImageView extends DOMWidgetView {
         return {
             // Dictionary of events and their handlers.
             'click': '_handle_click',
+            'mousemove': '_handle_mousemove'
         }
     }
 
@@ -105,6 +108,12 @@ class ImageView extends DOMWidgetView {
         this.touch();
     }
 
+    _handle_mousemove(event) {
+        var mouse_position = this._get_position(event);
+        this.model.set('x_mouse', mouse_position.x, {updated_view: this});
+        this.model.set('y_mouse', mouse_position.y, {updated_view: this});
+        this.touch();
+    }
     /**
      * The default tag name.
      *

--- a/packages/controls/src/widget_image.ts
+++ b/packages/controls/src/widget_image.ts
@@ -20,7 +20,9 @@ class ImageModel extends CoreDOMWidgetModel {
             format: 'png',
             width: '',
             height: '',
-            value: new Uint8Array(0)
+            value: new Uint8Array(0),
+            x_click: 0,
+            y_click: 0,
         });
     }
 }
@@ -72,6 +74,35 @@ class ImageView extends DOMWidgetView {
             URL.revokeObjectURL(this.el.src);
         }
         super.remove()
+    }
+
+    events(): {[e: string]: string} {
+        return {
+            // Dictionary of events and their handlers.
+            'click': '_handle_click',
+        }
+    }
+
+    _get_position(event) {
+        var bounding_rect = this.el.getBoundingClientRect();
+        var y_offset = bounding_rect.top;
+        var x_offset = bounding_rect.left;
+        return {
+            'x': event.clientX - x_offset,
+            'y': event.clientY - y_offset
+        }
+    }
+    /**
+     * Handles and validates user input.
+     *
+     * Calling model.set will trigger all of the other views of the
+     * model to update.
+     */
+    _handle_click(event) {
+        var mouse_position = this._get_position(event);
+        this.model.set('x_click', mouse_position.x, {updated_view: this});
+        this.model.set('y_click', mouse_position.y, {updated_view: this});
+        this.touch();
     }
 
     /**


### PR DESCRIPTION
This adds four new traits to the image widget, all pixel positions relative to the upper left corner of the image.

+ `x_click` and `y_click`, the pixel position of the most recent mouse click.
+ `x_mouse` and `y_mouse`, the pixel position of the mouse (changes triggered by the `mousemove` event on the front end).

@ejeschke -- this moves in the direction of making a ginga widget easier. I think it might be better to add a `Canvas` widget for that (looks relatively straightforward).

Whether this is the way to go for ginga or not this seems like a nice improvement to the `Image` widget.

I'm happy to change trait names or rethink the approach.

edit: add to do list:

- [ ] Correctly handle calculation of raw pixel position when border and/or padding are non-zero. Currently pixel position is measured relationship  to upper left of the border.
- [ ] Make click an event with a custom payload.
- [ ] Catch keypresses using suggestions from https://github.com/jupyter-widgets/ipywidgets/pull/1677#issuecomment-325587748.
- [ ] Make mouse monitoring optional.
- [ ] Factor mouse interactivity out of the `Image` widget.