### PR TITLE
Fix the output widget version.

### DIFF
--- a/ipywidgets/_version.py
+++ b/ipywidgets/_version.py
@@ -10,6 +10,7 @@ __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
 
 __protocol_version__ = '2.0.0'
 __jupyter_widgets_base_version__ = '1.0.0'
+__jupyter_widgets_output_version__ = '1.0.0'
 __jupyter_widgets_controls_version__ = '1.1.0'
 
 # A compatible @jupyter-widgets/html-manager npm package semver range

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -9,6 +9,7 @@ Represents a widget that can be used to display output within the widget area.
 from .domwidget import DOMWidget
 from .widget import register
 from .widget_core import CoreWidget
+from .._version import __jupyter_widgets_output_version__
 
 import sys
 from traitlets import Unicode, Tuple
@@ -18,7 +19,7 @@ from IPython import get_ipython
 
 
 @register
-class Output(DOMWidget, CoreWidget):
+class Output(DOMWidget):
     """Widget used as a context manager to display output.
 
     This widget can capture and display stdout, stderr, and rich output.  To use
@@ -41,6 +42,9 @@ class Output(DOMWidget, CoreWidget):
     _model_name = Unicode('OutputModel').tag(sync=True)
     _view_module = Unicode('@jupyter-widgets/output').tag(sync=True)
     _model_module = Unicode('@jupyter-widgets/output').tag(sync=True)
+    _view_module_version = Unicode(__jupyter_widgets_output_version__).tag(sync=True)
+    _model_module_version = Unicode(__jupyter_widgets_output_version__).tag(sync=True)
+
     msg_id = Unicode('', help="Parent message id of messages to capture").tag(sync=True)
     outputs = Tuple(help="The output messages synced from the frontend.").tag(sync=True)
 

--- a/packages/output/src/output.ts
+++ b/packages/output/src/output.ts
@@ -4,7 +4,7 @@ import {
 } from '@jupyter-widgets/base';
 
 export
-const OUTPUT_WIDGET_VERSION = JUPYTER_WIDGETS_VERSION;
+const OUTPUT_WIDGET_VERSION = '1.0.0';
 
 export class OutputModel extends DOMWidgetModel {
     defaults() {

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -877,16 +877,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | boolean          | `false`          | Bool value
 
-### OutputModel (@jupyter-widgets/output, 1.1.0); OutputView (@jupyter-widgets/output, 1.1.0)
+### OutputModel (@jupyter-widgets/output, 1.0.0); OutputView (@jupyter-widgets/output, 1.0.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array            | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/output'` | 
-`_model_module_version` | string           | `'1.1.0'`        | 
+`_model_module_version` | string           | `'1.0.0'`        | 
 `_model_name`    | string           | `'OutputModel'`  | 
 `_view_module`   | string           | `'@jupyter-widgets/output'` | 
-`_view_module_version` | string           | `'1.1.0'`        | 
+`_view_module_version` | string           | `'1.0.0'`        | 
 `_view_name`     | string           | `'OutputView'`   | 
 `layout`         | reference to Layout widget | reference to new instance | 
 `msg_id`         | string           | `''`             | Parent message id of messages to capture

--- a/packages/schema/jupyterwidgetmodels.v7-1.md
+++ b/packages/schema/jupyterwidgetmodels.v7-1.md
@@ -877,16 +877,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | boolean          | `false`          | Bool value
 
-### OutputModel (@jupyter-widgets/output, 1.1.0); OutputView (@jupyter-widgets/output, 1.1.0)
+### OutputModel (@jupyter-widgets/output, 1.0.0); OutputView (@jupyter-widgets/output, 1.0.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array            | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/output'` | 
-`_model_module_version` | string           | `'1.1.0'`        | 
+`_model_module_version` | string           | `'1.0.0'`        | 
 `_model_name`    | string           | `'OutputModel'`  | 
 `_view_module`   | string           | `'@jupyter-widgets/output'` | 
-`_view_module_version` | string           | `'1.1.0'`        | 
+`_view_module_version` | string           | `'1.0.0'`        | 
 `_view_name`     | string           | `'OutputView'`   | 
 `layout`         | reference to Layout widget | reference to new instance | 
 `msg_id`         | string           | `''`             | Parent message id of messages to capture


### PR DESCRIPTION
This is a separate widget with a separate version number. We accidentally tied it to the controls version.

Fixes https://github.com/jupyter-widgets/ipywidgets/issues/1917 and https://github.com/jupyter-widgets/ipywidgets/issues/1912