### PR TITLE
if moduleName contains a slash, use a different module/path

### DIFF
--- a/packages/html-manager/src/libembed-amd.ts
+++ b/packages/html-manager/src/libembed-amd.ts
@@ -24,8 +24,16 @@ function requireLoader(moduleName: string, moduleVersion: string) {
         let failedId = err.requireModules && err.requireModules[0];
         if (failedId) {
             console.log(`Falling back to unpkg.com for ${moduleName}@${moduleVersion}`);
-            return requirePromise([`https://unpkg.com/${moduleName}@${moduleVersion}/dist/index.js`]);
-        }
+            // default path
+            let path = 'index'
+            let index = moduleName.indexOf('/');
+            if(index != -1) {
+                // if a '/'' is present, like 'foo/bar', moduleName is changed to 'foo', and path to 'bar'
+                path = moduleName.substr(index+1)
+                moduleName = moduleName.substr(0, index)
+            }
+           return requirePromise([`https://unpkg.com/${moduleName}@${moduleVersion}/dist/${path}.js`]);
+       }
     });
 }
 


### PR DESCRIPTION
This is useful if a package contains multiple widget extensions (I use this for ipysheet).
For instance, use:
`_model_module = Unicode('ipysheet/renderer').tag(sync=True)`
The embed manager will try got get `ipysheet/renderer.js` from the server its running on (which is a valid request, and useful for local testing), if that fails it will fetch:
`https://unpkg.com/ipysheet@semver/dist/renderer.js`