### PR TITLE
Include the basic phosphor css only in the built widgets.css file.

### DIFF
--- a/packages/controls/css/phosphor.css
+++ b/packages/controls/css/phosphor.css
@@ -30,24 +30,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
- /* The following section is derived from https://github.com/phosphorjs/phosphor/blob/23b9d075ebc5b73ab148b6ebfc20af97f85714c4/packages/widgets/style/widget.css */
-
- /* The basic widget css is not namespaced so that it isn't more specific than widget classes. */
-.p-Widget {
-  box-sizing: border-box;
-  position: relative;
-  overflow: hidden;
-  cursor: default;
-}
-
-
-.jupyter-widgets .p-Widget.p-mod-hidden {
-  display: none !important;
-}
-
-/* End widget.css */
-
-/* The following section is derived from https://github.com/phosphorjs/phosphor/blob/23b9d075ebc5b73ab148b6ebfc20af97f85714c4/packages/widgets/style/tabbar.css */
+/*
+ * The following section is derived from https://github.com/phosphorjs/phosphor/blob/23b9d075ebc5b73ab148b6ebfc20af97f85714c4/packages/widgets/style/tabbar.css 
+ * We've scoped the rules so that they are consistent with exactly our code.
+ */
 
 .jupyter-widgets.widget-tab > .p-TabBar {
   display: flex;

--- a/packages/controls/css/widgets.css
+++ b/packages/controls/css/widgets.css
@@ -2,7 +2,9 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-/* We import all of these together in a single css file because the Webpack
+@import "@phosphor/widgets/style/widget.css";
+
+ /* We import all of these together in a single css file because the Webpack
 loader sees only one file at a time. This allows postcss to see the variable
 definitions when they are used. */
 


### PR DESCRIPTION
Including it in the css file the JLab plugin uses breaks JLab.