### PR TITLE
Ensure we fully resolve lab URLs

### DIFF
--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -164,7 +164,9 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
    * Resolve a URL relative to the current notebook location.
    */
   resolveUrl(url: string): Promise<string> {
-    return this.context.urlResolver.resolveUrl(url);
+    return this.context.urlResolver.resolveUrl(url).then((partial) => {
+      return this.context.urlResolver.getDownloadUrl(partial);
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes `resolveUrl` on lab manager to give a download URL instead of a server path. The base implementation does not give a server path, so neither should the lab one. This will lead to a disconnect in the widget API name vs that used in jupyterlab, but I think that is acceptable.