### PR TITLE
Assume the widget manager ensured the phosphor css was on the page.

### DIFF
--- a/packages/controls/css/widgets.css
+++ b/packages/controls/css/widgets.css
@@ -2,8 +2,6 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-@import "@phosphor/widgets/style/widget.css";
-
  /* We import all of these together in a single css file because the Webpack
 loader sees only one file at a time. This allows postcss to see the variable
 definitions when they are used. */


### PR DESCRIPTION
This is a continuation of #1856 (which is a continuation of #1841). Now, the widget manager is the one in charge of making sure the basic phosphor widget css is on the page.

Lucky for us, the html and classic notebook widget manager's already do this, and the jlab manager assumes it's on the page.