### PR TITLE
When a view is removed, hide the container and delete the model id

### DIFF
--- a/packages/jupyterlab-manager/src/renderer.ts
+++ b/packages/jupyterlab-manager/src/renderer.ts
@@ -30,13 +30,27 @@ class WidgetRenderer extends Panel implements IRenderMime.IRenderer, IDisposable
 
   async renderModel(model: IRenderMime.IMimeModel) {
     const source: any = model.data[this.mimeType];
+
+    // If there is no model id, the view was removed, so hide the node.
+    if (source.model_id === '') {
+      this.hide();
+      return Promise.resolve();
+    }
+
     const modelPromise = this._manager.get_model(source.model_id);
     if (modelPromise) {
       try {
         let wModel = await modelPromise;
         let widget = await this._manager.display_model(void 0, wModel, void 0);
         this.addWidget(widget);
-      } catch(err) {
+
+        // If the widget is disposed, hide this container and make sure we
+        // change the output model to reflect the view was closed.
+        widget.disposed.connect(() => {
+          this.hide();
+          source.model_id = '';
+        });
+      } catch (err) {
         console.log('Error displaying widget');
         console.log(err);
         this.node.textContent = 'Error displaying widget';

--- a/widgetsnbextension/src/extension.js
+++ b/widgetsnbextension/src/extension.js
@@ -108,6 +108,12 @@ function register_events(Jupyter, events, outputarea) {
             return;
         }
 
+        // Missing model id means the view was removed. Hide this element.
+        if (data.model_id === '') {
+            node.style.display = 'none';
+            return;
+        }
+
         var model = manager.get_model(data.model_id);
         if (model) {
             model.then(function(model) {
@@ -118,6 +124,14 @@ function register_events(Jupyter, events, outputarea) {
                 output._jupyterWidgetViews.push(id);
                 views[id] = view;
                 PhosphorWidget.Widget.attach(view.pWidget, node);
+
+                // Make the node completely disappear if the view is removed.
+                view.once('remove', () => {
+                    // Since we have a mutable reference to the data, delete the
+                    // model id to indicate the view is removed.
+                    data.model_id = '';
+                    node.style.display = 'none';
+                })
             });
         } else {
             node.textContent = 'A Jupyter widget could not be displayed because the widget state could not be found. This could happen if the kernel storing the widget is no longer available, or if the widget state was not saved in the notebook. You may be able to create the widget by running the appropriate cells.';


### PR DESCRIPTION
We modify the actual data in the view mimetype to change the model_id to be the empty string. This is valid according to the view schema. As a new convention, an empty string for the model id indicates that the view was explicitly removed and should be hidden.

Fixes #1845

This actually doesn’t quite remove all of the empty space in JuptyerLab because there is an extra nesting of containers for rendered outputs, but it does make it better, and does seem to remove space in the separate (simplified) output area views.

CC @SylvainCorlay