### PR TITLE
Clean up state restore in nbextension manager

### DIFF
--- a/widgetsnbextension/src/manager.js
+++ b/widgetsnbextension/src/manager.js
@@ -49,6 +49,18 @@ function new_comm(manager, target_name, data, callbacks, metadata, comm_id, buff
     return manager.new_comm.apply(manager, Array.prototype.slice.call(arguments, 1));
 }
 
+function filter_existing_model_state(manager, state) {
+    var models = state.state;
+    models = Object.keys(models)
+          .filter(function(model_id) {
+              return !manager._models[model_id];
+          })
+          .reduce(function(res, model_id) {
+              return Object.assign(res, { [model_id]: models[model_id] });
+          }, {});
+    return Object.assign({}, state, {state: models});
+}
+
 //--------------------------------------------------------------------
 // WidgetManager class
 //--------------------------------------------------------------------
@@ -63,24 +75,29 @@ var WidgetManager = function (comm_manager, notebook) {
     this.comm_manager = comm_manager;
 
     var widget_md = notebook.metadata.widgets
-    if (widget_md && widget_md['application/vnd.jupyter.widget-state+json']) {
-        this.set_state(notebook.metadata.widgets['application/vnd.jupyter.widget-state+json'])
-    }
 
-    // Register with the comm manager.
+    // Steps that needs to be done:
+    // 1. Register comm target
+    // 2. Get any widget state from the kernel and open comms with existing state
+    // 3. Check saved state for widgets, and restore any that would not overwrite
+    //    any live widgets.
+
+    // Register with the comm manager. (1)
     this.comm_manager.register_target(this.comm_target_name, _.bind(this.handle_comm_open,this));
 
-    // Attempt to reconstruct any live comms by requesting them from the back-end.
+    // Attempt to reconstruct any live comms by requesting them from the back-end (2).
     var that = this;
-    var backed_widgets_loaded = this._get_comm_info().then(function(comm_ids) {
+    var backed_widgets_loaded = Promise.resolve().then(function() {
+        return that._get_comm_info();
+    }).then(function(comm_ids) {
 
-        // Create comm class instances from comm ids.
+        // Create comm class instances from comm ids (2).
         var comm_promises = Object.keys(comm_ids).map(function(comm_id) {
             return that._create_comm(that.comm_target_name, comm_id);
         });
 
         // Send a state request message out for each widget comm and wait
-        // for the responses.
+        // for the responses (2).
         return Promise.all(comm_promises).then(function(comms) {
             return Promise.all(comms.map(function(comm) {
                 var update_promise = new Promise(function(resolve, reject) {
@@ -110,6 +127,14 @@ var WidgetManager = function (comm_manager, notebook) {
                     comm: widget_info.comm,
                 }, widget_info.msg.content.data.state);
             }));
+        }).then(function() {
+            // Now that we have mirrored any widgets from the kernel...
+            // Restore any widgets from saved state that are not live (3)
+            if (widget_md && widget_md['application/vnd.jupyter.widget-state+json']) {
+                var state = notebook.metadata.widgets['application/vnd.jupyter.widget-state+json'];
+                state = filter_existing_model_state(that, state);
+                return that.set_state(state);
+            }
         }).then(function() {
             // Rerender cells that have widget data
             that.notebook.get_cells().forEach(function(cell) {


### PR DESCRIPTION
- Restore live widgets from kernel before widgets from the saved state.
- Afterwards, restore any widgets from saved state that would not overwrite a live widget.
- Also adds some helpful comments.

Fixes #1875.