### PR TITLE
Fix versions of the typings packages.

### DIFF
--- a/jupyter-js-widgets/examples/web3/package.json
+++ b/jupyter-js-widgets/examples/web3/package.json
@@ -22,6 +22,7 @@
     "jupyter-js-widgets": "file:../.."
   },
   "devDependencies": {
+    "@types/jquery": "2.0.48",
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.5",
     "fs-extra": "^0.30.0",

--- a/jupyter-js-widgets/package.json
+++ b/jupyter-js-widgets/package.json
@@ -84,8 +84,8 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^0.35.0",
-    "@types/backbone": "^1.3.33",
-    "@types/semver": "^5.3.30",
+    "@types/backbone": "1.3.36",
+    "@types/semver": "5.3.34",
     "ajv": "^4.9.0",
     "backbone": "1.2.0",
     "d3-format": "^0.5.1",


### PR DESCRIPTION
Newer versions of the typings files don’t compile in this older version of Typescript.