### PR TITLE
Possible errors in documentation?

### DIFF
--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -158,7 +158,7 @@ html_template = """
 """
 
 manager_state = json.dumps(data['manager_state'])
-widget_views = [json.dumps(view) for view in data['widget_views']]
+widget_views = [json.dumps(view) for view in data['view_specs']]
 rendered_template = html_template.format(manager_state=manager_state, widget_views=widget_views)
 with open('export.html', 'w') as fp:
     fp.write(rendered_template)
@@ -189,7 +189,7 @@ from ipywidgets.embed import embed_snippet, dependency_state
 
 s1 = IntSlider(max=200, value=100)
 s2 = IntSlider(value=40)
-embed_minimal_html(views=[s1, s2], state=dependency_state([s1, s2]))
+embed_minimal_html('export.html', views=[s1, s2], state=dependency_state([s1, s2]))
 ```
 
 ## Embedding Widgets in the Sphinx HTML Documentation

--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -185,7 +185,7 @@ the relevant ones in your export. To include only the state of specific views
 and their dependencies, use the function `dependency_state`:
 
 ```py
-from ipywidgets.embed import embed_snippet, dependency_state
+from ipywidgets.embed import embed_minimal_html, dependency_state
 
 s1 = IntSlider(max=200, value=100)
 s2 = IntSlider(value=40)


### PR DESCRIPTION
I got errors when trying to run a few of these (potentially outdated?) examples.

Line 161:
`widget_views = [json.dumps(view) for view in data['widget_views']]`
--> `KeyError: 'widget_views' `

Line 192:
`embed_minimal_html('export.html', views=[s1, s2], state=dependency_state([s1, s2]))`
--> `TypeError: embed_minimal_html() missing 1 required positional argument: 'fp'`

I hope these changes are correct and useful!!


*Note:* I'm using ipywidgets version 7.1.1