### PR TITLE
Extend unit tests for the Output widget

### DIFF
--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -124,6 +124,25 @@ class TestOutputWidget(TestCase):
         assert clear_output.calls[0] == clear_output.calls[1] == \
             ((), {'wait': True})
 
+    def test_capture_decorator_no_clear_output(self):
+        msg_id = 'msg-id'
+        get_ipython = self._mock_get_ipython(msg_id)
+        clear_output = self._mock_clear_output()
+
+        with self._mocked_ipython(get_ipython, clear_output):
+            widget = widget_output.Output()
+            assert widget.msg_id == ''
+
+            @widget.capture(clear_output=False)
+            def captee(*args, **kwargs):
+                # Check that we are capturing output
+                assert widget.msg_id == msg_id
+
+            captee()
+            captee()
+
+        assert len(clear_output.calls) == 0
+
 
 
 def _make_stream_output(text, name):

--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -5,11 +5,11 @@ from ipywidgets import Output
 
 
 def _make_stream_output(text, name):
-        return {
-            'output_type': 'stream',
-            'name': name,
-            'text': text
-        }
+    return {
+        'output_type': 'stream',
+        'name': name,
+        'text': text
+    }
 
 
 def test_append_stdout():

--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -103,6 +103,27 @@ class TestOutputWidget(TestCase):
         )
         assert captee_calls[1] == ((), {})
 
+    def test_capture_decorator_clear_output(self):
+        msg_id = 'msg-id'
+        get_ipython = self._mock_get_ipython(msg_id)
+        clear_output = self._mock_clear_output()
+
+        with self._mocked_ipython(get_ipython, clear_output):
+            widget = widget_output.Output()
+            assert widget.msg_id == ''
+
+            @widget.capture(clear_output=True, wait=True)
+            def captee(*args, **kwargs):
+                # Check that we are capturing output
+                assert widget.msg_id == msg_id
+
+            captee()
+            captee()
+
+        assert len(clear_output.calls) == 2
+        assert clear_output.calls[0] == clear_output.calls[1] == \
+            ((), {'wait': True})
+
 
 
 def _make_stream_output(text, name):

--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -110,7 +110,6 @@ class TestOutputWidget(TestCase):
 
         with self._mocked_ipython(get_ipython, clear_output):
             widget = widget_output.Output()
-            assert widget.msg_id == ''
 
             @widget.capture(clear_output=True, wait=True)
             def captee(*args, **kwargs):
@@ -131,7 +130,6 @@ class TestOutputWidget(TestCase):
 
         with self._mocked_ipython(get_ipython, clear_output):
             widget = widget_output.Output()
-            assert widget.msg_id == ''
 
             @widget.capture(clear_output=False)
             def captee(*args, **kwargs):
@@ -142,7 +140,6 @@ class TestOutputWidget(TestCase):
             captee()
 
         assert len(clear_output.calls) == 0
-
 
 
 def _make_stream_output(text, name):

--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -10,6 +10,7 @@ class TestOutputWidget(TestCase):
 
     @contextmanager
     def _mocked_ipython(self, get_ipython, clear_output):
+        """ Context manager that monkeypatches get_ipython and clear_output """
         original_clear_output = widget_output.clear_output
         original_get_ipython = widget_output.get_ipython
         widget_output.get_ipython = get_ipython
@@ -21,16 +22,19 @@ class TestOutputWidget(TestCase):
             widget_output.get_ipython = original_get_ipython
 
     def _mock_get_ipython(self, msg_id):
-        # Specifically override this so the traceback
-        # is still printed to screen
-        def showtraceback(self_, exc_tuple, *args, **kwargs):
-            etype, evalue, tb = exc_tuple
-            raise etype(evalue)
+        """ Returns a mock IPython application with a mocked kernel """
         kernel = type(
             'mock_kernel',
             (object, ),
             {'_parent_header': {'header': {'msg_id': msg_id}}}
         )
+
+        # Specifically override this so the traceback
+        # is still printed to screen
+        def showtraceback(self_, exc_tuple, *args, **kwargs):
+            etype, evalue, tb = exc_tuple
+            raise etype(evalue)
+
         ipython = type(
             'mock_ipython',
             (object, ),
@@ -39,6 +43,7 @@ class TestOutputWidget(TestCase):
         return ipython
 
     def _mock_clear_output(self):
+        """ Mock function that records calls to it """
         calls = []
 
         def clear_output(*args, **kwargs):

--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -71,6 +71,39 @@ class TestOutputWidget(TestCase):
         assert len(clear_output.calls) == 1
         assert clear_output.calls[0] == ((), {'wait': True})
 
+    def test_capture_decorator(self):
+        msg_id = 'msg-id'
+        get_ipython = self._mock_get_ipython(msg_id)
+        clear_output = self._mock_clear_output()
+        expected_argument = 'arg'
+        expected_keyword_argument = True
+        captee_calls = []
+
+        with self._mocked_ipython(get_ipython, clear_output):
+            widget = widget_output.Output()
+            assert widget.msg_id == ''
+
+            @widget.capture()
+            def captee(*args, **kwargs):
+                # Check that we are capturing output
+                assert widget.msg_id == msg_id
+
+                # Check that arguments are passed correctly
+                captee_calls.append((args, kwargs))
+
+            captee(
+                expected_argument, keyword_argument=expected_keyword_argument)
+            assert widget.msg_id == ''
+            captee()
+
+        assert len(captee_calls) == 2
+        assert captee_calls[0] == (
+            (expected_argument, ),
+            {'keyword_argument': expected_keyword_argument}
+        )
+        assert captee_calls[1] == ((), {})
+
+
 
 def _make_stream_output(text, name):
     return {

--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -59,6 +59,18 @@ class TestOutputWidget(TestCase):
                 assert widget.msg_id == msg_id
             assert widget.msg_id == ''
 
+    def test_clear_output(self):
+        msg_id = 'msg-id'
+        get_ipython = self._mock_get_ipython(msg_id)
+        clear_output = self._mock_clear_output()
+
+        with self._mocked_ipython(get_ipython, clear_output):
+            widget = widget_output.Output()
+            widget.clear_output(wait=True)
+
+        assert len(clear_output.calls) == 1
+        assert clear_output.calls[0] == ((), {'wait': True})
+
 
 def _make_stream_output(text, name):
     return {

--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -1,7 +1,7 @@
 import sys
 
 from IPython.display import Markdown, Image
-from ipywidgets import Output
+from ipywidgets import widget_output
 
 
 def _make_stream_output(text, name):
@@ -13,38 +13,38 @@ def _make_stream_output(text, name):
 
 
 def test_append_stdout():
-    output = Output()
+    widget = widget_output.Output()
 
     # Try appending a message to stdout.
-    output.append_stdout("snakes!")
+    widget.append_stdout("snakes!")
     expected = (_make_stream_output("snakes!", "stdout"),)
-    assert output.outputs == expected, repr(output.outputs)
+    assert widget.outputs == expected, repr(widget.outputs)
 
     # Try appending a second message.
-    output.append_stdout("more snakes!")
+    widget.append_stdout("more snakes!")
     expected += (_make_stream_output("more snakes!", "stdout"),)
-    assert output.outputs == expected, repr(output.outputs)
+    assert widget.outputs == expected, repr(widget.outputs)
 
 
 def test_append_stderr():
-    output = Output()
+    widget = widget_output.Output()
 
     # Try appending a message to stderr.
-    output.append_stderr("snakes!")
+    widget.append_stderr("snakes!")
     expected = (_make_stream_output("snakes!", "stderr"),)
-    assert output.outputs == expected, repr(output.outputs)
+    assert widget.outputs == expected, repr(widget.outputs)
 
     # Try appending a second message.
-    output.append_stderr("more snakes!")
+    widget.append_stderr("more snakes!")
     expected += (_make_stream_output("more snakes!", "stderr"),)
-    assert output.outputs == expected, repr(output.outputs)
+    assert widget.outputs == expected, repr(widget.outputs)
 
 
 def test_append_display_data():
-    output = Output()
+    widget = widget_output.Output()
 
     # Try appending a Markdown object.
-    output.append_display_data(Markdown("# snakes!"))
+    widget.append_display_data(Markdown("# snakes!"))
     expected = (
         {
             'output_type': 'display_data',
@@ -55,13 +55,13 @@ def test_append_display_data():
             'metadata': {}
         },
     )
-    assert output.outputs == expected, repr(output.outputs)
+    assert widget.outputs == expected, repr(widget.outputs)
 
     # Now try appending an Image.
     image_data = b"foobar"
     image_data_b64 = image_data if sys.version_info[0] < 3 else 'Zm9vYmFy\n'
 
-    output.append_display_data(Image(image_data, width=123, height=456))
+    widget.append_display_data(Image(image_data, width=123, height=456))
     expected += (
         {
             'output_type': 'display_data',
@@ -77,4 +77,4 @@ def test_append_display_data():
             }
         },
     )
-    assert output.outputs == expected, repr(output.outputs)
+    assert widget.outputs == expected, repr(widget.outputs)

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -45,7 +45,7 @@ class Output(DOMWidget):
         with out:
             print('prints to output widget')
 
-        @out.decorate
+        @out.capture()
         def func():
             print('prints to output widget')
     """
@@ -60,11 +60,36 @@ class Output(DOMWidget):
     outputs = Tuple(help="The output messages synced from the frontend.").tag(sync=True)
 
     def clear_output(self, *pargs, **kwargs):
+        """
+        Clear the content of the output widget.
+
+        Parameters
+        ----------
+
+        wait: bool
+            If True, wait to clear the output until new output is
+            available to replace it. Default: False
+        """
         with self:
             clear_output(*pargs, **kwargs)
 
     def capture(self, clear_output=True, *outer_args, **outer_kwargs):
-        """Decorator to capture the stdout and stderr of a function"""
+        """
+        Decorator to capture the stdout and stderr of a function.
+
+        Parameters
+        ----------
+
+        clear_output: bool
+            If True, clear the content of the output widget at every
+            new function call. Default: True
+
+        wait: bool
+            If True, wait to clear the output until new output is
+            available to replace it. This is only used if clear_output
+            is also True.
+            Default: False
+        """
         def capture_decorator(func):
             @wraps(func)
             def inner(*args, **kwargs):

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -53,6 +53,7 @@ class Output(DOMWidget):
             clear_output(*pargs, **kwargs)
 
     def capture(self, func):
+        """Decorator to capture the stdout and stderr of a function"""
         def inner(*args, **kwargs):
             with self:
                 return func(*args, **kwargs)

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -23,9 +23,15 @@ class Output(DOMWidget):
     """Widget used as a context manager to display output.
 
     This widget can capture and display stdout, stderr, and rich output.  To use
-    it, create an instance of it and display it.  Then use it as a context
-    manager.  Any output produced while in it's context will be captured and
-    displayed in it instead of the standard output area.
+    it, create an instance of it and display it.
+
+    You can then use it as a context manager: any output produced while in it's
+    context will be captured and displayed in it instead of the standard output
+    area.
+
+    You can also use it to decorate a function or a method. Any output produced
+    by the function will then go to the output widget. This is useful for
+    debugging widget callbacks, for instance.
 
     Example::
         import ipywidgets as widgets
@@ -36,6 +42,10 @@ class Output(DOMWidget):
         print('prints to output area')
 
         with out:
+            print('prints to output widget')
+
+        @out.decorate
+        def func():
             print('prints to output widget')
     """
     _view_name = Unicode('OutputView').tag(sync=True)

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -73,6 +73,7 @@ class Output(DOMWidget):
         with self:
             clear_output(*pargs, **kwargs)
 
+    # PY3: Force passing clear_output and clear_kwargs as kwargs
     def capture(self, clear_output=True, *clear_args, **clear_kwargs):
         """
         Decorator to capture the stdout and stderr of a function.

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -73,7 +73,7 @@ class Output(DOMWidget):
         with self:
             clear_output(*pargs, **kwargs)
 
-    def capture(self, clear_output=True, *outer_args, **outer_kwargs):
+    def capture(self, clear_output=True, *clear_args, **clear_kwargs):
         """
         Decorator to capture the stdout and stderr of a function.
 
@@ -94,7 +94,7 @@ class Output(DOMWidget):
             @wraps(func)
             def inner(*args, **kwargs):
                 if clear_output:
-                    self.clear_output(*outer_args, **outer_kwargs)
+                    self.clear_output(*clear_args, **clear_kwargs)
                 with self:
                     return func(*args, **kwargs)
             return inner

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -11,7 +11,6 @@ from functools import wraps
 
 from .domwidget import DOMWidget
 from .widget import register
-from .widget_core import CoreWidget
 from .._version import __jupyter_widgets_output_version__
 
 from traitlets import Unicode, Tuple

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -52,6 +52,12 @@ class Output(DOMWidget):
         with self:
             clear_output(*pargs, **kwargs)
 
+    def capture(self, func):
+        def inner(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+        return inner
+
     def __enter__(self):
         """Called upon entering output widget context manager."""
         self._flush()

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -6,12 +6,14 @@
 Represents a widget that can be used to display output within the widget area.
 """
 
+import sys
+from functools import wraps
+
 from .domwidget import DOMWidget
 from .widget import register
 from .widget_core import CoreWidget
 from .._version import __jupyter_widgets_output_version__
 
-import sys
 from traitlets import Unicode, Tuple
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.display import clear_output
@@ -64,6 +66,7 @@ class Output(DOMWidget):
 
     def capture(self, func):
         """Decorator to capture the stdout and stderr of a function"""
+        @wraps(func)
         def inner(*args, **kwargs):
             with self:
                 return func(*args, **kwargs)

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -63,13 +63,17 @@ class Output(DOMWidget):
         with self:
             clear_output(*pargs, **kwargs)
 
-    def capture(self, func):
+    def capture(self, clear_output=True, *outer_args, **outer_kwargs):
         """Decorator to capture the stdout and stderr of a function"""
-        @wraps(func)
-        def inner(*args, **kwargs):
-            with self:
-                return func(*args, **kwargs)
-        return inner
+        def capture_decorator(func):
+            @wraps(func)
+            def inner(*args, **kwargs):
+                if clear_output:
+                    self.clear_output(*outer_args, **outer_kwargs)
+                with self:
+                    return func(*args, **kwargs)
+            return inner
+        return capture_decorator
 
     def __enter__(self):
         """Called upon entering output widget context manager."""

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -74,7 +74,7 @@ class Output(DOMWidget):
             clear_output(*pargs, **kwargs)
 
     # PY3: Force passing clear_output and clear_kwargs as kwargs
-    def capture(self, clear_output=True, *clear_args, **clear_kwargs):
+    def capture(self, clear_output=False, *clear_args, **clear_kwargs):
         """
         Decorator to capture the stdout and stderr of a function.
 
@@ -83,7 +83,7 @@ class Output(DOMWidget):
 
         clear_output: bool
             If True, clear the content of the output widget at every
-            new function call. Default: True
+            new function call. Default: False
 
         wait: bool
             If True, wait to clear the output until new output is


### PR DESCRIPTION
This builds on PR #1934, and the diff currently includes some commits from that PR.

While working on PR #1934, I felt that the test coverage on the Python side of the output widget was somewhat sparse. The difficulty is that a lot of the output widget code relies on `IPython.display` and `IPython` methods. I've mocked these out in these tests (using manual monkeypatching, rather than introducing a dependency on a mocking library).

* Is this useful? I personally think this will help developers like me who are less familiar with the codebase, but happy to discard this if maintainers think it adds too much overhead.
* Should we write this differently? For instance, we could use a real mocking library rather than my home-grown attempts at one. There isn't (AFAICT) much mocking in unit tests at the moment, so it's probably worth settling on one way of doing things.