### PR TITLE
Add @capture decorator to output widget

### DIFF
--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -5,11 +5,11 @@ from ipywidgets import Output
 
 
 def _make_stream_output(text, name):
-        return {
-            'output_type': 'stream',
-            'name': name,
-            'text': text
-        }
+    return {
+        'output_type': 'stream',
+        'name': name,
+        'text': text
+    }
 
 
 def test_append_stdout():

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -45,7 +45,7 @@ class Output(DOMWidget):
         with out:
             print('prints to output widget')
 
-        @out.decorate
+        @out.capture()
         def func():
             print('prints to output widget')
     """
@@ -60,11 +60,36 @@ class Output(DOMWidget):
     outputs = Tuple(help="The output messages synced from the frontend.").tag(sync=True)
 
     def clear_output(self, *pargs, **kwargs):
+        """
+        Clear the content of the output widget.
+
+        Parameters
+        ----------
+
+        wait: bool
+            If True, wait to clear the output until new output is
+            available to replace it. Default: False
+        """
         with self:
             clear_output(*pargs, **kwargs)
 
     def capture(self, clear_output=True, *outer_args, **outer_kwargs):
-        """Decorator to capture the stdout and stderr of a function"""
+        """
+        Decorator to capture the stdout and stderr of a function.
+
+        Parameters
+        ----------
+
+        clear_output: bool
+            If True, clear the content of the output widget at every
+            new function call. Default: True
+
+        wait: bool
+            If True, wait to clear the output until new output is
+            available to replace it. This is only used if clear_output
+            is also True.
+            Default: False
+        """
         def capture_decorator(func):
             @wraps(func)
             def inner(*args, **kwargs):

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -53,6 +53,7 @@ class Output(DOMWidget):
             clear_output(*pargs, **kwargs)
 
     def capture(self, func):
+        """Decorator to capture the stdout and stderr of a function"""
         def inner(*args, **kwargs):
             with self:
                 return func(*args, **kwargs)

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -23,9 +23,15 @@ class Output(DOMWidget):
     """Widget used as a context manager to display output.
 
     This widget can capture and display stdout, stderr, and rich output.  To use
-    it, create an instance of it and display it.  Then use it as a context
-    manager.  Any output produced while in it's context will be captured and
-    displayed in it instead of the standard output area.
+    it, create an instance of it and display it.
+
+    You can then use it as a context manager: any output produced while in it's
+    context will be captured and displayed in it instead of the standard output
+    area.
+
+    You can also use it to decorate a function or a method. Any output produced
+    by the function will then go to the output widget. This is useful for
+    debugging widget callbacks, for instance.
 
     Example::
         import ipywidgets as widgets
@@ -36,6 +42,10 @@ class Output(DOMWidget):
         print('prints to output area')
 
         with out:
+            print('prints to output widget')
+
+        @out.decorate
+        def func():
             print('prints to output widget')
     """
     _view_name = Unicode('OutputView').tag(sync=True)

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -73,6 +73,7 @@ class Output(DOMWidget):
         with self:
             clear_output(*pargs, **kwargs)
 
+    # PY3: Force passing clear_output and clear_kwargs as kwargs
     def capture(self, clear_output=True, *clear_args, **clear_kwargs):
         """
         Decorator to capture the stdout and stderr of a function.

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -73,7 +73,7 @@ class Output(DOMWidget):
         with self:
             clear_output(*pargs, **kwargs)
 
-    def capture(self, clear_output=True, *outer_args, **outer_kwargs):
+    def capture(self, clear_output=True, *clear_args, **clear_kwargs):
         """
         Decorator to capture the stdout and stderr of a function.
 
@@ -94,7 +94,7 @@ class Output(DOMWidget):
             @wraps(func)
             def inner(*args, **kwargs):
                 if clear_output:
-                    self.clear_output(*outer_args, **outer_kwargs)
+                    self.clear_output(*clear_args, **clear_kwargs)
                 with self:
                     return func(*args, **kwargs)
             return inner

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -11,7 +11,6 @@ from functools import wraps
 
 from .domwidget import DOMWidget
 from .widget import register
-from .widget_core import CoreWidget
 from .._version import __jupyter_widgets_output_version__
 
 from traitlets import Unicode, Tuple

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -52,6 +52,12 @@ class Output(DOMWidget):
         with self:
             clear_output(*pargs, **kwargs)
 
+    def capture(self, func):
+        def inner(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+        return inner
+
     def __enter__(self):
         """Called upon entering output widget context manager."""
         self._flush()

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -6,12 +6,14 @@
 Represents a widget that can be used to display output within the widget area.
 """
 
+import sys
+from functools import wraps
+
 from .domwidget import DOMWidget
 from .widget import register
 from .widget_core import CoreWidget
 from .._version import __jupyter_widgets_output_version__
 
-import sys
 from traitlets import Unicode, Tuple
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.display import clear_output
@@ -64,6 +66,7 @@ class Output(DOMWidget):
 
     def capture(self, func):
         """Decorator to capture the stdout and stderr of a function"""
+        @wraps(func)
         def inner(*args, **kwargs):
             with self:
                 return func(*args, **kwargs)

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -63,13 +63,17 @@ class Output(DOMWidget):
         with self:
             clear_output(*pargs, **kwargs)
 
-    def capture(self, func):
+    def capture(self, clear_output=True, *outer_args, **outer_kwargs):
         """Decorator to capture the stdout and stderr of a function"""
-        @wraps(func)
-        def inner(*args, **kwargs):
-            with self:
-                return func(*args, **kwargs)
-        return inner
+        def capture_decorator(func):
+            @wraps(func)
+            def inner(*args, **kwargs):
+                if clear_output:
+                    self.clear_output(*outer_args, **outer_kwargs)
+                with self:
+                    return func(*args, **kwargs)
+            return inner
+        return capture_decorator
 
     def __enter__(self):
         """Called upon entering output widget context manager."""

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -26,13 +26,13 @@ class Output(DOMWidget):
     This widget can capture and display stdout, stderr, and rich output.  To use
     it, create an instance of it and display it.
 
-    You can then use it as a context manager: any output produced while in it's
-    context will be captured and displayed in it instead of the standard output
+    You can then use the widget as a context manager: any output produced while in the
+    context will be captured and displayed in the widget instead of the standard output
     area.
 
-    You can also use it to decorate a function or a method. Any output produced
-    by the function will then go to the output widget. This is useful for
-    debugging widget callbacks, for instance.
+    You can also use the .capture() method to decorate a function or a method. Any output 
+    produced by the function will then go to the output widget. This is useful for
+    debugging widget callbacks, for example.
 
     Example::
         import ipywidgets as widgets

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -74,7 +74,7 @@ class Output(DOMWidget):
             clear_output(*pargs, **kwargs)
 
     # PY3: Force passing clear_output and clear_kwargs as kwargs
-    def capture(self, clear_output=True, *clear_args, **clear_kwargs):
+    def capture(self, clear_output=False, *clear_args, **clear_kwargs):
         """
         Decorator to capture the stdout and stderr of a function.
 
@@ -83,7 +83,7 @@ class Output(DOMWidget):
 
         clear_output: bool
             If True, clear the content of the output widget at every
-            new function call. Default: True
+            new function call. Default: False
 
         wait: bool
             If True, wait to clear the output until new output is


### PR DESCRIPTION
This PR adds a `@out.capture` decorator that pushes all the output of a function to an output widget. It addresses issue #1846 .

For instance, 

```py
out = widgets.Output()

@out.capture
def f(arg):
    print(arg)

f('argument')

out.outputs
# => ({'name': 'stdout', 'output_type': 'stream', 'text': 'argument'},)
```

This is useful for capturing output from widget callbacks:
```py
b = widgets.Button()
b.on_click(f)
# everytime someone clicks on `b`, `out.outputs` gets appended to.
```

To do:

 ~~- [x] Documentation on output widget (probably in a separate PR)~~ (moved to issue #1935)
 - [x] Use `functools.wraps` to avoid losing the function name and docstring (https://docs.python.org/3.6/library/functools.html#functools.wraps)
 ~~- [ ] Is there a better name than `out.capture`? (I'm comfortable with `out.capture`).~~
 ~~- [ ] Should current outputs be cleared on entry? (I think that would be more confusing -- we could add a recipe to the documentation for creating an output widget with a clear button).~~