### PR TITLE
Factor out `doc_subst` decorator

### DIFF
--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -13,6 +13,7 @@ Functions for generating embeddable HTML/javascript of a widget.
 import json
 from .widgets import Widget, DOMWidget
 from .widgets.widget_link import Link
+from .widgets.docutils import doc_subst
 from ._version import __html_manager_version__
 
 snippet_template = u"""
@@ -89,14 +90,6 @@ _doc_snippets['embed_kwargs'] = """
         the scripts.
 """
 
-def _doc_subst(func):
-    """ Substitute format strings in class docstring """
-    # Strip the snippets to avoid trailing new lines and whitespace
-    stripped_snippets = {
-        key: snippet.strip() for (key, snippet) in _doc_snippets.items()
-    }
-    func.__doc__ = func.__doc__.format(**stripped_snippets)
-    return func
 
 def _find_widget_refs_by_state(widget, state):
     """Find references to other widgets in a widget's state"""
@@ -187,7 +180,7 @@ def dependency_state(widgets, drop_defaults=True):
     return state
 
 
-@_doc_subst
+@doc_subst(_doc_snippets)
 def embed_data(views, drop_defaults=True, state=None):
     """Gets data for embedding.
 
@@ -234,7 +227,7 @@ def embed_data(views, drop_defaults=True, state=None):
     return dict(manager_state=json_data, view_specs=view_specs)
 
 
-@_doc_subst
+@doc_subst(_doc_snippets)
 def embed_snippet(views,
                   drop_defaults=True,
                   state=None,
@@ -277,7 +270,7 @@ def embed_snippet(views,
     return snippet_template.format(**values)
 
 
-@_doc_subst
+@doc_subst(_doc_snippets)
 def embed_minimal_html(fp, views, title=u'IPyWidget export', template=None, **kwargs):
     """Write a minimal HTML file with widget views embedded.
 

--- a/ipywidgets/widgets/docutils.py
+++ b/ipywidgets/widgets/docutils.py
@@ -1,3 +1,5 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 def doc_subst(snippets):
     """ Substitute format strings in class or function docstring """

--- a/ipywidgets/widgets/docutils.py
+++ b/ipywidgets/widgets/docutils.py
@@ -1,0 +1,11 @@
+
+def doc_subst(snippets):
+    """ Substitute format strings in class or function docstring """
+    def decorator(cls):
+        # Strip the snippets to avoid trailing new lines and whitespace
+        stripped_snippets = {
+            key: snippet.strip() for (key, snippet) in snippets.items()
+        }
+        cls.__doc__ = cls.__doc__.format(**stripped_snippets)
+        return cls
+    return decorator

--- a/ipywidgets/widgets/tests/test_docutils.py
+++ b/ipywidgets/widgets/tests/test_docutils.py
@@ -1,3 +1,5 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from unittest import TestCase
 

--- a/ipywidgets/widgets/tests/test_docutils.py
+++ b/ipywidgets/widgets/tests/test_docutils.py
@@ -1,0 +1,25 @@
+
+from unittest import TestCase
+
+from ipywidgets.widgets.docutils import doc_subst
+
+
+class TestDocSubst(TestCase):
+
+    def test_substitution(self):
+        snippets = {'key': '62'}
+
+        @doc_subst(snippets)
+        def f():
+            """ Docstring with value {key} """
+
+        assert f.__doc__ == " Docstring with value 62 "
+
+    def test_unused_keys(self):
+        snippets = {'key': '62', 'other-key': 'unused'}
+
+        @doc_subst(snippets)
+        def f():
+            """ Docstring with value {key} """
+
+        assert f.__doc__ == " Docstring with value 62 "

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -11,6 +11,7 @@ relative layouts.
 from .widget import register, widget_serialization
 from .domwidget import DOMWidget
 from .widget_core import CoreWidget
+from .docutils import doc_subst
 from traitlets import Unicode, Tuple, CaselessStrEnum
 
 
@@ -26,18 +27,8 @@ _doc_snippets['box_params'] = """
 """
 
 
-def _doc_subst(cls):
-    """ Substitute format strings in class docstring """
-    # Strip the snippets to avoid trailing new lines and whitespace
-    stripped_snippets = {
-        key: snippet.strip() for (key, snippet) in _doc_snippets.items()
-    }
-    cls.__doc__ = cls.__doc__.format(**stripped_snippets)
-    return cls
-
-
 @register
-@_doc_subst
+@doc_subst(_doc_snippets)
 class Box(DOMWidget, CoreWidget):
     """ Displays multiple widgets in a group.
 
@@ -78,7 +69,7 @@ class Box(DOMWidget, CoreWidget):
 
 
 @register
-@_doc_subst
+@doc_subst(_doc_snippets)
 class VBox(Box):
     """ Displays multiple widgets vertically using the flexible box model.
 
@@ -98,7 +89,7 @@ class VBox(Box):
 
 
 @register
-@_doc_subst
+@doc_subst(_doc_snippets)
 class HBox(Box):
     """ Displays multiple widgets horizontally using the flexible box model.
 

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -19,6 +19,7 @@ from .widget_core import CoreWidget
 from .widget_style import Style
 from .trait_types import InstanceDict
 from .widget import register, widget_serialization
+from .docutils import doc_subst
 from traitlets import (Unicode, Bool, Int, Any, Dict, TraitError, CaselessStrEnum,
                        Tuple, List, Union, observe, validate)
 from ipython_genutils.py3compat import unicode_type
@@ -104,16 +105,6 @@ _doc_snippets['slider_params'] = """
         holds the slider. Otherwise, the model is only updated after the
         user has released the slider. Defaults to ``True``.
 """
-
-
-def _doc_subst(cls):
-    """ Substitute format strings in class docstring """
-    # Strip the snippets to avoid trailing new lines and whitespace
-    stripped_snippets = {
-        key: snippet.strip() for (key, snippet) in _doc_snippets.items()
-    }
-    cls.__doc__ = cls.__doc__.format(**stripped_snippets)
-    return cls
 
 
 def _make_options(x):
@@ -398,7 +389,7 @@ class ToggleButtonsStyle(DescriptionStyle, CoreWidget):
     button_width = Unicode(help="The width of each button.").tag(sync=True)
 
 @register
-@_doc_subst
+@doc_subst(_doc_snippets)
 class ToggleButtons(_Selection):
     """Group of toggle buttons that represent an enumeration.
 
@@ -437,7 +428,7 @@ class ToggleButtons(_Selection):
 
 
 @register
-@_doc_subst
+@doc_subst(_doc_snippets)
 class Dropdown(_Selection):
     """Allows you to select a single item from a dropdown.
 
@@ -450,7 +441,7 @@ class Dropdown(_Selection):
 
 
 @register
-@_doc_subst
+@doc_subst(_doc_snippets)
 class RadioButtons(_Selection):
     """Group of radio buttons that represent an enumeration.
 
@@ -465,7 +456,7 @@ class RadioButtons(_Selection):
 
 
 @register
-@_doc_subst
+@doc_subst(_doc_snippets)
 class Select(_Selection):
     """
     Listbox that only allows one item to be selected at any given time.
@@ -482,7 +473,7 @@ class Select(_Selection):
     rows = Int(5, help="The number of rows to display.").tag(sync=True)
 
 @register
-@_doc_subst
+@doc_subst(_doc_snippets)
 class SelectMultiple(_MultipleSelection):
     """
     Listbox that allows many items to be selected at any given time.
@@ -541,7 +532,7 @@ class _MultipleSelectionNonempty(_MultipleSelection):
         return proposal.value
 
 @register
-@_doc_subst
+@doc_subst(_doc_snippets)
 class SelectionSlider(_SelectionNonempty):
     """
     Slider to select a single item from a list or dictionary.
@@ -564,7 +555,7 @@ class SelectionSlider(_SelectionNonempty):
         help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
 
 @register
-@_doc_subst
+@doc_subst(_doc_snippets)
 class SelectionRangeSlider(_MultipleSelectionNonempty):
     """
     Slider to select multiple contiguous items from a list.


### PR DESCRIPTION
We use the `doc_subst` pattern in several source files. Each time, the decorator was re-implemented as a private function. This PR factors out the decorator into a new source file, `docutils`. This seems like a useful refactoring before adding many new docstrings.

I'm not wedded to the name `docutils`, if anyone has a better suggestion.