### PR TITLE
data_files should not have a trailing slash

### DIFF
--- a/widgetsnbextension/setup.py
+++ b/widgetsnbextension/setup.py
@@ -205,7 +205,7 @@ setup_args = dict(
                 'widgetsnbextension/static/extension.js',
                 'widgetsnbextension/static/extension.js.map'
         ]),
-        ('etc/jupyter/nbconfig/notebook.d/' , ['widgetsnbextension.json'])
+        ('etc/jupyter/nbconfig/notebook.d' , ['widgetsnbextension.json'])
     ],
     zip_safe=False,
     include_package_data = True,


### PR DESCRIPTION
This causes an error installing on windows.

CC @maartenbreddels 