### PR TITLE
'new' is not guaranteed to be in change

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -592,7 +592,7 @@ class Widget(LoggingHasTraits):
         name = change['name']
         if self.comm is not None and self.comm.kernel is not None:
             # Make sure this isn't information that the front-end just sent us.
-            if name in self.keys and self._should_send_property(name, change['new']):
+            if name in self.keys and self._should_send_property(name, getattr(self, name)):
                 # Send new state to front-end
                 self.send_state(key=name)
         super(Widget, self).notify_change(change)


### PR DESCRIPTION
With [eventful traits](https://github.com/ipython/traitlets/pull/466) near completion this should be changed due to the fact that the only keys guaranteed to be included in the change dictionary are `'owner'`, `'type'`, and `'name'`.

cc: @SylvainCorlay, @jasongrout