### PR TITLE
WIP Make ToggleButtons respect passed `style` kwarg

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -50,6 +50,7 @@ Gabriel Becker <gmbecker@ucdavis.edu> gmbecker <gmbecker@ucdavis.edu>
 Gael Varoquaux <gael.varoquaux@normalesup.org> gael.varoquaux <>
 Gael Varoquaux <gael.varoquaux@normalesup.org> gvaroquaux <gvaroquaux@gvaroquaux-desktop>
 Gael Varoquaux <gael.varoquaux@normalesup.org> Gael Varoquaux <>
+Henry Hinnefeld <henry.hinnefeld@gmail.com> hinnefe2 <hhinnefeld@civisanalytics.com>
 Ingolf Becker <ingolf.becker@googlemail.com> watercrossing <ingolf.becker@googlemail.com>
 Jake Vanderplas <jakevdp@gmail.com> Jake Vanderplas <vanderplas@astro.washington.edu>
 Jakob Gager <jakob.gager@gmail.com> jakobgager <jakob.gager@gmail.com>

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -13,7 +13,7 @@ except ImportError:  #python3.x
     izip = zip
 from itertools import chain
 
-from .widget_description import DescriptionWidget
+from .widget_description import DescriptionWidget, DescriptionStyle
 from .valuewidget import ValueWidget
 from .widget_core import CoreWidget
 from .widget_style import Style
@@ -385,7 +385,7 @@ class _MultipleSelection(DescriptionWidget, ValueWidget, CoreWidget):
             yield key
 
 @register
-class ToggleButtonsStyle(Style, CoreWidget):
+class ToggleButtonsStyle(DescriptionStyle, CoreWidget):
     """Button style widget.
 
     Parameters

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -375,6 +375,7 @@ class ToggleButtonsStyleModel extends DescriptionStyleModel {
     }
 
     public static styleProperties = {
+        ...DescriptionStyleModel.styleProperties,
         button_width: {
             selector: '.widget-toggle-button',
             attribute: 'width',

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -10,7 +10,7 @@ import {
 } from './widget_core';
 
 import {
-    DescriptionView
+    DescriptionView, DescriptionStyleModel
 } from './widget_description';
 
 import {
@@ -367,7 +367,7 @@ class RadioButtonsView extends DescriptionView {
 }
 
 export
-class ToggleButtonsStyleModel extends StyleModel {
+class ToggleButtonsStyleModel extends DescriptionStyleModel {
     defaults() {
         return _.extend(super.defaults(), {
             _model_name: 'ToggleButtonsStyleModel',


### PR DESCRIPTION
This PR is a (work in progress) attempt to solve #1691.

Things that ~~I've tried so far (which haven't worked)~~ this includes:

- [x] make `ToggleButtonStyle` inherit from `DescriptionStyle` in both the `.py` and `.ts` definitions.
- [x] modify the `styleProperties` in the `.ts` definition.