### PR TITLE
Use the conda-forge recommonmark package for building docs.

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,6 +15,6 @@ dependencies:
 - sphinx_rtd_theme
 - tornado
 - python-dateutil
+- recommonmark
 - pip:
-  - recommonmark==0.4 # See https://github.com/rtfd/recommonmark/issues/78
   - jupyter-alabaster-theme


### PR DESCRIPTION
Once https://github.com/conda-forge/recommonmark-feedstock/pull/1 is merged, we should merge this so that we can use the recommonmark conda-forge package when building docs.