### PR TITLE
Adding min_gap property to IntRangeSlider

### DIFF
--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -15,7 +15,6 @@ from .trait_types import Color, InstanceDict, NumberFormat
 from traitlets import (
     Unicode, CInt, Bool, CaselessStrEnum, Tuple, TraitError, default, validate
 )
-from warnings import warn
 
 _int_doc_t = """
 Parameters

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -15,6 +15,7 @@ from .trait_types import Color, InstanceDict, NumberFormat
 from traitlets import (
     Unicode, CInt, Bool, CaselessStrEnum, Tuple, TraitError, default, validate
 )
+from warnings import warn
 
 _int_doc_t = """
 Parameters
@@ -238,9 +239,10 @@ class Play(_BoundedInt):
 class _BoundedIntRange(_IntRange):
     max = CInt(100, help="Max value").tag(sync=True)
     min = CInt(0, help="Min value").tag(sync=True)
+    min_gap = CInt(0, help="Min gap between integer pair").tag(sync=True)
 
     def __init__(self, *args, **kwargs):
-        min, max = kwargs.get('min', 0), kwargs.get('max', 100)
+        min, max, min_gap = kwargs.get('min', 0), kwargs.get('max', 100), kwargs.get('min_gap', 0)
         if not kwargs.get('value', None):
             kwargs['value'] = (0.75 * min + 0.25 * max,
                                0.25 * min + 0.75 * max)
@@ -258,13 +260,49 @@ class _BoundedIntRange(_IntRange):
             self.value = (max(new, self.value[0]), max(new, self.value[1]))
         if trait.name == 'max':
             self.value = (min(new, self.value[0]), min(new, self.value[1]))
+        if self.min_gap > 0:
+            # make sure new max/min range is > min_gap
+            value_gap = self.value[1] - self.value[0]
+            range_gap = self.max - self.min
+            if range_gap < self.min_gap:
+                raise TraitError('new min/max violates min_gap')
+            if value_gap < self.min_gap:
+                # if value gap is < min_gap, revert to min or max
+                if trait.name == 'min':
+                    self.value = (self.value[0], self.max)
+                if trait.name == 'max':
+                    self.value = (self.min, self.value[1])
+                value_gap = self.value[1] - self.value[0]
+                # fallback, we shouldn't reach this point,
+                # but if we do, reset values to min/max
+                if value_gap < self.min_gap:
+                    self.value = (self.min, self.max)
         return new
+
+        @validate('min_gap')
+        def _validate_min_gap(self, proposal):
+            new_gap = proposal['value']
+            value_gap = self.value[1] - self.value[0]
+            range_gap = self.max - self.min
+            if range_gap < new_gap:
+                raise TraitError('new min_gap violates min/max range')
+            if value_gap < range_gap:
+                raise TraitError('new min_gap violates gap between values')
+            return new_gap
+
 
     @validate('value')
     def _validate_value(self, proposal):
         lower, upper = super(_BoundedIntRange, self)._validate_value(proposal)
         lower, upper = min(lower, self.max), min(upper, self.max)
         lower, upper = max(lower, self.min), max(upper, self.min)
+        if self.min_gap > 0:
+            value_gap = upper - lower
+            if value_gap < self.min_gap:
+                # if value gap is smaller than min_gap, clamp
+                # values within the min-max range of the slider
+                lower = self.min
+                upper = self.max
         return lower, upper
 
 
@@ -280,6 +318,8 @@ class IntRangeSlider(_BoundedIntRange):
         The lowest allowed value for `lower`
     max : int
         The highest allowed value for `upper`
+    min_gap : int
+        The lowest allowed distance between pair of ints on slider
     """
     _view_name = Unicode('IntRangeSliderView').tag(sync=True)
     _model_name = Unicode('IntRangeSliderModel').tag(sync=True)

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -281,12 +281,13 @@ class _BoundedIntRange(_IntRange):
         @validate('min_gap')
         def _validate_min_gap(self, proposal):
             new_gap = proposal['value']
-            value_gap = self.value[1] - self.value[0]
-            range_gap = self.max - self.min
-            if range_gap < new_gap:
-                raise TraitError('new min_gap violates min/max range')
-            if value_gap < range_gap:
-                raise TraitError('new min_gap violates gap between values')
+            if new_gap > 0:
+                value_gap = self.value[1] - self.value[0]
+                range_gap = self.max - self.min
+                if range_gap < new_gap:
+                    raise TraitError('new min_gap violates min/max range')
+                if value_gap < range_gap:
+                    raise TraitError('new min_gap violates gap between values')
             return new_gap
 
 

--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -439,7 +439,7 @@ class IntSliderView extends BaseIntSliderView {
         }
         this.$slider.slider('option', 'value', value);
         this.readout.textContent = this.valueToString(value);
-        if(this.model.get('value')) {
+        if(this.model.get('value') !== value) {
             this.model.set('value', value, {updated_view: this});
             this.touch();
         }

--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -339,6 +339,15 @@ class IntRangeSliderView extends BaseIntSliderView {
             value = [Math.max(Math.min(value[0], vmax), vmin),
                         Math.max(Math.min(value[1], vmax), vmin)];
 
+            let min_gap = this.model.get('min_gap');
+            if (min_gap > 0) {
+                let value_gap = value[1] - value[2];
+                if (value_gap < min_gap) {
+                    // reject input where value gap < min_gap
+                    this.readout.textContent = this.valueToString(this.model.get('value'));
+                    return;
+                }
+            }
             if ((value[0] !== this.model.get('value')[0]) ||
                 (value[1] !== this.model.get('value')[1])) {
                 this.readout.textContent = this.valueToString(value);
@@ -371,6 +380,40 @@ class IntRangeSliderView extends BaseIntSliderView {
      */
     handleSliderChanged(e, ui) {
         let actual_value = ui.values.map(this._validate_slide_value);
+        let min_gap = this.model.get('min_gap');
+        if (min_gap > 0) {
+            let old_lower = this.model.get('value')[0];
+            let old_upper = this.model.get('value')[1];
+            let value_gap = actual_value[1] - actual_value[0];
+            let max = this.model.get('max');
+            let min = this.model.get('min');
+            // if value gap is smaller than min_gap, clamp
+            // values within the min-max range of the slider
+            if (value_gap < min_gap) {
+                if (actual_value[0] !== this.model.get('value')[0]) {
+                    actual_value[0] = Math.max(min, actual_value[1] - min_gap);
+                    value_gap = actual_value[1] - actual_value[0];
+                    if (value_gap < min_gap) {
+                        actual_value[1] = Math.min(max, actual_value[0] + min_gap);
+                    }
+                }
+                else if (actual_value[1] !== this.model.get('value')[1]) {
+                    actual_value[1] = Math.min(max, actual_value[0] + min_gap);
+                    value_gap = actual_value[1] - actual_value[0];
+                    if (value_gap < min_gap) {
+                        actual_value[0] = Math.max(min, actual_value[1] - min_gap);
+                    }
+                }
+                // fallback, we shouldn't reach this point,
+                // but if we do, reset values to min/max
+                value_gap = actual_value[1] - actual_value[0];
+                if (value_gap < min_gap) {
+                    actual_value[0] = min;
+                    actual_value[1] = max;
+                }
+            }
+        }
+        this.$slider.slider('option', 'values', actual_value.slice());
         this.model.set('value', actual_value, {updated_view: this});
         this.touch();
     }
@@ -396,7 +439,7 @@ class IntSliderView extends BaseIntSliderView {
         }
         this.$slider.slider('option', 'value', value);
         this.readout.textContent = this.valueToString(value);
-        if(this.model.get('value') !== value) {
+        if(this.model.get('value')) {
             this.model.set('value', value, {updated_view: this});
             this.touch();
         }


### PR DESCRIPTION
first pass at supporting feature request in: 
https://github.com/jupyter-widgets/ipywidgets/issues/1312
definitely open to suggestions here on how to set default/fallback values (especially when validating a new min/max against existing values/min_gap properties, and when validating a changed value against existing min/max/min_gap properties) - if there's a cleaner/more consistent way to handle those cases (or if there's a bug I've missed while testing :) ), I can clean up that logic!
If it makes sense, I can make a similar addition (when it looks clean/good to merge) to the FloatRangeSlider as part of this PR