### PR TITLE
set display to block for Tab widget tab bar

### DIFF
--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -931,6 +931,7 @@
 
 .jupyter-widgets.widget-tab .widget-tab-bar.p-TabBar {
     font: var(--jp-widgets-font-size) Helvetica, Arial, sans-serif;
+    display: block;
 }
 
 .jupyter-widgets.widget-tab .p-TabBar-tab {


### PR DESCRIPTION
I think this fixes #1754. Here's a screenshot related to the ones in #1754, but with the change proposed here:

![screen shot 2017-10-12 at 5 03 49 pm](https://user-images.githubusercontent.com/181744/31521506-5b735092-af6f-11e7-8c9a-4b2343f25798.png)

Perhaps there's a better way, but I figured I'd suggest this before going too far down the CSS rabbit hole.