### PR TITLE
Extend embedding documentation

### DIFF
--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -114,33 +114,43 @@ html_template = """
 
     <title>Widget export</title>
 
+    <!-- Load RequireJS, used by the IPywidgets for dependency management -->
     <script 
       src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js" 
       integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA=" 
       crossorigin="anonymous">
     </script>
+
+    <!-- Load IPywidgets bundle for embedding. -->
     <script 
       src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js" 
       crossorigin="anonymous">
     </script>
 
+    <!-- The state of all the widget models on the page -->
     <script type="application/vnd.jupyter.widget-state+json">
       {manager_state}
     </script>
   </head>
 
   <body>
+
     <div id="first-slider-widget">
+      <!-- This script tag will be replaced by the view's DOM tree -->
       <script type="application/vnd.jupyter.widget-view+json">
         {widget_views[0]}
       </script>
     </div>
+
     <hrule />
+
     <div id="second-slider-widget">
+      <!-- This script tag will be replaced by the view's DOM tree -->
       <script type="application/vnd.jupyter.widget-view+json">
         {widget_views[1]}
       </script>
     </div>
+
   </body>
 </html>
 """

--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -95,7 +95,7 @@ browser search bar).
 You will sometimes want greater granularity than that afforded by
 `embed_minimal_html`. Often, you want to control the structure of the HTML
 document in which the widgets are embedded. For this, use `embed_data` to get
-JSON exports of specific parts of the widget state, and embed these in an
+JSON exports of specific parts of the widget state. You can embed these in an
 HTML template:
 
 ```py
@@ -159,6 +159,10 @@ document. For each widget view, place a `<script>` tag of type
 `application/vnd.juptyer.widget-view.json` in the DOM element that should
 contain the view. The widget manager will replace each `<script>` tag with
 the DOM tree corresponding to the widget.
+
+In this example, we used Python's string format. For embedding in more
+complex documents, you may want to use a templating engine like
+[Jinja2](http://jinja.pocoo.org/).
 
 In all embedding functions, the state of all widgets known to the widget manager is
 included by default. You can alternatively pass a reduced state to use instead.

--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -71,9 +71,9 @@ the `application/vnd.jupyter.widget-state+json` format specified in the
 
 ## Python interface
 
-Embeddable code for the widgets can also be produced from Python.
-
-The `ipywidgets.embed` module provides several functions for embedding widgets into HTML documents programatically.
+Embeddable code for the widgets can also be produced from Python. The
+`ipywidgets.embed` module provides several functions for embedding widgets
+into HTML documents programatically.
 
 Use `embed_minimal_html` to create a simple, stand-alone HTML page:
 
@@ -85,15 +85,18 @@ slider = IntSlider(value=40)
 embed_minimal_html('export.html', views=[slider], title='Widgets export')
 ```
 
-This creates the stand-alone file `'export.html'`. To view the file, either
-start an HTTP server (such as the HTTP server in the Python standard library)
-or just open it in your web browser (by double-clicking on the file, or by
-writing `file:///path/to/file` in your browser search bar).
+This creates the stand-alone file `export.html`. To view the file, either
+start an HTTP server, such as the [HTTP
+server](https://docs.python.org/3.6/library/http.server.html#module-http.server)
+in the Python standard library. or just open it in your web browser (by
+double-clicking on the file, or by writing `file:///path/to/file` in your
+browser search bar).
 
 You will sometimes want greater granularity than that afforded by
 `embed_minimal_html`. Often, you want to control the structure of the HTML
 document in which the widgets are embedded. For this, use `embed_data` to get
-JSON exports of specific parts of the widget state:
+JSON exports of specific parts of the widget state, and embed these in an
+HTML template:
 
 ```py
 import json
@@ -111,7 +114,6 @@ html_template = """
 
     <title>Widget export</title>
 
-    <!-- Load require.js. Delete this if your page already loads require.js -->
     <script 
       src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js" 
       integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA=" 
@@ -119,8 +121,8 @@ html_template = """
     </script>
     <script 
       src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js" 
-      crossorigin="anonymous"
-    ></script>
+      crossorigin="anonymous">
+    </script>
 
     <script type="application/vnd.jupyter.widget-state+json">
       {manager_state}
@@ -150,11 +152,13 @@ with open('export.html', 'w') as fp:
     fp.write(rendered_template)
 ```
 
-The manager state needs to go inside a `<script>` tag of type
-`application/vnd.jupyter.widget-state+json`. For each view, place a
-`<script>` tag of type `application/vnd.juptyer.widget-view.json` in the DOM
-element that should contain the widget. The widget manager will replace each
-`<script>` tag with the DOM tree corresponding to the widget.
+The web page needs to load RequireJS and the Jupyter widgets HTML manager.
+You then need to include the manager state in a `<script>` tag of type
+`application/vnd.jupyter.widget-state+json`, which can go in the head of the
+document. For each widget view, place a `<script>` tag of type
+`application/vnd.juptyer.widget-view.json` in the DOM element that should
+contain the view. The widget manager will replace each `<script>` tag with
+the DOM tree corresponding to the widget.
 
 In all embedding functions, the state of all widgets known to the widget manager is
 included by default. You can alternatively pass a reduced state to use instead.
@@ -164,14 +168,19 @@ include only the state of the views and their dependencies, use the function
 `dependency_state`:
 
 ```py
-s1, s2 = IntSlider(max=200, value=100), IntSlider(value=40)
+from ipywidgets.embed import embed_snippet, dependency_state
+
+s1 = IntSlider(max=200, value=100)
+s2 = IntSlider(value=40)
 print(embed_snippet(
     views=[s1, s2],
     state=dependency_state([s1, s2]),
     ))
 ```
 
-In the `embed_snippet` and `embed_minimal_html` examples above, the `requirejs=True` gives the RequireJS embedder. To get the standard embedder, omit this option or give `requirejs=False`.
+In the `embed_snippet` and `embed_minimal_html` examples above, the
+`requirejs=True` gives the RequireJS embedder. To get the standard embedder,
+omit this option or give `requirejs=False`.
 
 ## Embedding Widgets in the Sphinx HTML Documentation
 

--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -88,7 +88,7 @@ embed_minimal_html('export.html', views=[slider], title='Widgets export')
 This creates the stand-alone file `export.html`. To view the file, either
 start an HTTP server, such as the [HTTP
 server](https://docs.python.org/3.6/library/http.server.html#module-http.server)
-in the Python standard library. or just open it in your web browser (by
+in the Python standard library, or just open it in your web browser (by
 double-clicking on the file, or by writing `file:///path/to/file` in your
 browser search bar).
 
@@ -135,6 +135,8 @@ html_template = """
 
   <body>
 
+    <h1>Widget export</h1>
+
     <div id="first-slider-widget">
       <!-- This script tag will be replaced by the view's DOM tree -->
       <script type="application/vnd.jupyter.widget-view+json">
@@ -166,20 +168,21 @@ The web page needs to load RequireJS and the Jupyter widgets HTML manager.
 You then need to include the manager state in a `<script>` tag of type
 `application/vnd.jupyter.widget-state+json`, which can go in the head of the
 document. For each widget view, place a `<script>` tag of type
-`application/vnd.juptyer.widget-view.json` in the DOM element that should
+`application/vnd.jupyter.widget-view+json` in the DOM element that should
 contain the view. The widget manager will replace each `<script>` tag with
 the DOM tree corresponding to the widget.
 
-In this example, we used Python's string format. For embedding in more
-complex documents, you may want to use a templating engine like
+In this example, we used a Python string for the template, and used the
+`format` method to interpolate the state. For embedding in more complex
+documents, you may want to use a templating engine like
 [Jinja2](http://jinja.pocoo.org/).
 
-In all embedding functions, the state of all widgets known to the widget manager is
-included by default. You can alternatively pass a reduced state to use instead.
-This can be particularly relevant if you have many independent widgets with a
-large state, but only want to include the relevant ones in your export. To
-include only the state of the views and their dependencies, use the function
-`dependency_state`:
+In all embedding functions in `ipywidgets.embed`, the state of all widgets
+known to the widget manager is included by default. You can alternatively
+pass a reduced state to use instead. This can be particularly relevant if you
+have many independent widgets with a large state, but only want to include
+the relevant ones in your export. To include only the state of specific views
+and their dependencies, use the function `dependency_state`:
 
 ```py
 from ipywidgets.embed import embed_snippet, dependency_state

--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -192,10 +192,6 @@ s2 = IntSlider(value=40)
 embed_minimal_html(views=[s1, s2], state=dependency_state([s1, s2]))
 ```
 
-In the `embed_snippet` and `embed_minimal_html` examples above, the
-`requirejs=True` gives the RequireJS embedder. To get the standard embedder,
-omit this option or give `requirejs=False`.
-
 ## Embedding Widgets in the Sphinx HTML Documentation
 
 As of ipywidgets 6.0, Jupyter interactive widgets can be rendered in Sphinx html

--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -186,10 +186,7 @@ from ipywidgets.embed import embed_snippet, dependency_state
 
 s1 = IntSlider(max=200, value=100)
 s2 = IntSlider(value=40)
-print(embed_snippet(
-    views=[s1, s2],
-    state=dependency_state([s1, s2]),
-    ))
+embed_minimal_html(views=[s1, s2], state=dependency_state([s1, s2]))
 ```
 
 In the `embed_snippet` and `embed_minimal_html` examples above, the

--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -257,8 +257,8 @@ def embed_minimal_html(fp, views, title=u'IPyWidget export', template=None, **kw
     views: widget or collection of widgets or None
         The widgets to include views for. If None, all DOMWidgets are
         included (not just the displayed ones).
-	title: title for the html page
-	template: template string for the html,
+    title: title of the html page.
+    template: template string for the html.
 
     Further it accepts keyword args similar to `embed_snippet`.
     """

--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -258,9 +258,12 @@ def embed_minimal_html(fp, views, title=u'IPyWidget export', template=None, **kw
         The widgets to include views for. If None, all DOMWidgets are
         included (not just the displayed ones).
     title: title of the html page.
-    template: template string for the html.
+    template: Template in which to embed the widget state.abs
+        This should be a Python string with placeholders
+        `{title}` and `{snippet}`. The `{snippet}` placeholder
+        will be replaced by all the widgets.
 
-    Further it accepts keyword args similar to `embed_snippet`.
+    This method also accepts keyword arguments accepted by `embed_snippet`.
     """
 
     snippet = embed_snippet(views, **kwargs)

--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -279,10 +279,8 @@ def embed_minimal_html(fp, views, title=u'IPyWidget export', template=None, **kw
         This should be a Python string with placeholders
         `{{title}}` and `{{snippet}}`. The `{{snippet}}` placeholder
         will be replaced by all the widgets.
-
-    This method also accepts keyword arguments accepted by `embed_snippet`.
+    {embed_kwargs}
     """
-
     snippet = embed_snippet(views, **kwargs)
 
     values = {

--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -174,6 +174,7 @@ def dependency_state(widgets, drop_defaults=True):
     return state
 
 
+@_doc_subst
 def embed_data(views, drop_defaults=True, state=None):
     """Gets data for embedding.
 
@@ -182,9 +183,7 @@ def embed_data(views, drop_defaults=True, state=None):
 
     Parameters
     ----------
-    views: widget or collection of widgets or None
-        The widgets to include views for. If None, all DOMWidgets are
-        included (not just the displayed ones).
+    {views_attribute}
     drop_defaults: boolean
         Whether to drop default values from the widget states.
     state: dict or None (default)

--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -274,7 +274,7 @@ def embed_minimal_html(fp, views, title=u'IPyWidget export', template=None, **kw
         The file to write the HTML output to.
     {views_attribute}
     title: title of the html page.
-    template: Template in which to embed the widget state.abs
+    template: Template in which to embed the widget state.
         This should be a Python string with placeholders
         `{{title}}` and `{{snippet}}`. The `{{snippet}}` placeholder
         will be replaced by all the widgets.

--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -144,6 +144,15 @@ def add_resolved_links(store, drop_defaults):
 def dependency_state(widgets, drop_defaults=True):
     """Get the state of all widgets specified, and their dependencies.
 
+    Parameters
+    ----------
+
+    widgets: single widget or list of widgets.
+       This function will return the state of every widget mentioned
+       and of all their dependencies.
+    drop_defaults: boolean
+        Whether to drop default values from the widget states.
+
     This uses a simple dependency finder, including:
      - any widget directly referenced in the state of an included widget
      - any widget in a list/tuple attribute in the state of an included widget

--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -59,6 +59,45 @@ widget_view_template = u"""<script type="application/vnd.jupyter.widget-view+jso
 DEFAULT_EMBED_SCRIPT_URL = u'https://unpkg.com/@jupyter-widgets/html-manager@%s/dist/embed.js'%__html_manager_version__
 DEFAULT_EMBED_REQUIREJS_URL = u'https://unpkg.com/@jupyter-widgets/html-manager@%s/dist/embed-amd.js'%__html_manager_version__
 
+_doc_snippets = {}
+_doc_snippets['views_attribute'] = """
+    views: widget or collection of widgets or None
+        The widgets to include views for. If None, all DOMWidgets are
+        included (not just the displayed ones).
+"""
+_doc_snippets['embed_kwargs'] = """
+    drop_defaults: boolean
+        Whether to drop default values from the widget states.
+    state: dict or None (default)
+        The state to include. When set to None, the state of all widgets
+        know to the widget manager is included. Otherwise it uses the
+        passed state directly. This allows for end users to include a
+        smaller state, under the responsibility that this state is
+        sufficient to reconstruct the embedded views.
+    indent: integer, string or None
+        The indent to use for the JSON state dump. See `json.dumps` for
+        full description.
+    embed_url: string or None
+        Allows for overriding the URL used to fetch the widget manager
+        for the embedded code. This defaults (None) to an `unpkg` CDN url.
+    requirejs: boolean (True)
+        Enables the requirejs-based embedding, which allows for custom widgets.
+        If True, the embed_url should point to an AMD module.
+    cors: boolean (True)
+        If True avoids sending user credentials while requesting the scripts.
+        When opening an HTML file from disk, some browsers may refuse to load
+        the scripts.
+"""
+
+def _doc_subst(func):
+    """ Substitute format strings in class docstring """
+    # Strip the snippets to avoid trailing new lines and whitespace
+    stripped_snippets = {
+        key: snippet.strip() for (key, snippet) in _doc_snippets.items()
+    }
+    func.__doc__ = func.__doc__.format(**stripped_snippets)
+    return func
+
 def _find_widget_refs_by_state(widget, state):
     """Find references to other widgets in a widget's state"""
     # Copy keys to allow changes to state during iteration:
@@ -183,6 +222,7 @@ def embed_data(views, drop_defaults=True, state=None):
     return dict(manager_state=json_data, view_specs=view_specs)
 
 
+@_doc_subst
 def embed_snippet(views,
                   drop_defaults=True,
                   state=None,
@@ -195,30 +235,8 @@ def embed_snippet(views,
 
     Parameters
     ----------
-    views: widget or collection of widgets or None
-        The widgets to include views for. If None, all DOMWidgets are
-        included (not just the displayed ones).
-    drop_defaults: boolean
-        Whether to drop default values from the widget states.
-    state: dict or None (default)
-        The state to include. When set to None, the state of all widgets
-        know to the widget manager is included. Otherwise it uses the
-        passed state directly. This allows for end users to include a
-        smaller state, under the responsibility that this state is
-        sufficient to reconstruct the embedded views.
-    indent: integer, string or None
-        The indent to use for the JSON state dump. See `json.dumps` for
-        full description.
-    embed_url: string or None
-        Allows for overriding the URL used to fetch the widget manager
-        for the embedded code. This defaults (None) to an `unpkg` CDN url.
-    requirejs: boolean (True)
-        Enables the requirejs-based embedding, which allows for custom widgets.
-        If True, the embed_url should point to an AMD module.
-    cors: boolean (True)
-        If True avoids sending user credentials while requesting the scripts.
-        When opening an HTML file from disk, some browsers may refuse to load
-        the scripts.
+    {views_attribute}
+    {embed_kwargs}
 
     Returns
     -------
@@ -247,6 +265,7 @@ def embed_snippet(views,
     return snippet_template.format(**values)
 
 
+@_doc_subst
 def embed_minimal_html(fp, views, title=u'IPyWidget export', template=None, **kwargs):
     """Write a minimal HTML file with widget views embedded.
 
@@ -254,13 +273,11 @@ def embed_minimal_html(fp, views, title=u'IPyWidget export', template=None, **kw
     ----------
     fp: filename or file-like object
         The file to write the HTML output to.
-    views: widget or collection of widgets or None
-        The widgets to include views for. If None, all DOMWidgets are
-        included (not just the displayed ones).
+    {views_attribute}
     title: title of the html page.
     template: Template in which to embed the widget state.abs
         This should be a Python string with placeholders
-        `{title}` and `{snippet}`. The `{snippet}` placeholder
+        `{{title}}` and `{{snippet}}`. The `{{snippet}}` placeholder
         will be replaced by all the widgets.
 
     This method also accepts keyword arguments accepted by `embed_snippet`.

--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -144,15 +144,6 @@ def add_resolved_links(store, drop_defaults):
 def dependency_state(widgets, drop_defaults=True):
     """Get the state of all widgets specified, and their dependencies.
 
-    Parameters
-    ----------
-
-    widgets: single widget or list of widgets.
-       This function will return the state of every widget mentioned
-       and of all their dependencies.
-    drop_defaults: boolean
-        Whether to drop default values from the widget states.
-
     This uses a simple dependency finder, including:
      - any widget directly referenced in the state of an included widget
      - any widget in a list/tuple attribute in the state of an included widget
@@ -165,6 +156,19 @@ def dependency_state(widgets, drop_defaults=True):
     Note that this searches the state of the widgets for references, so if
     a widget reference is not included in the serialized state, it won't
     be considered as a dependency.
+
+    Parameters
+    ----------
+    widgets: single widget or list of widgets.
+       This function will return the state of every widget mentioned
+       and of all their dependencies.
+    drop_defaults: boolean
+        Whether to drop default values from the widget states.
+
+    Returns
+    -------
+    A dictionary with the state of the widgets and any widget they
+    depend on.
     """
     # collect the state of all relevant widgets
     if widgets is None:


### PR DESCRIPTION
The Python interface for embedding is great. 

I expect that a common workflow for users who need to embed widgets programatically would be:

 - First export a widget using `embed_minimal_html` to get a single stand-alone file.
 - In some cases, realise that they may want to embed the widgets in a custom HTML template, and so need more granularity on how widgets are embedded. If that's the case, I'm guessing they *probably* want to place widgets individually on the page. They then have to use `embed_data`.

I've tried to re-order the documentation to fit this workflow.

Very happy to change things around if you think that this isn't actually how users use `ipywidgets.embed`, or if I'm missing important aspects.

This PR also tidies up the docstrings in `_embed` a little. I re-use the `_doc_subst` pattern that we stole from ipyvolume to document the selection widget.

This PR addresses #1669 -- showing users how to embed widgets in their own HTML template. 

Still to do:

 - [x] Better commenting around embedding example
 - [x] Clear up confusion around `requireJS` keyword argument.