### PR TITLE
Hide prompt area in classic notebook output widget.

### DIFF
--- a/widgetsnbextension/src/widget_output.css
+++ b/widgetsnbextension/src/widget_output.css
@@ -7,3 +7,8 @@
 .jupyter-widgets-output-area div.output_subarea {
     max-width: 100%;
 }
+
+/* Work-around for the bug fixed in https://github.com/jupyter/notebook/pull/2961 */
+.jupyter-widgets-output-area > .out_prompt_overlay {
+    display: none;
+}


### PR DESCRIPTION
This works around for the bug fixed in https://github.com/jupyter/notebook/pull/2961

Thanks to @mheilman for noting the problem and suggesting a fix.

Fixes #1765