### PR TITLE
Add utility function resolveUrl on manager

### DIFF
--- a/packages/base/src/manager-base.ts
+++ b/packages/base/src/manager-base.ts
@@ -481,6 +481,16 @@ abstract class ManagerBase<T> {
             this._models[i].then(model => { model.comm_live = false; });
         });
     }
+
+    /**
+     * Resolve a URL relative to the current notebook location.
+     *
+     * The default implementation just returns the original url.
+     */
+    resolveUrl(url: string): Promise<string> {
+        return Promise.resolve(url);
+    }
+
     /**
      * The comm target name to register
      */

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -157,6 +157,13 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
   }
 
   /**
+   * Resolve a URL relative to the current notebook location.
+   */
+  resolveUrl(url: string): Promise<string> {
+    return this.context.resolveUrl(url);
+  }
+
+  /**
    * Load a class and return a promise to the loaded object.
    */
   protected loadClass(className: string, moduleName: string, moduleVersion: string): Promise<typeof WidgetModel | typeof WidgetView> {


### PR DESCRIPTION
This is needed to be able to resolve file URLs relative to the widget's notebook.

Example: My widget needs to load an image at the path 'img/earth.jpg'. This is implied to be relative to the path of the current notebook (I cannot see a case where this wouldn't be what the user would expect, but I'm sure someone will come along at some point). In classic notebook, this works out of the box, since the url always incorporates the location of the notebook. For jupyter lab, this is not the case. By adding a utility function on the widget manger, we add a frontend-agnostic way of resolving the URL.