### PR TITLE
Fixup binary buffer saving

### DIFF
--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -420,9 +420,6 @@ class WidgetModel extends Backbone.Model {
             try {
                 if (serializers[k] && serializers[k].serialize) {
                     state[k] = (serializers[k].serialize)(state[k], this);
-                } else {
-                    // the default serializer just deep-copies the object
-                    state[k] = JSON.parse(JSON.stringify(state[k]));
                 }
                 if (state[k] && state[k].toJSON) {
                     state[k] = state[k].toJSON();


### PR DESCRIPTION
`JSON.parse(JSON.stringify(` results in removing any binary buffer in the state.

It happens that the state passed to `serialize` is a transient mutable object, so we should not need to do any deep copy there.

Fixes #1950 