### PR TITLE
Lock in the typings for jquery to a version that works with the typescript version.

### DIFF
--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@types/expect.js": "^0.3.29",
+    "@types/jquery": "^2.0.40",
     "@types/mathjax": "0.0.31",
     "@types/mocha": "2.2.32",
     "@types/requirejs": "^2.1.28",


### PR DESCRIPTION
Otherwise we have typescript errors, when we pull newer versions of jquery typings with this version of the typescript compiler.