### PR TITLE
Change float log slider default format to .3g

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are 10 widgets distributed with IPython that are designed to display numeric values.  Widgets exist for displaying integers and floats, both bounded and unbounded.  The integer widgets share a similar naming scheme to their floating point counterparts.  By replacing `Float` with `Int` in the widget name, you can find the Integer equivalent."
+    "There are many widgets distributed with IPython that are designed to display numeric values.  Widgets exist for displaying integers and floats, both bounded and unbounded.  The integer widgets share a similar naming scheme to their floating point counterparts.  By replacing `Float` with `Int` in the widget name, you can find the Integer equivalent."
    ]
   },
   {
@@ -215,6 +215,36 @@
     "    orientation='vertical',\n",
     "    readout=True,\n",
     "    readout_format='.1f',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### FloatLogSlider"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `FloatLogSlider` has a log scale, which makes it easy to have a slider that covers a wide range of positive magnitudes. The `min` and `max` refer to the minimum and maximum exponents of the base, and the `value` refers to the actual value of the slider."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "widgets.FloatLogSlider(\n",
+    "    value=10,\n",
+    "    base=10,\n",
+    "    min=-10, # max exponent of base\n",
+    "    max=10, # min exponent of base\n",
+    "    step=0.2, # exponent step\n",
+    "    description='Log Slider'\n",
     ")"
    ]
   },

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -201,7 +201,7 @@ class FloatLogSlider(_BoundedLogFloat):
     readout : {True, False}
         default is True, display the current value of the slider next to it
     readout_format : str
-        default is '.2f', specifier for the format function used to represent
+        default is '.3g', specifier for the format function used to represent
         slider value for human consumption, modeled after Python 3's format
         specification mini-language (PEP 3101).
     """
@@ -212,11 +212,10 @@ class FloatLogSlider(_BoundedLogFloat):
         default_value='horizontal', help="Vertical or horizontal.").tag(sync=True)
     readout = Bool(True, help="Display the current value of the slider next to it.").tag(sync=True)
     readout_format = NumberFormat(
-        '.2f', help="Format for the readout").tag(sync=True)
+        '.3g', help="Format for the readout").tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
     base = CFloat(10., help="Base for the logarithm").tag(sync=True)
-
 
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
 

--- a/packages/controls/src/widget_float.ts
+++ b/packages/controls/src/widget_float.ts
@@ -80,7 +80,7 @@ class FloatLogSliderModel extends BoundedFloatModel {
             orientation: 'horizontal',
             _range: false,
             readout: true,
-            readout_format: '.2f',
+            readout_format: '.3g',
             slider_color: null,
             continuous_update: true,
             disabled: false,

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -316,7 +316,7 @@ Attribute        | Type             | Default          | Help
 `min`            | number (float)   | `0.0`            | Min value for the exponent
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `readout`        | boolean          | `true`           | Display the current value of the slider next to it.
-`readout_format` | string           | `'.2f'`          | Format for the readout
+`readout_format` | string           | `'.3g'`          | Format for the readout
 `step`           | number (float)   | `0.1`            | Minimum step in the exponent to increment the value
 `style`          | reference to SliderStyle widget | reference to new instance | 
 `value`          | number (float)   | `1.0`            | Float value


### PR DESCRIPTION
After playing with the float slider for a bit, I realized it is very easy to get very small or large orders of magnitude (duh!). These formats are much more readable using .3g rather than .2f as the default format.

Also, I added it to the widget list doc page.

CC @sebasguts - what do you think about changing the default format? For example, `FloatLogSlider(min=-10, max=10, readout_format='.2f')` has a huge number of values that are either difficult to understand (at the max) or just plain not visible (at the min). Changing the format to .3f makes both cases much easier to understand.
