### PR TITLE
Allow requireLoader to be configurable

### DIFF
--- a/packages/html-manager/src/libembed-amd.ts
+++ b/packages/html-manager/src/libembed-amd.ts
@@ -52,12 +52,14 @@ function requireLoader(moduleName: string, moduleVersion: string) {
  * Render widgets in a given element.
  *
  * @param element (default document.documentElement) The element containing widget state and views.
+ * @param loader (default requireLoader) The function used to look up the modules containing
+ * the widgets' models and views classes. (The default loader looks them up on unpkg.com) 
  */
 export
-function renderWidgets(element = document.documentElement) {
+function renderWidgets(element = document.documentElement, loader: (moduleName: string, moduleVersion: string) => Promise<any>  = requireLoader) {
     requirePromise(['@jupyter-widgets/html-manager']).then((htmlmanager) => {
         let managerFactory = () => {
-            return new htmlmanager.HTMLManager({loader: requireLoader});
+            return new htmlmanager.HTMLManager({loader: loader});
         }
         libembed.renderWidgets(managerFactory, element);
     });


### PR DESCRIPTION
I'd really like to be able to configure where I look up the widget models and views classes, and not always pick up from unpkg (for inhouse software).

I didn't know if there was a better way to do it, but allowing a configurable loader for htmlManager might do it.

Please let me know if this can be merged or if there is a better solution to my problem