### PR TITLE
Firefox can now use the date input field

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -1349,7 +1349,7 @@
    "source": [
     "## Date picker\n",
     "\n",
-    "The date picker widget works in Chrome and IE Edge, but does not currently work in Firefox or Safari because they do not support the HTML date input field."
+    "The date picker widget works in Chrome, Firefox and IE Edge, but does not currently work in Safari because it does not support the HTML date input field."
    ]
   },
   {


### PR DESCRIPTION
See https://caniuse.com/#feat=input-datetime for reference.
Demonstration: 
![peek 18-07-2018 14-46](https://user-images.githubusercontent.com/11994719/42882550-76854cd6-8a99-11e8-88f5-0c0f92814f1c.gif)
