### PR TITLE
update widgets fallback message

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -757,14 +757,14 @@ class Widget(LoggingHasTraits):
 _FALLBACK_HTML_TEMPLATE = """\
 <p>Failed to display Jupyter Widget of type <code>{widget_type}</code>.</p>
 <p>
-  If you're reading this message in Jupyter Notebook or JupyterLab, it may mean
+  If you're reading this message in Jupyter or JupyterLab Notebook, it may mean
   that the widgets JavaScript is still loading. If this message persists, it
   likely means that the widgets JavaScript library is either not installed or
   not enabled. See the <a href="https://ipywidgets.readthedocs.io/en/stable/user_install.html">Jupyter
   Widgets Documentation</a> for setup instructions.
 </p>
 <p>
-  If you're reading this message in another notebook frontend (for example, a static
+  If you're reading this message in another frontend (for example, a static
   rendering on GitHub or <a href="https://nbviewer.jupyter.org/">NBViewer</a>),
   it may mean that your frontend doesn't currently support widgets.
 </p>

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -757,7 +757,7 @@ class Widget(LoggingHasTraits):
 _FALLBACK_HTML_TEMPLATE = """\
 <p>Failed to display Jupyter Widget of type <code>{widget_type}</code>.</p>
 <p>
-  If you're reading this message in Jupyter or JupyterLab Notebook, it may mean
+  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean
   that the widgets JavaScript is still loading. If this message persists, it
   likely means that the widgets JavaScript library is either not installed or
   not enabled. See the <a href="https://ipywidgets.readthedocs.io/en/stable/user_install.html">Jupyter


### PR DESCRIPTION
the fallback message also shows up in a jupyterlab console, where it is currently confusing to the user because it suggests that the widgets are incorrectly installed

![image](https://user-images.githubusercontent.com/2069677/32701167-f5153d18-c7d0-11e7-80db-ae7d32bdbbac.png)

I suggest reformulating the image being specific that it is only supposed to work in the jupyterlab notebooks.