### PR TITLE
Fixed the link to github repository.

### DIFF
--- a/docs/source/developer_docs.rst
+++ b/docs/source/developer_docs.rst
@@ -1,7 +1,7 @@
 Developer Docs
 ===============
 
-The Jupyter widgets packages are developed in the [https://github.com/jupyter-widgets/ipywidgets](https://github.com/jupyter-widgets/ipywidgets) git repository.
+The Jupyter widgets packages are developed in the `https://github.com/jupyter-widgets/ipywidgets <https://github.com/jupyter-widgets/ipywidgets>`_ git repository.
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION
The link was formatted as markdown instead of restructured text.