### PR TITLE
Fix selection container default index

### DIFF
--- a/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/ipywidgets/widgets/widget_selectioncontainer.py
@@ -90,11 +90,6 @@ class Tab(_SelectionContainer):
             kwargs['selected_index'] = 0
         super(Tab, self).__init__(**kwargs)
 
-    @observe('children')
-    def _observe_children(self, change):
-        if len(change.new) > 0:
-            self.selected_index = 0
-
 @register
 class Stacked(_SelectionContainer):
     """Displays only the selected child."""

--- a/packages/controls/src/widget_selectioncontainer.ts
+++ b/packages/controls/src/widget_selectioncontainer.ts
@@ -31,7 +31,7 @@ export class SelectionContainerModel extends BoxModel {
     return {
       ...super.defaults(),
       _model_name: 'SelectionContainerModel',
-      selected_index: 0,
+      selected_index: null,
       _titles: {}
     };
   }

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -78,7 +78,7 @@ Attribute        | Type             | Default          | Help
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
-`selected_index` | `null` or number (integer) | `0`              | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
+`selected_index` | `null` or number (integer) | `null`           | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
 
@@ -956,7 +956,7 @@ Attribute        | Type             | Default          | Help
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
-`selected_index` | `null` or number (integer) | `0`              | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
+`selected_index` | `null` or number (integer) | `null`           | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
 
@@ -975,7 +975,7 @@ Attribute        | Type             | Default          | Help
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
-`selected_index` | `null` or number (integer) | `0`              | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
+`selected_index` | `null` or number (integer) | `null`           | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
 


### PR DESCRIPTION
cf discussions on #1822

- It does not make sense to default to 0 for an empty list of children.
- The default value of most attributes allowing None is None.
