### PR TITLE
Return a promise so that comm message processing is delayed until we are instantiated

### DIFF
--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -102,7 +102,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
     this._commRegistration = kernel.registerCommTarget(this.comm_target_name,
     (comm, msg) => {
       let oldComm = new shims.services.Comm(comm);
-      this.handle_comm_open(oldComm, msg);
+      return this.handle_comm_open(oldComm, msg);
     });
   }
 


### PR DESCRIPTION
Otherwise, we miss some messages coming from the kernel, because the comm message handler is not registered.