### PR TITLE
Move the JupyterLab registry token to the base package.

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^0.50.2",
+    "@phosphor/coreutils": "^1.2.0",
     "@phosphor/messaging": "^1.2.1",
     "@phosphor/widgets": "^1.3.0",
     "@types/backbone": "^1.3.33",

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -8,3 +8,4 @@ export * from './widget_style';
 export * from './services-shim';
 export * from './viewlist';
 export * from './utils';
+export * from './registry';

--- a/packages/base/src/registry.ts
+++ b/packages/base/src/registry.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  Token
+} from '@phosphor/coreutils';
+
+/**
+ * A runtime interface token for a widget registry.
+ */
+export
+const IJupyterWidgetRegistry = new Token<IJupyterWidgetRegistry>('jupyter.extensions.jupyterWidgetRegistry');
+
+/**
+ * A registry of Jupyter Widgets.
+ *
+ * This is used by widget managers that support an external registry.
+ */
+export
+interface IJupyterWidgetRegistry {
+  /**
+   * Register a widget module.
+   */
+  registerWidget(data: IWidgetRegistryData): void;
+}
+
+export
+interface IWidgetRegistryData {
+  /**
+   * The widget module name.
+   */
+  name: string;
+
+  /**
+   * The widget module version.
+   */
+  version: string;
+
+  /**
+   * A map of object names to widget classes provided by the module.
+   */
+  exports: any;
+}

--- a/packages/jupyterlab-manager/package.json
+++ b/packages/jupyterlab-manager/package.json
@@ -16,7 +16,6 @@
     "@jupyterlab/rendermime": "^0.11.1",
     "@jupyterlab/rendermime-interfaces": "^0.4.1",
     "@jupyterlab/services": "^0.50.2",
-    "@phosphor/coreutils": "^1.2.0",
     "@phosphor/disposable": "^1.1.1",
     "@phosphor/messaging": "^1.2.1",
     "@phosphor/widgets": "^1.3.0",

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -5,7 +5,7 @@
 import * as Backbone from 'backbone';
 
 import {
-    ManagerBase, shims
+    ManagerBase, shims, IWidgetRegistryData
 } from '@jupyter-widgets/base';
 
 import {
@@ -177,7 +177,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
     return this._rendermime;
   }
 
-  register(data: WidgetManager.IWidgetData) {
+  register(data: IWidgetRegistryData) {
     this._registry.set(data.name, data.version, data.exports);
   }
 
@@ -188,13 +188,4 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
   _commRegistration: IDisposable;
 }
 
-export
-namespace WidgetManager {
-  export
-  interface IWidgetData {
-    name: string,
-    version: string,
-    exports: any
-  }
-}
 

--- a/packages/jupyterlab-manager/src/plugin.ts
+++ b/packages/jupyterlab-manager/src/plugin.ts
@@ -18,10 +18,6 @@ import {
 } from '@jupyterlab/application';
 
 import {
-  Token
-} from '@phosphor/coreutils';
-
-import {
   IDisposable, DisposableDelegate
 } from '@phosphor/disposable';
 
@@ -46,22 +42,8 @@ import '@jupyter-widgets/controls/css/widgets-base.css';
 
 const WIDGET_MIMETYPE = 'application/vnd.jupyter.widget-view+json';
 
-/**
- * The token identifying the JupyterLab plugin.
- */
 export
-const INBWidgetExtension = new Token<INBWidgetExtension>('jupyter.extensions.nbWidgetManager');
-
-/**
- * The type of the provided value of the plugin in JupyterLab.
- */
-export
-interface INBWidgetExtension extends DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
-  /**
-   * Register a widget module.
-   */
-  registerWidget(data: WidgetManager.IWidgetData): void;
-}
+type INBWidgetExtension = DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel>
 
 
 export
@@ -112,10 +94,10 @@ class NBWidgetExtension implements INBWidgetExtension {
   /**
    * Register a widget module.
    */
-  registerWidget(data: WidgetManager.IWidgetData) {
+  registerWidget(data: base.IWidgetRegistryData) {
     this._registry.push(data);
   }
-  private _registry: WidgetManager.IWidgetData[] = [];
+  private _registry: base.IWidgetRegistryData[] = [];
 }
 
 
@@ -123,9 +105,9 @@ class NBWidgetExtension implements INBWidgetExtension {
 /**
  * The widget manager provider.
  */
-const widgetManagerProvider: JupyterLabPlugin<INBWidgetExtension> = {
+const widgetManagerProvider: JupyterLabPlugin<base.IJupyterWidgetRegistry> = {
   id: 'jupyter.extensions.nbWidgetManager',
-  provides: INBWidgetExtension,
+  provides: base.IJupyterWidgetRegistry,
   activate: activateWidgetExtension,
   autoStart: true
 };
@@ -136,8 +118,12 @@ export default widgetManagerProvider;
 /**
  * Activate the widget extension.
  */
-function activateWidgetExtension(app: JupyterLab): INBWidgetExtension {
+function activateWidgetExtension(app: JupyterLab): base.IJupyterWidgetRegistry {
   let extension = new NBWidgetExtension();
   app.docRegistry.addWidgetExtension('Notebook', extension);
-  return extension;
+  return {
+    registerWidget(data: base.IWidgetRegistryData): void {
+      extension.registerWidget(data);
+    }
+  }
 }


### PR DESCRIPTION
Addresses #1781 

I looked into moving the token to the base package. I realized a few things:

1. There is a lot of confusion right now in what the jlab plugin exports. It exports the actual jlab document widget, but it shouldn't - it should just export the registration function. This should definitely be untangled.
2. The registry is specific to the jlab widget manager - the classic notebook widget manager does not have the concept of a registry (it uses require as a default registry). So it's a little weird to have the concept of a registry in the base package and/or the base widget manager.

This is definitely still a work in progress.