### PR TITLE
Avoid Python 2 integer division error in examples.

### DIFF
--- a/docs/source/examples/Widget Asynchronous.ipynb
+++ b/docs/source/examples/Widget Asynchronous.ipynb
@@ -273,7 +273,7 @@
     "    total = 100\n",
     "    for i in range(total):\n",
     "        time.sleep(0.2)\n",
-    "        progress.value = (i+1)/total\n",
+    "        progress.value = float(i+1)/total\n",
     "\n",
     "thread = threading.Thread(target=work, args=(progress,))\n",
     "display(progress)\n",


### PR DESCRIPTION
The [async progressbar example](https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20Asynchronous.html#Updating-a-widget-in-the-background) behaved differently in Python2 and Python3. Because `/` on integers is integer division in Python2, `progress.value` was always set to `0`. 