### PR TITLE
Make the basic phosphor css less specific

### DIFF
--- a/packages/controls/css/phosphor.css
+++ b/packages/controls/css/phosphor.css
@@ -32,7 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  /* The following section is derived from https://github.com/phosphorjs/phosphor/blob/23b9d075ebc5b73ab148b6ebfc20af97f85714c4/packages/widgets/style/widget.css */
 
-.jupyter-widgets .p-Widget {
+ /* The basic widget css is not namespaced so that it isn't more specific than widget classes. */
+.p-Widget {
   box-sizing: border-box;
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
This is so that it doesn’t override widget-specific settings.

Fixes #1837