### PR TITLE
Update jupyterlab-manager version compatibility

### DIFF
--- a/packages/jupyterlab-manager/README.md
+++ b/packages/jupyterlab-manager/README.md
@@ -26,6 +26,7 @@ JupyterLab extension.
 * For JupyterLab 0.31rc2, use `jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.33`
 * For JupyterLab 0.31.x, use `jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.34`
 * For JupyterLab 0.32.x, use `jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.35`
+* For JupyterLab 0.33.x, use `jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.36`
 
 
 Source Build


### PR DESCRIPTION
So JupyterLab 0.33.x matches with `@jupyter-widgets/jupyterlab-manager@0.36`.