### PR TITLE
Widget Alignment isn’t rendered since it doesn’t have a title.

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -12,7 +12,6 @@ User Guide
   examples/Widget Events.ipynb
   examples/Widget Styling.ipynb
   examples/Widget Custom.ipynb
-  examples/Widget Alignment.ipynb
   examples/Widget Low Level.ipynb
   examples/Widget Asynchronous.ipynb
   embedding.md


### PR DESCRIPTION
It wasn’t meant to be in the official docs in its current rough form either.