### PR TITLE
IE 11 doesn’t support the two-argument form of toggle, so use phosphor add/remove class

### DIFF
--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -884,7 +884,11 @@ class DOMWidgetView extends WidgetView {
     }
 
     private _comm_live_update() {
-        this.pWidget.node.classList.toggle('jupyter-widgets-disconnected', !this.model.comm_live);
+        if (this.model.comm_live) {
+            this.pWidget.removeClass('jupyter-widgets-disconnected');
+        } else {
+            this.pWidget.addClass('jupyter-widgets-disconnected');
+        }
     }
 
     '$el': any;


### PR DESCRIPTION
Fixes #1709

See also https://developer.mozilla.org/en-US/docs/Web/API/Element/classList and https://connect.microsoft.com/IE/feedback/details/878564/element-classlist-toggle-does-not-support-second-parameter