### PR TITLE
Fix URL resolver compilation.

### DIFF
--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -160,7 +160,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
    * Resolve a URL relative to the current notebook location.
    */
   resolveUrl(url: string): Promise<string> {
-    return this.context.resolveUrl(url);
+    return this.context.urlResolver.resolveUrl(url);
   }
 
   /**


### PR DESCRIPTION
I had an error trying to compile:

```
> @jupyter-widgets/jupyterlab-manager@0.33.2 build:src [snip]/ipywidgets/packages/jupyterlab-manager
> tsc --project src

src/manager.ts(163,25): error TS2339: Property 'resolveUrl' does not exist on type 'IContext<IModel>'.
```
This fixes it.