### PR TITLE
Remove value from the Image repr

### DIFF
--- a/ipywidgets/widgets/tests/test_widget_image.py
+++ b/ipywidgets/widgets/tests/test_widget_image.py
@@ -130,6 +130,20 @@ def test_format_inference_overridable():
     assert img.format == 'gif'
 
 
+def test_value_repr_length():
+    with get_logo_png() as LOGO_PNG:
+        with open(LOGO_PNG, 'rb') as f:
+            img = Image.from_file(f)
+            assert len(img.__repr__()) < 120
+            assert img.__repr__().endswith("...')")
+
+
+def test_value_repr_url():
+    img = Image.from_url(b'https://jupyter.org/assets/main-logo.svg')
+
+    assert 'https://jupyter.org/assets/main-logo.svg' in img.__repr__()
+
+
 # Helper functions
 def get_hash_hex(byte_str):
     m = hashlib.new('sha256')

--- a/ipywidgets/widgets/widget_image.py
+++ b/ipywidgets/widgets/widget_image.py
@@ -6,6 +6,7 @@
 Represents an image in the frontend using a widget.
 """
 import mimetypes
+import hashlib
 
 from .widget_core import CoreWidget
 from .domwidget import DOMWidget
@@ -129,9 +130,19 @@ class Image(DOMWidget, ValueWidget, CoreWidget):
         except Exception:
             return None
 
-    def _repr_keys(self):
-        # Do not include value in the repr, since it will
+    def __repr__(self):
+        def hash_string(s):
+            return hashlib.md5(s.encode("utf8")).hexdigest()
+
+        # Truncate the value in the repr, since it will
         # typically be very, very large.
+        class_name = self.__class__.__name__
+
+        signature = []
         for key in super(Image, self)._repr_keys():
-            if key != 'value':
-                yield key
+            value = str(getattr(self, key))
+            if len(value) > 100:
+                value = '<base64, hash={}...>'.format(hash_string(value)[:16])
+            signature.append('%s=%r' % (key, value))
+        signature = ', '.join(signature)
+        return '%s(%s)' % (class_name, signature)

--- a/ipywidgets/widgets/widget_image.py
+++ b/ipywidgets/widgets/widget_image.py
@@ -128,3 +128,10 @@ class Image(DOMWidget, ValueWidget, CoreWidget):
             return mtype[len('image/'):]
         except Exception:
             return None
+
+    def _repr_keys(self):
+        # Do not include value in the repr, since it will
+        # typically be very, very large.
+        for key in super(Image, self)._repr_keys():
+            if key != 'value':
+                yield key

--- a/ipywidgets/widgets/widget_image.py
+++ b/ipywidgets/widgets/widget_image.py
@@ -131,18 +131,25 @@ class Image(DOMWidget, ValueWidget, CoreWidget):
             return None
 
     def __repr__(self):
+        # Truncate the value in the repr, since it will
+        # typically be very, very large.
+
         def hash_string(s):
             return hashlib.md5(s.encode("utf8")).hexdigest()
 
-        # Truncate the value in the repr, since it will
-        # typically be very, very large.
         class_name = self.__class__.__name__
 
+        # Return value first like a ValueWidget
         signature = []
+        sig_value = str(self.value)
+        if len(str(self.value)) > 100:
+            sig_value = '<base64, hash={}...>'.format(hash_string(sig_value)[:16])
+        signature.append('%s=%r' % ('value', sig_value))
+
         for key in super(Image, self)._repr_keys():
+            if key == 'value':
+                continue
             value = str(getattr(self, key))
-            if len(value) > 100:
-                value = '<base64, hash={}...>'.format(hash_string(value)[:16])
             signature.append('%s=%r' % (key, value))
         signature = ', '.join(signature)
         return '%s(%s)' % (class_name, signature)

--- a/ipywidgets/widgets/widget_image.py
+++ b/ipywidgets/widgets/widget_image.py
@@ -133,18 +133,16 @@ class Image(DOMWidget, ValueWidget, CoreWidget):
     def __repr__(self):
         # Truncate the value in the repr, since it will
         # typically be very, very large.
-
-        def hash_string(s):
-            return hashlib.md5(s.encode("utf8")).hexdigest()
-
         class_name = self.__class__.__name__
 
         # Return value first like a ValueWidget
         signature = []
-        sig_value = str(self.value)
-        if len(str(self.value)) > 100:
-            sig_value = '<base64, hash={}...>'.format(hash_string(sig_value)[:16])
-        signature.append('%s=%r' % ('value', sig_value))
+        sig_value = repr(self.value)
+        prefix, rest = sig_value.split("'", 1)
+        content = rest[:-1]
+        if len(content) > 100:
+            sig_value = "{}'{}...'".format(prefix, content[0:100])
+        signature.append('%s=%s' % ('value', sig_value))
 
         for key in super(Image, self)._repr_keys():
             if key == 'value':


### PR DESCRIPTION
Right now `Image.__repr__` includes the value of the image...which bring my browser to a crashing halt for large images.

This is likely not the ideal way to handle this; I'd be happy to change `widget.__repr__` to truncate all large values (over maybe 10k characters?) in the repr instead.