### PR TITLE
Box widget docstrings and unittests

### DIFF
--- a/ipywidgets/widgets/tests/test_widget_box.py
+++ b/ipywidgets/widgets/tests/test_widget_box.py
@@ -1,0 +1,33 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from unittest import TestCase
+
+from traitlets import TraitError
+
+import ipywidgets as widgets
+
+
+class TestBox(TestCase):
+
+    def test_construction(self):
+        box = widgets.Box()
+        assert box.get_state()['children'] == []
+
+    def test_construction_with_children(self):
+        html = widgets.HTML('some html')
+        slider = widgets.IntSlider()
+        box = widgets.Box([html, slider])
+        children_state = box.get_state()['children']
+        assert children_state == [
+            widgets.widget._widget_to_json(html, None),
+            widgets.widget._widget_to_json(slider, None),
+        ]
+
+    def test_construction_style(self):
+        box = widgets.Box(box_style='warning')
+        assert box.get_state()['box_style'] == 'warning'
+
+    def test_construction_invalid_style(self):
+        with self.assertRaises(TraitError):
+            widgets.Box(box_style='invalid')

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -1,9 +1,11 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-"""Box class.
+"""Box widgets.
 
-Represents a container that can be used to group other widgets.
+These widgets are containers that can be used to
+group other widgets together and control their
+relative layouts.
 """
 
 from .widget import register, widget_serialization
@@ -14,7 +16,26 @@ from traitlets import Unicode, Tuple, CaselessStrEnum
 
 @register
 class Box(DOMWidget, CoreWidget):
-    """Displays multiple widgets in a group."""
+    """ Displays multiple widgets in a group.
+
+    Parameters
+    ----------
+    children: iterable of Widget instances
+        list of widgets to display
+
+    box_style: str
+        one of 'success', 'info', 'warning' or 'danger', or ''.
+        Applies a predefined style to the box. Defaults to '',
+        which applies no pre-defined style.
+
+    Examples
+    --------
+
+    >>> import ipywidgets as widgets
+    >>> title_widget = widgets.HTML('<em>Box Example</em>')
+    >>> slider = widgets.IntSlider()
+    >>> widgets.Box([title_widget, slider])
+    """
     _model_name = Unicode('BoxModel').tag(sync=True)
     _view_name = Unicode('BoxView').tag(sync=True)
 

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -9,9 +9,7 @@ Represents a container that can be used to group other widgets.
 from .widget import register, widget_serialization
 from .domwidget import DOMWidget
 from .widget_core import CoreWidget
-from .widget_layout import Layout
-from traitlets import Unicode, Tuple, Int, CaselessStrEnum, Instance, default
-from warnings import warn
+from traitlets import Unicode, Tuple, CaselessStrEnum
 
 
 @register

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -78,14 +78,40 @@ class Box(DOMWidget, CoreWidget):
 
 
 @register
+@_doc_subst
 class VBox(Box):
-    """Displays multiple widgets vertically using the flexible box model."""
+    """ Displays multiple widgets vertically using the flexible box model.
+
+    Parameters
+    ----------
+    {box_params}
+
+    Examples
+    --------
+    >>> import ipywidgets as widgets
+    >>> title_widget = widgets.HTML('<em>Vertical Box Example</em>')
+    >>> slider = widgets.IntSlider()
+    >>> widgets.VBox([title_widget, slider])
+    """
     _model_name = Unicode('VBoxModel').tag(sync=True)
     _view_name = Unicode('VBoxView').tag(sync=True)
 
 
 @register
+@_doc_subst
 class HBox(Box):
-    """Displays multiple widgets horizontally using the flexible box model."""
+    """ Displays multiple widgets horizontally using the flexible box model.
+
+    Parameters
+    ----------
+    {box_params}
+
+    Examples
+    --------
+    >>> import ipywidgets as widgets
+    >>> title_widget = widgets.HTML('<em>Horizontal Box Example</em>')
+    >>> slider = widgets.IntSlider()
+    >>> widgets.HBox([title_widget, slider])
+    """
     _model_name = Unicode('HBoxModel').tag(sync=True)
     _view_name = Unicode('HBoxView').tag(sync=True)

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -59,7 +59,7 @@ class Box(DOMWidget, CoreWidget):
 
     # Child widgets in the container.
     # Using a tuple here to force reassignment to update the list.
-    # When a proper notifying-list trait exists, that is what should be used here.
+    # When a proper notifying-list trait exists, use that instead.
     children = Tuple(help="List of widget children").tag(
         sync=True, **widget_serialization)
 

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -14,14 +14,8 @@ from .widget_core import CoreWidget
 from traitlets import Unicode, Tuple, CaselessStrEnum
 
 
-@register
-class Box(DOMWidget, CoreWidget):
-    """ Displays multiple widgets in a group.
-
-    The widgets are laid out horizontally.
-
-    Parameters
-    ----------
+_doc_snippets = {}
+_doc_snippets['box_params'] = """
     children: iterable of Widget instances
         list of widgets to display
 
@@ -29,6 +23,29 @@ class Box(DOMWidget, CoreWidget):
         one of 'success', 'info', 'warning' or 'danger', or ''.
         Applies a predefined style to the box. Defaults to '',
         which applies no pre-defined style.
+"""
+
+
+def _doc_subst(cls):
+    """ Substitute format strings in class docstring """
+    # Strip the snippets to avoid trailing new lines and whitespace
+    stripped_snippets = {
+        key: snippet.strip() for (key, snippet) in _doc_snippets.items()
+    }
+    cls.__doc__ = cls.__doc__.format(**stripped_snippets)
+    return cls
+
+
+@register
+@_doc_subst
+class Box(DOMWidget, CoreWidget):
+    """ Displays multiple widgets in a group.
+
+    The widgets are laid out horizontally.
+
+    Parameters
+    ----------
+    {box_params}
 
     Examples
     --------

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -23,13 +23,14 @@ class Box(DOMWidget, CoreWidget):
     # Child widgets in the container.
     # Using a tuple here to force reassignment to update the list.
     # When a proper notifying-list trait exists, that is what should be used here.
-    children = Tuple(help="List of widget children").tag(sync=True, **widget_serialization)
+    children = Tuple(help="List of widget children").tag(
+        sync=True, **widget_serialization)
 
     box_style = CaselessStrEnum(
         values=['success', 'info', 'warning', 'danger', ''], default_value='',
         help="""Use a predefined styling for the box.""").tag(sync=True)
 
-    def __init__(self, children = (), **kwargs):
+    def __init__(self, children=(), **kwargs):
         kwargs['children'] = children
         super(Box, self).__init__(**kwargs)
         self.on_displayed(Box._fire_children_displayed)

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -18,6 +18,8 @@ from traitlets import Unicode, Tuple, CaselessStrEnum
 class Box(DOMWidget, CoreWidget):
     """ Displays multiple widgets in a group.
 
+    The widgets are laid out horizontally.
+
     Parameters
     ----------
     children: iterable of Widget instances
@@ -30,7 +32,6 @@ class Box(DOMWidget, CoreWidget):
 
     Examples
     --------
-
     >>> import ipywidgets as widgets
     >>> title_widget = widgets.HTML('<em>Box Example</em>')
     >>> slider = widgets.IntSlider()


### PR DESCRIPTION
This PR adds docstrings and unittests (Python-side) for the box widget.

The docstrings use the decorator pattern copied from ipyvolume. Since we're repeating this in a few places, it may be useful to factor it out into a separate source file (docutils?), but I think that's out of scope of this PR.

This also adds very basic unit tests for the Python side of the box widget. The unittests are constructed such that they verify the state given to the client is what the client expects. 