### PR TITLE
Add buffers argument to comm open

### DIFF
--- a/packages/base/src/manager-base.ts
+++ b/packages/base/src/manager-base.ts
@@ -292,6 +292,15 @@ abstract class ManagerBase<T> {
         });
     }
 
+    register_model(model_id: string, modelPromise: Promise<WidgetModel>): void {
+        this._models[model_id] = modelPromise;
+        modelPromise.then(model => {
+            model.once('comm:close', () => {
+                delete this._models[model_id];
+            });
+        });
+    }
+
     /**
      * Create and return a promise for a new widget model
      *
@@ -319,7 +328,7 @@ abstract class ManagerBase<T> {
         }
 
         let modelPromise = this._make_model(options, serialized_state);
-        this._models[model_id] = modelPromise;
+        this.register_model(model_id, modelPromise);
         return await modelPromise;
     }
 
@@ -349,9 +358,6 @@ abstract class ManagerBase<T> {
             comm: options.comm,
         };
         let widget_model = new ModelType(attributes, modelOptions);
-        widget_model.once('comm:close', () => {
-            delete this._models[model_id];
-        });
         widget_model.name = options.model_name;
         widget_model.module = options.model_module;
         return widget_model;

--- a/packages/base/src/manager-base.ts
+++ b/packages/base/src/manager-base.ts
@@ -9,7 +9,7 @@ import {
 } from './widget';
 
 import {
-    shims
+    IComm
 } from './services-shim';
 
 import {
@@ -111,7 +111,7 @@ interface WidgetOptions {
     /**
      * Comm object associated with the widget.
      */
-    comm?: any;
+    comm?: IComm;
 
     /**
      * The model id to use. If not provided, the comm id of the comm is used.
@@ -209,7 +209,7 @@ abstract class ManagerBase<T> {
     /**
      * Handle when a comm is opened.
      */
-    handle_comm_open(comm: shims.services.Comm, msg: services.KernelMessage.ICommOpenMsg): Promise<WidgetModel> {
+    handle_comm_open(comm: IComm, msg: services.KernelMessage.ICommOpenMsg): Promise<WidgetModel> {
         let protocolVersion = ((msg.metadata || {}).version as string) || '';
         if (protocolVersion.split('.', 1)[0] !== PROTOCOL_MAJOR_VERSION) {
             let error = `Wrong widget protocol version: received protocol version '${protocolVersion}', but was expecting major version '${PROTOCOL_MAJOR_VERSION}'`;
@@ -504,7 +504,13 @@ abstract class ManagerBase<T> {
      * @param data The initial data for the comm
      * @param metadata The metadata in the open message
      */
-    protected abstract _create_comm(comm_target_name: string, model_id: string, data?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): Promise<any>;
+    protected abstract _create_comm(
+        comm_target_name: string,
+        model_id: string,
+        data?: any,
+        metadata?: any,
+        buffers?: ArrayBuffer[] | ArrayBufferView[]):
+        Promise<IComm>;
     protected abstract _get_comm_info();
 
     /**

--- a/packages/base/src/manager-base.ts
+++ b/packages/base/src/manager-base.ts
@@ -9,7 +9,7 @@ import {
 } from './widget';
 
 import {
-    IComm
+    IClassicComm
 } from './services-shim';
 
 import {
@@ -111,7 +111,7 @@ interface WidgetOptions {
     /**
      * Comm object associated with the widget.
      */
-    comm?: IComm;
+    comm?: IClassicComm;
 
     /**
      * The model id to use. If not provided, the comm id of the comm is used.
@@ -209,7 +209,7 @@ abstract class ManagerBase<T> {
     /**
      * Handle when a comm is opened.
      */
-    handle_comm_open(comm: IComm, msg: services.KernelMessage.ICommOpenMsg): Promise<WidgetModel> {
+    handle_comm_open(comm: IClassicComm, msg: services.KernelMessage.ICommOpenMsg): Promise<WidgetModel> {
         let protocolVersion = ((msg.metadata || {}).version as string) || '';
         if (protocolVersion.split('.', 1)[0] !== PROTOCOL_MAJOR_VERSION) {
             let error = `Wrong widget protocol version: received protocol version '${protocolVersion}', but was expecting major version '${PROTOCOL_MAJOR_VERSION}'`;
@@ -510,7 +510,7 @@ abstract class ManagerBase<T> {
         data?: any,
         metadata?: any,
         buffers?: ArrayBuffer[] | ArrayBufferView[]):
-        Promise<IComm>;
+        Promise<IClassicComm>;
     protected abstract _get_comm_info();
 
     /**

--- a/packages/base/src/manager-base.ts
+++ b/packages/base/src/manager-base.ts
@@ -498,7 +498,7 @@ abstract class ManagerBase<T> {
      * @param data The initial data for the comm
      * @param metadata The metadata in the open message
      */
-    protected abstract _create_comm(comm_target_name: string, model_id: string, data?: any, metadata?: any): Promise<any>;
+    protected abstract _create_comm(comm_target_name: string, model_id: string, data?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): Promise<any>;
     protected abstract _get_comm_info();
 
     /**

--- a/packages/base/src/services-shim.ts
+++ b/packages/base/src/services-shim.ts
@@ -12,6 +12,64 @@ import {
     Kernel
 } from '@jupyterlab/services';
 
+
+export
+interface IComm {
+    /**
+     * Comm id
+     * @return {string}
+     */
+    comm_id: string;
+
+    /**
+     * Target name
+     * @return {string}
+     */
+    target_name: string;
+
+    /**
+     * Opens a sibling comm in the backend
+     * @param  data
+     * @param  callbacks
+     * @param  metadata
+     * @param  buffers
+     * @return msg id
+     */
+    open(data: any, callbacks: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): string;
+
+    /**
+     * Sends a message to the sibling comm in the backend
+     * @param  data
+     * @param  callbacks
+     * @param  metadata
+     * @param  buffers
+     * @return message id
+     */
+    send(data: any, callbacks: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): string;
+
+    /**
+     * Closes the sibling comm in the backend
+     * @param  data
+     * @param  callbacks
+     * @param  metadata
+     * @param  buffers
+     * @return msg id
+     */
+    close(data?: any, callbacks?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): string;
+
+    /**
+     * Register a message handler
+     * @param  callback, which is given a message
+     */
+    on_msg(callback: (x: any) => void): void;
+
+    /**
+     * Register a handler for when the comm is closed by the backend
+     * @param  callback, which is given a message
+     */
+    on_close(callback: (x: any) => void): void;
+}
+
 export
 namespace shims {
     export
@@ -106,7 +164,7 @@ namespace shims {
          * @param  {IComm} jsServicesComm - @jupyterlab/services IComm instance
          */
         export
-        class Comm {
+        class Comm implements IComm {
             constructor(jsServicesComm: Kernel.IComm) {
                 this.jsServicesComm = jsServicesComm;
             }

--- a/packages/base/src/services-shim.ts
+++ b/packages/base/src/services-shim.ts
@@ -14,7 +14,7 @@ import {
 
 
 export
-interface IComm {
+interface IClassicComm {
     /**
      * Comm id
      * @return {string}
@@ -164,7 +164,7 @@ namespace shims {
          * @param  {IComm} jsServicesComm - @jupyterlab/services IComm instance
          */
         export
-        class Comm implements IComm {
+        class Comm implements IClassicComm {
             constructor(jsServicesComm: Kernel.IComm) {
                 this.jsServicesComm = jsServicesComm;
             }

--- a/packages/base/src/services-shim.ts
+++ b/packages/base/src/services-shim.ts
@@ -44,10 +44,10 @@ namespace shims {
              * @param  {string} comm_id
              * @return {Comm}
              */
-            new_comm(target_name: string, data: any, callbacks: any, metadata: any, comm_id: string): Comm {
+            new_comm(target_name: string, data: any, callbacks: any, metadata: any, comm_id: string, buffers?: ArrayBuffer[] | ArrayBufferView[]): Comm {
                 let comm = new Comm(this.jsServicesKernel.connectToComm(target_name, comm_id));
                 this.register_comm(comm);
-                comm.open(data, callbacks, metadata);
+                comm.open(data, callbacks, metadata, buffers);
                 return comm;
             }
 
@@ -57,7 +57,7 @@ namespace shims {
              * @param  {(Comm, object) => void} f - callback that is called when the
              *                         comm is made.  Signature of f(comm, msg).
              */
-            register_target (target_name, f) {
+            register_target(target_name, f) {
                 let handle = this.jsServicesKernel.registerCommTarget(target_name,
                 (jsServicesComm, msg) => {
                     // Create the comm.
@@ -80,7 +80,7 @@ namespace shims {
              * Unregisters a comm target
              * @param  {string} target_name
              */
-            unregister_target (target_name, f) {
+            unregister_target(target_name, f) {
                 let handle = this.targets[target_name];
                 handle.dispose();
                 delete this.targets[target_name];
@@ -89,7 +89,7 @@ namespace shims {
             /**
              * Register a comm in the mapping
              */
-            register_comm = function (comm) {
+            register_comm(comm) {
               this.comms[comm.comm_id] = Promise.resolve(comm);
               comm.kernel = this.kernel;
               return comm.comm_id;
@@ -134,8 +134,8 @@ namespace shims {
              * @param  metadata
              * @return msg id
              */
-            open(data: any, callbacks: any, metadata: any): string {
-                let future = this.jsServicesComm.open(data, metadata);
+            open(data: any, callbacks: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): string {
+                let future = this.jsServicesComm.open(data, metadata, buffers);
                 this._hookupCallbacks(future, callbacks);
                 return future.msg.header.msg_id;
             }
@@ -148,7 +148,7 @@ namespace shims {
              * @param  buffers
              * @return message id
              */
-            send(data: any, callbacks: any, metadata: any, buffers: ArrayBuffer[] | ArrayBufferView[]): string {
+            send(data: any, callbacks: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): string {
                 let future = this.jsServicesComm.send(data, metadata, buffers);
                 this._hookupCallbacks(future, callbacks);
                 return future.msg.header.msg_id;
@@ -161,8 +161,8 @@ namespace shims {
              * @param  metadata
              * @return msg id
              */
-            close(data?: any, callbacks?: any, metadata?: any): string {
-                let future = this.jsServicesComm.close(data, metadata);
+            close(data?: any, callbacks?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): string {
+                let future = this.jsServicesComm.close(data, metadata, buffers);
                 this._hookupCallbacks(future, callbacks);
                 return future.msg.header.msg_id;
             }

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -21,6 +21,10 @@ import {
 } from '@phosphor/messaging';
 
 import {
+    IComm
+} from './services-shim';
+
+import {
     JUPYTER_WIDGETS_VERSION
 } from './version';
 
@@ -534,7 +538,7 @@ class WidgetModel extends Backbone.Model {
     model_id: string;
     views: {[key: string]: Promise<WidgetView>};
     state_change: Promise<any>;
-    comm: any;
+    comm: IComm;
     name: string;
     module: string;
 

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -21,7 +21,7 @@ import {
 } from '@phosphor/messaging';
 
 import {
-    IComm
+    IClassicComm
 } from './services-shim';
 
 import {
@@ -538,7 +538,7 @@ class WidgetModel extends Backbone.Model {
     model_id: string;
     views: {[key: string]: Promise<WidgetView>};
     state_change: Promise<any>;
-    comm: IComm;
+    comm: IClassicComm;
     name: string;
     module: string;
 

--- a/packages/base/test/src/dummy-manager.ts
+++ b/packages/base/test/src/dummy-manager.ts
@@ -10,7 +10,7 @@ import * as sinon from 'sinon';
 let numComms = 0;
 
 export
-class MockComm implements widgets.IComm {
+class MockComm implements widgets.IClassicComm {
     constructor() {
         this.comm_id = `mock-comm-id-${numComms}`;
         numComms += 1;

--- a/packages/base/test/src/dummy-manager.ts
+++ b/packages/base/test/src/dummy-manager.ts
@@ -10,10 +10,13 @@ import * as sinon from 'sinon';
 let numComms = 0;
 
 export
-class MockComm {
+class MockComm implements widgets.IComm {
     constructor() {
         this.comm_id = `mock-comm-id-${numComms}`;
         numComms += 1;
+    }
+    on_open(fn) {
+        this._on_open = fn;
     }
     on_close(fn) {
         this._on_close = fn;
@@ -28,16 +31,25 @@ class MockComm {
             return Promise.resolve();
         }
     }
+    open() {
+        if (this._on_open) {
+            this._on_open();
+        }
+        return '';
+    }
     close() {
         if (this._on_close) {
             this._on_close();
         }
+        return '';
     }
     send() {
-        return;
+        return '';
     }
     comm_id: string;
+    target_name: string;
     _on_msg: Function = null;
+    _on_open: Function = null;
     _on_close: Function = null;
 }
 
@@ -47,7 +59,7 @@ class DummyManager extends widgets.ManagerBase<HTMLElement> {
         super();
         this.el = window.document.createElement('div');
     }
-    
+
     display_view(msg: services.KernelMessage.IMessage, view: Backbone.View<Backbone.Model>, options: any) {
         // TODO: make this a spy
         // TODO: return an html element

--- a/packages/controls/test/src/dummy-manager.ts
+++ b/packages/controls/test/src/dummy-manager.ts
@@ -15,6 +15,9 @@ class MockComm {
         this.comm_id = `mock-comm-id-${numComms}`;
         numComms += 1;
     }
+    on_open(fn) {
+        this._on_open = fn;
+    }
     on_close(fn) {
         this._on_close = fn;
     }
@@ -28,16 +31,25 @@ class MockComm {
             return Promise.resolve();
         }
     }
+    open() {
+        if (this._on_open) {
+            this._on_open();
+        }
+        return '';
+    }
     close() {
         if (this._on_close) {
             this._on_close();
         }
+        return '';
     }
     send() {
-        return;
+        return '';
     }
     comm_id: string;
+    target_name: string;
     _on_msg: Function = null;
+    _on_open: Function = null;
     _on_close: Function = null;
 }
 

--- a/packages/html-manager/src/htmlmanager.ts
+++ b/packages/html-manager/src/htmlmanager.ts
@@ -50,7 +50,7 @@ class HTMLManager extends base.ManagerBase<HTMLElement> {
     /**
      * Placeholder implementation for _create_comm.
      */
-    _create_comm(comm_target_name: string, model_id: string, data?: any, metadata?: any): Promise<any> {
+    _create_comm(comm_target_name: string, model_id: string, data?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): Promise<any> {
         return Promise.resolve({
             on_close: () => {},
             on_msg: () => {},

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -5,7 +5,8 @@
 import * as Backbone from 'backbone';
 
 import {
-    ManagerBase, shims, IWidgetRegistryData, ExportMap, ExportData, WidgetModel, WidgetView
+    ManagerBase, shims, IComm, IWidgetRegistryData, ExportMap,
+    ExportData, WidgetModel, WidgetView
 } from '@jupyter-widgets/base';
 
 import {
@@ -116,7 +117,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
   /**
    * Create a comm.
    */
-   _create_comm(target_name: string, model_id: string, data?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): Promise<shims.services.Comm> {
+   _create_comm(target_name: string, model_id: string, data?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): Promise<IComm> {
     let comm = this._context.session.kernel.connectToComm(target_name, model_id);
     if (data || metadata) {
       comm.open(data, metadata, buffers);

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -5,7 +5,7 @@
 import * as Backbone from 'backbone';
 
 import {
-    ManagerBase, shims, IComm, IWidgetRegistryData, ExportMap,
+    ManagerBase, shims, IClassicComm, IWidgetRegistryData, ExportMap,
     ExportData, WidgetModel, WidgetView
 } from '@jupyter-widgets/base';
 
@@ -117,7 +117,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
   /**
    * Create a comm.
    */
-   _create_comm(target_name: string, model_id: string, data?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): Promise<IComm> {
+   _create_comm(target_name: string, model_id: string, data?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): Promise<IClassicComm> {
     let comm = this._context.session.kernel.connectToComm(target_name, model_id);
     if (data || metadata) {
       comm.open(data, metadata, buffers);

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -116,10 +116,10 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
   /**
    * Create a comm.
    */
-   _create_comm(target_name: string, model_id: string, data?: any, metadata?: any): Promise<shims.services.Comm> {
+   _create_comm(target_name: string, model_id: string, data?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): Promise<shims.services.Comm> {
     let comm = this._context.session.kernel.connectToComm(target_name, model_id);
     if (data || metadata) {
-      comm.open(data, metadata);
+      comm.open(data, metadata, buffers);
     }
     return Promise.resolve(new shims.services.Comm(comm));
   }

--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -210,12 +210,13 @@ WidgetManager.prototype.display_view = function(msg, view, options) {
 }
 
 
-WidgetManager.prototype._create_comm = function(comm_target_name, comm_id, data, metadata) {
+WidgetManager.prototype._create_comm = function(comm_target_name, comm_id, data, metadata, buffers) {
     var that = this;
     return this._get_connected_kernel().then(function(kernel) {
         if (data || metadata) {
             return kernel.comm_manager.new_comm(comm_target_name, data,
-                                                that.callbacks(), metadata, comm_id);
+                                                that.callbacks(), metadata,
+                                                comm_id, buffers);
         } else {
             // Construct a comm that already is open on the kernel side. We
             // don't want to send an open message, which would supersede the

--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -40,6 +40,8 @@ function polyfill_new_comm_buffers(manager, target_name, data, callbacks, metada
 
 function new_comm(manager, target_name, data, callbacks, metadata, comm_id, buffers) {
     // Checks whether new_comm needs a polyfill, and calls the correct version
+    // Polyfill needed for notebook <5.1, in which the new_comm method does not support a buffers argument.
+    // See https://github.com/jupyter-widgets/ipywidgets/pull/1817
     var need_polyfill = manager.new_comm.length < 6;
     if (need_polyfill) {
         return polyfill_new_comm_buffers.apply(null, arguments);


### PR DESCRIPTION
After https://github.com/jupyter/notebook/issues/2730 and https://github.com/jupyterlab/jupyterlab/issues/2556 were fixed, the comm open functions now support the buffers argument. This PR updates the different shims and utilities to reflect this. It also adds a an interface definition for the comm object used in widgets (the classic notebook one, shimmed in jlab).