### PR TITLE
Add examples for asynchronous display and interactive_output

### DIFF
--- a/docs/source/examples/Using Interact.ipynb
+++ b/docs/source/examples/Using Interact.ipynb
@@ -898,6 +898,94 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### `interactive_output`\n",
+    "\n",
+    "`interactive_output` provides additional flexibility: you can control how the UI elements are laid out.\n",
+    "\n",
+    "Unlike `interact`, `interactive`, and `interact_manual`, `interactive_output` does not generate a user interface for the widgets. This is powerful, because it means you can create a widget, put it in a box, and then pass the widget to `interactive_output`, and have control over the widget and its layout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e6e8696551f64c45a73ef7cb61af3c08",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>VBox</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in Jupyter Notebook or JupyterLab, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another notebook frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "VBox(children=(HBox(children=(IntSlider(value=0), IntSlider(value=0), IntSlider(value=0))),))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "597c952b0a5b43248e25011e2d6bbfed",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/html": [
+       "<p>Failed to display Jupyter Widget of type <code>Output</code>.</p>\n",
+       "<p>\n",
+       "  If you're reading this message in Jupyter Notebook or JupyterLab, it may mean\n",
+       "  that the widgets JavaScript is still loading. If this message persists, it\n",
+       "  likely means that the widgets JavaScript library is either not installed or\n",
+       "  not enabled. See the <a href=\"https://ipywidgets.readthedocs.io/en/stable/user_install.html\">Jupyter\n",
+       "  Widgets Documentation</a> for setup instructions.\n",
+       "</p>\n",
+       "<p>\n",
+       "  If you're reading this message in another notebook frontend (for example, a static\n",
+       "  rendering on GitHub or <a href=\"https://nbviewer.jupyter.org/\">NBViewer</a>),\n",
+       "  it may mean that your frontend doesn't currently support widgets.\n",
+       "</p>\n"
+      ],
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "a = widgets.IntSlider()\n",
+    "b = widgets.IntSlider()\n",
+    "c = widgets.IntSlider()\n",
+    "ui = widgets.HBox([a, b, c])\n",
+    "def f(a, b, c):\n",
+    "    print((a, b, c))\n",
+    "\n",
+    "out = widgets.interactive_output(f, {'a': a, 'b': b, 'c': c})\n",
+    "\n",
+    "display(ui, out)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Arguments that are dependent on each other"
    ]
   },

--- a/docs/source/examples/Widget Asynchronous.ipynb
+++ b/docs/source/examples/Widget Asynchronous.ipynb
@@ -282,6 +282,75 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interacting with output widgets from background threads\n",
+    "\n",
+    "Output widgets capture output based on the thread in which they were invoked.\n",
+    "In other words, in the thread where the output is invoked, there is a context\n",
+    "manager which starts and then stops the output capturing. If you call `display`\n",
+    "in a thread other than the thread containing the context manager, you cannot\n",
+    "rely on those `display` calls being captured by the context manager.\n",
+    "\n",
+    "Instead, we can pass an `Output` widget to the function executing in a thread,\n",
+    "and use the `Output`'s `append_display_data()`, `append_stdout()`, or\n",
+    "`append_stderr()` methods to append displayable output (such as from `HTML()`),\n",
+    "standard output (such as from `print()`), or standard error to the `Output`\n",
+    "widget."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Display in main thread'"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "32e8e3b06ec44fabb832283d779fda97",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "A Jupyter Widget"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import threading\n",
+    "from IPython.display import display, HTML\n",
+    "import ipywidgets as widgets\n",
+    "\n",
+    "def thread_func(something, out):\n",
+    "    for i in range(1, 10):\n",
+    "        out.append_stdout('{} {} {}'.format(i, '**'*i, something))\n",
+    "    out.append_display_data(HTML(\"<h3>All done!</h3>\"))\n",
+    "\n",
+    "display('Display in main thread')\n",
+    "out = widgets.Output()\n",
+    "# Now the key: the container is displayed (while empty) in the main thread\n",
+    "display(out)\n",
+    "\n",
+    "thread = threading.Thread(\n",
+    "    target=thread_func,\n",
+    "    args=(\"whatever\", out))\n",
+    "thread.start()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "nbsphinx": "hidden"
    },


### PR DESCRIPTION
As discussed in https://github.com/jupyter-widgets/ipywidgets/issues/1790

@jasongrout I stole some of your prose and code from comments in that issue. I hope that's ok - if not I can rewrite it.

I'm also not sure how to save the outputs so that they'll render properly on the documentation site. I tried to do the cleanest commit I could, so I just copied the JSON from my running copy of the notebooks into a clean copy from git. Is that OK, or do I need to do something else to make sure that the widgets are displayable on the documentation site?