### PR TITLE
IE 11 croaks on `string`. Use '' instead.

### DIFF
--- a/widgetsnbextension/src/extension.js
+++ b/widgetsnbextension/src/extension.js
@@ -120,7 +120,7 @@ function register_events(Jupyter, events, outputarea) {
                 PhosphorWidget.Widget.attach(view.pWidget, node);
             });
         } else {
-            node.textContent = `A Jupyter widget could not be displayed because the widget state could not be found. This could happen if the kernel storing the widget is no longer available, or if the widget state was not saved in the notebook. You may be able to create the widget by running the appropriate cells.`;
+            node.textContent = 'A Jupyter widget could not be displayed because the widget state could not be found. This could happen if the kernel storing the widget is no longer available, or if the widget state was not saved in the notebook. You may be able to create the widget by running the appropriate cells.';
         }
     }
 


### PR DESCRIPTION
The change in 7062add7 introduced `` which IE doesn't like, causing the extensions to not load properly.