### PR TITLE
Use _repr_mimebundle_ and require IPython 6.1 or later.

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -214,8 +214,7 @@ class interactive(VBox):
         else:
             for widget in self.kwargs_widgets:
                 widget.observe(self.update, names='value')
-
-            self.on_displayed(self.update)
+            self.update()
 
     # Callback function
     def update(self, *args):

--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -472,8 +472,8 @@ def test_call_decorated_on_trait_change(clear_display):
         def foo(a='default'):
             d['a'] = a
             return a
-    assert len(displayed) == 1
-    w = displayed[0].children[0]
+    assert len(displayed) == 2 # display the result and the interact
+    w = displayed[1].children[0]
     check_widget(w,
         cls=widgets.Text,
         value='default',
@@ -487,7 +487,7 @@ def test_call_decorated_on_trait_change(clear_display):
     with patch.object(interaction, 'display', record_display):
         w.value = 'called'
     assert d['a'] == 'called'
-    assert len(displayed) == 2
+    assert len(displayed) == 3
     assert w.value == displayed[-1]
 
 def test_call_decorated_kwargs_on_trait_change(clear_display):
@@ -498,8 +498,8 @@ def test_call_decorated_kwargs_on_trait_change(clear_display):
         def foo(a='default'):
             d['a'] = a
             return a
-    assert len(displayed) == 1
-    w = displayed[0].children[0]
+    assert len(displayed) == 2 # display the result and the interact
+    w = displayed[1].children[0]
     check_widget(w,
         cls=widgets.Text,
         value='kwarg',
@@ -513,7 +513,7 @@ def test_call_decorated_kwargs_on_trait_change(clear_display):
     with patch.object(interaction, 'display', record_display):
         w.value = 'called'
     assert d['a'] == 'called'
-    assert len(displayed) == 2
+    assert len(displayed) == 3
     assert w.value == displayed[-1]
 
 

--- a/ipywidgets/widgets/tests/utils.py
+++ b/ipywidgets/widgets/tests/utils.py
@@ -27,10 +27,10 @@ undefined = object()
 def setup_test_comm():
     _widget_attrs['_comm_default'] = getattr(Widget, '_comm_default', undefined)
     Widget._comm_default = lambda self: DummyComm()
-    _widget_attrs['_ipython_display_'] = Widget._ipython_display_
+    _widget_attrs['_repr_mimebundle_'] = Widget._repr_mimebundle_
     def raise_not_implemented(*args, **kwargs):
         raise NotImplementedError()
-    Widget._ipython_display_ = raise_not_implemented
+    Widget._repr_mimebundle_ = raise_not_implemented
 
 def teardown_test_comm():
     for attr, value in _widget_attrs.items():

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -62,12 +62,6 @@ class Box(DOMWidget, CoreWidget):
     def __init__(self, children=(), **kwargs):
         kwargs['children'] = children
         super().__init__(**kwargs)
-        self.on_displayed(Box._fire_children_displayed)
-
-    def _fire_children_displayed(self):
-        for child in self.children:
-            child._handle_displayed()
-
 
 @register
 @doc_subst(_doc_snippets)

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'ipykernel>=4.5.1',
+    'ipython>=6.1.0', # to use _repr_mimebundle
     'traitlets>=4.3.1',
     # Requiring nbformat to specify bugfix version which is not required by
     # notebook.
@@ -120,7 +121,6 @@ install_requires = setuptools_args['install_requires'] = [
 ]
 
 extras_require = setuptools_args['extras_require'] = {
-    '': ['ipython>=4.0.0'],
     'test': ['pytest>=3.6.0', 'pytest-cov'],
 }
 


### PR DESCRIPTION
Fixes #1811 

This has the problem (noted in the code) that the display callback now happens *before* the display message is sent. Before this, the display callback happened *after* the display message was sent.

CC @SylvainCorlay - what do you think about this? I'm thinking that this backwards compatibility difference would make this actually an 8.0 change, and may cause other problems.

