### PR TITLE
Fixed Jupyterlab releases link in the dev docs

### DIFF
--- a/docs/source/dev_install.md
+++ b/docs/source/dev_install.md
@@ -15,7 +15,7 @@ To install ipywidgets from git, you will need:
   + See the
     [Compatibility table](https://github.com/jupyter-widgets/ipywidgets#compatibility)
     
-- the latest [JupyterLab release](https://github.com/jupyter/notebook/releases)
+- the latest [JupyterLab release](https://github.com/jupyterlab/jupyterlab/releases)
 
 
 


### PR DESCRIPTION
Noticed while going through the [Developer Install](https://ipywidgets.readthedocs.io/en/latest/dev_install.html) documentation.