### PR TITLE
Bug: cannot deserialize Image.value

### DIFF
--- a/ipywidgets/widgets/tests/test_widget_image.py
+++ b/ipywidgets/widgets/tests/test_widget_image.py
@@ -121,6 +121,23 @@ def test_format_inference_stream():
     assert img.format == 'png'
 
 
+def test_serialize():
+    fstream = io.BytesIO(b'123')
+    img = Image.from_file(fstream)
+
+    img_state = img.get_state()
+
+    # for python27 it is a memoryview
+    assert isinstance(img_state['value'], (bytes, memoryview))
+    # make sure it is (for python 3), since that is what it will be once it comes off the wire
+    img_state['value'] = memoryview(img_state['value'])
+
+    # check that we can deserialize it and get back the original value
+    img_copy = Image()
+    img_copy.set_state(img_state)
+    assert img.value == img_copy.value
+
+
 def test_format_inference_overridable():
     with tempfile.NamedTemporaryFile(suffix='.svg', delete=False) as f:
         name = f.name


### PR DESCRIPTION
If the `Image.value` value comes off the wire, it will/can be a memoryview, which will make deserializing (quietly fail).
We need a custom deserializer for this.