### PR TITLE
DOC: Installation with notebook and kernel in different envs

### DIFF
--- a/docs/source/user_install.md
+++ b/docs/source/user_install.md
@@ -35,11 +35,11 @@ environments (either virtualenv or conda environments).
 This happens when environments are used to
 provide different IPython kernels. In this case, the installation requires two steps.
 
-First, you need to install the `widgetsnbextension` in the environment
+First, you need to install the `widgetsnbextension` package in the environment
 containing the Jupyter Notebook server. Next, you need to install 
-`ipywidgets` in each environment that will use the ipywidgets.
+`ipywidgets` in each kernel's environment that will use ipywidgets.
 
-For example, when if using conda environments, with the notebook installed on the 
+For example, if using conda environments, with the notebook installed on the 
 `base` environment and the kernel installed in an environment called `py36`,
 the commands are:
 

--- a/docs/source/user_install.md
+++ b/docs/source/user_install.md
@@ -27,21 +27,21 @@ conda install -c conda-forge ipywidgets
 
 Installing **ipywidgets** with conda will also enable the extension for you.
 
-Installing with multiple environment
-------------------------------------
+Installing with multiple environments
+-------------------------------------
 
 Sometimes the Jupyter Notebook and the IPython kernel are installed in different
-environments (they can be either virtualenv or conda environments).
-This happens for example when environments are used to
-provide different IPython kernels. In this the installation requires two steps.
+environments (either virtualenv or conda environments).
+This happens when environments are used to
+provide different IPython kernels. In this case, the installation requires two steps.
 
 First, you need to install the `widgetsnbextension` in the environment
 containing the Jupyter Notebook server. Next, you need to install 
-`ipywidgets` in each environment that will use widgets.
+`ipywidgets` in each environment that will use the ipywidgets.
 
 For example, when if using conda environments, with the notebook installed on the 
 `base` environment and the kernel installed in an environment called `py36`,
-the commands needed are:
+the commands are:
 
 ```bash
 conda install -n base -c conda-forge widgetsnbextension

--- a/docs/source/user_install.md
+++ b/docs/source/user_install.md
@@ -27,6 +27,27 @@ conda install -c conda-forge ipywidgets
 
 Installing **ipywidgets** with conda will also enable the extension for you.
 
+Installing with multiple environment
+------------------------------------
+
+Sometimes the Jupyter Notebook and the IPython kernel are installed in different
+environments (they can be either virtualenv or conda environments).
+This happens for example when environments are used to
+provide different IPython kernels. In this the installation requires two steps.
+
+First, you need to install the `widgetsnbextension` in the environment
+containing the Jupyter Notebook server. Next, you need to install 
+`ipywidgets` in each environment that will use widgets.
+
+For example, when if using conda environments, with the notebook installed on the 
+`base` environment and the kernel installed in an environment called `py36`,
+the commands needed are:
+
+```bash
+conda install -n base -c conda-forge widgetsnbextension
+conda install -n py36 -c conda-forge ipywidgets
+
+```
 
 Installing the JupyterLab Extension
 -----------------------------------


### PR DESCRIPTION
Following #1949, this PR adds a small docs section explaining how to install `ipywidgets` when notebook and ipython kernels are on different environments.