### PR TITLE
Use _repr_mimebundle_ instead of _ipython_display_ message for initial display

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -697,7 +697,7 @@ class Widget(LoggingHasTraits):
         """Convert json values to objects."""
         return x
 
-    def _ipython_display_(self, **kwargs):
+    def _repr_mimebundle_(self, **kwargs):
         """Called when `IPython.display.display` is called on the widget."""
         if self._view_name is not None:
 
@@ -715,9 +715,8 @@ class Widget(LoggingHasTraits):
                     'model_id': self._model_id
                 }
             }
-            display(data, raw=True)
-
             self._handle_displayed(**kwargs)
+            return data
 
     def _send(self, msg, buffers=None):
         """Sends a message to the model in the front-end."""


### PR DESCRIPTION
I guess this is up to debate, but using the `execute_result` message instead of `display_data` enables the display of the prompt number like for other types of outputs.

<img width="633" alt="screen shot 2018-02-27 at 8 16 37 pm" src="https://user-images.githubusercontent.com/2397974/36749653-acc8c974-1bfb-11e8-9954-5cb7f85391e4.png">

cc @Carreau @jasongrout
