### PR TITLE
Delete html fallback message.

### DIFF
--- a/docs/source/user_install.md
+++ b/docs/source/user_install.md
@@ -64,3 +64,17 @@ running the `jupyter lab clean` command which will remove the staging and
 static directories from the lab directory. The location of the lab directory
 can be queried by executing the command `jupyter lab path` in your terminal.
 
+Frequently Asked Questions
+--------------------------
+
+**Question**: When I display a widget or interact, I just see some text, such as `IntSlider(value=0)` or `interactive(children=(IntSlider(value=0, description='x', max=1), Output()), _dom_classes=('widget-interact',))`. What is wrong?
+
+**Answer**: A text representation of the widget is printed if the widget control
+is not available. It may mean the widget JavaScript is still loading. If the
+message persists in the Jupyter Notebook or JupyterLab, it likely means that the
+widgets JavaScript library is either not installed or not enabled. See the
+installation instructions above for setup instructions.
+
+If you see this message in another frontend (for example, a static rendering on
+GitHub or <a href="https://nbviewer.jupyter.org/">NBViewer</a>), it may mean
+that your frontend doesn't currently support widgets.

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -708,7 +708,6 @@ class Widget(LoggingHasTraits):
             # http://www.iana.org/assignments/media-types/media-types.xhtml.
             data = {
                 'text/plain': repr(self),
-                'text/html': self._fallback_html(),
                 'application/vnd.jupyter.widget-view+json': {
                     'version_major': 2,
                     'version_minor': 0,
@@ -749,23 +748,3 @@ class Widget(LoggingHasTraits):
             for key in keys
         )
         return '%s(%s)' % (class_name, signature)
-
-    def _fallback_html(self):
-        return _FALLBACK_HTML_TEMPLATE.format(widget_type=type(self).__name__)
-
-
-_FALLBACK_HTML_TEMPLATE = """\
-<p>Failed to display Jupyter Widget of type <code>{widget_type}</code>.</p>
-<p>
-  If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean
-  that the widgets JavaScript is still loading. If this message persists, it
-  likely means that the widgets JavaScript library is either not installed or
-  not enabled. See the <a href="https://ipywidgets.readthedocs.io/en/stable/user_install.html">Jupyter
-  Widgets Documentation</a> for setup instructions.
-</p>
-<p>
-  If you're reading this message in another frontend (for example, a static
-  rendering on GitHub or <a href="https://nbviewer.jupyter.org/">NBViewer</a>),
-  it may mean that your frontend doesn't currently support widgets.
-</p>
-"""

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -701,13 +701,16 @@ class Widget(LoggingHasTraits):
         """Called when `IPython.display.display` is called on the widget."""
         if self._view_name is not None:
 
+            plaintext = repr(self)
+            if len(plaintext) > 110:
+                plaintext = plaintext[:110] + '…'
             # The 'application/vnd.jupyter.widget-view+json' mimetype has not been registered yet.
             # See the registration process and naming convention at
             # http://tools.ietf.org/html/rfc6838
             # and the currently registered mimetypes at
             # http://www.iana.org/assignments/media-types/media-types.xhtml.
             data = {
-                'text/plain': repr(self),
+                'text/plain': plaintext,
                 'application/vnd.jupyter.widget-view+json': {
                     'version_major': 2,
                     'version_minor': 0,


### PR DESCRIPTION
This reverts #1674, since we discovered some problems with the classic notebook and html outputs.

Fixes #1777
Fixes #1951