### PR TITLE
added convenience methods on output widget

### DIFF
--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -1,0 +1,80 @@
+import sys
+
+from IPython.display import Markdown, Image
+from ipywidgets import Output
+
+
+def _make_stream_output(text, name):
+        return {
+            'output_type': 'stream',
+            'name': name,
+            'text': text
+        }
+
+
+def test_append_stdout():
+    output = Output()
+
+    # Try appending a message to stdout.
+    output.append_stdout("snakes!")
+    expected = (_make_stream_output("snakes!", "stdout"),)
+    assert output.outputs == expected, repr(output.outputs)
+
+    # Try appending a second message.
+    output.append_stdout("more snakes!")
+    expected += (_make_stream_output("more snakes!", "stdout"),)
+    assert output.outputs == expected, repr(output.outputs)
+
+
+def test_append_stderr():
+    output = Output()
+
+    # Try appending a message to stderr.
+    output.append_stderr("snakes!")
+    expected = (_make_stream_output("snakes!", "stderr"),)
+    assert output.outputs == expected, repr(output.outputs)
+
+    # Try appending a second message.
+    output.append_stderr("more snakes!")
+    expected += (_make_stream_output("more snakes!", "stderr"),)
+    assert output.outputs == expected, repr(output.outputs)
+
+
+def test_append_display_data():
+    output = Output()
+
+    # Try appending a Markdown object.
+    output.append_display_data(Markdown("# snakes!"))
+    expected = (
+        {
+            'output_type': 'display_data',
+            'data': {
+                'text/plain': '<IPython.core.display.Markdown object>',
+                'text/markdown': '# snakes!'
+            },
+            'metadata': {}
+        },
+    )
+    assert output.outputs == expected, repr(output.outputs)
+
+    # Now try appending an Image.
+    image_data = b"foobar"
+    image_data_b64 = image_data if sys.version_info[0] < 3 else 'Zm9vYmFy\n'
+
+    output.append_display_data(Image(image_data, width=123, height=456))
+    expected += (
+        {
+            'output_type': 'display_data',
+            'data': {
+                'image/png': image_data_b64,
+                'text/plain': '<IPython.core.display.Image object>'
+            },
+            'metadata': {
+                'image/png': {
+                    'width': 123,
+                    'height': 456
+                }
+            }
+        },
+    )
+    assert output.outputs == expected, repr(output.outputs)

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -12,6 +12,7 @@ from .widget_core import CoreWidget
 
 import sys
 from traitlets import Unicode, Tuple
+from IPython.core.interactiveshell import InteractiveShell
 from IPython.display import clear_output
 from IPython import get_ipython
 
@@ -68,3 +69,36 @@ class Output(DOMWidget, CoreWidget):
         """Flush stdout and stderr buffers."""
         sys.stdout.flush()
         sys.stderr.flush()
+
+    def _append_stream_output(self, text, stream_name):
+        """Append a stream output."""
+        self.outputs += (
+            {'output_type': 'stream', 'name': stream_name, 'text': text},
+        )
+
+    def append_stdout(self, text):
+        """Append text to the stdout stream."""
+        self._append_stream_output(text, stream_name='stdout')
+
+    def append_stderr(self, text):
+        """Append text to the stderr stream."""
+        self._append_stream_output(text, stream_name='stderr')
+
+    def append_display_data(self, display_object):
+        """Append a display object as an output.
+
+        Parameters
+        ----------
+        display_object : IPython.core.display.DisplayObject
+            The object to display (e.g., an instance of
+            `IPython.display.Markdown` or `IPython.display.Image`).
+        """
+        fmt = InteractiveShell.instance().display_formatter.format
+        data, metadata = fmt(display_object)
+        self.outputs += (
+            {
+                'output_type': 'display_data',
+                'data': data,
+                'metadata': metadata
+            },
+        )


### PR DESCRIPTION
This adds some convenience methods for adding output items to the Output widget in order to address #1724.

It also should make it easier to work around the apparent race condition discussed in #1722.