### PR TITLE
Fix Edge select box styling to show selected items

### DIFF
--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -730,11 +730,6 @@
     border-color: var(--jp-widgets-input-focus-border-color);
 }
 
-.widget-select > select > option:checked {
-    color: var(--jp-ui-font-color0);
-    background: var(--jp-layout-color0) repeat url("data:image/gif;base64,R0lGO...");
-}
-
 .wiget-select > select > option {
     padding-left: var(--jp-widgets-input-padding);
     line-height: var(--jp-widgets-inline-height);

--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -693,11 +693,6 @@
     text-shadow: 0 0 0 #000;
 }
 
-.widget-dropdown > select > option:checked {
-    color: var(--jp-ui-font-color0);
-    background: var(--jp-layout-color0) repeat url("data:image/gif;base64,R0lGO...");
-}
-
 /* Select and SelectMultiple */
 
 .widget-select {


### PR DESCRIPTION
Fixes #1996

Apparently Edge is the only browser that was paying attention to the checked option’s color and background - no other browser seemed to be affected by this.