### PR TITLE
Trigger notification for an index change if the options changed for a selection widget

### DIFF
--- a/ipywidgets/widgets/tests/test_widget_selection.py
+++ b/ipywidgets/widgets/tests/test_widget_selection.py
@@ -1,0 +1,44 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from unittest import TestCase
+
+from traitlets import TraitError
+
+from ipywidgets import SelectionSlider, Select
+
+class TestSelectionSlider(TestCase):
+
+    def test_construction(self):
+        SelectionSlider(options=['a', 'b', 'c'])
+
+    def test_index_trigger(self):
+        slider = SelectionSlider(options=['a', 'b', 'c'])
+        observations = []
+        def f(change):
+            observations.append(change.new)
+        slider.observe(f, 'index')
+        assert slider.index == 0
+        slider.options = [4, 5, 6]
+        assert slider.index == 0
+        assert slider.value == 4
+        assert slider.label == '4'
+        assert observations == [0]
+
+class TestSelection(TestCase):
+
+    def test_construction(self):
+        select = Select(options=['a', 'b', 'c'])
+
+    def test_index_trigger(self):
+        select = Select(options=[1, 2, 3])
+        observations = []
+        def f(change):
+            observations.append(change.new)
+        select.observe(f, 'index')
+        assert select.index == 0
+        select.options = [4, 5, 6]
+        assert select.index == 0
+        assert select.value == 4
+        assert select.label == '4'
+        assert observations == [0]

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -207,11 +207,13 @@ class _Selection(DescriptionWidget, ValueWidget, CoreWidget):
         self._options_values = tuple(i[1] for i in options)
         if self._initializing_traits_ is not True:
             if len(options) > 0:
-                # if the index is already 0, we set it to None so that setting it to 0
-                # will be recognized as a change (and pick up the new option value and label).
                 if self.index == 0:
-                    self.index = None
-                self.index = 0
+                    # Explicitly trigger the observers to pick up the new value and
+                    # label. Just setting the value would not trigger the observers
+                    # since traitlets thinks the value hasn't changed.
+                    self._notify_trait('index', 0, 0)
+                else:
+                    self.index = 0
             else:
                 self.index = None
 
@@ -526,6 +528,13 @@ class _SelectionNonempty(_Selection):
         if len(self._options_full) == 0:
             raise TraitError("Option list must be nonempty")
         return proposal.value
+
+    @validate('index')
+    def _validate_index(self, proposal):
+        if 0 <= proposal.value < len(self._options_labels):
+            return proposal.value
+        else:
+            raise TraitError('Invalid selection: index out of bounds')
 
 class _MultipleSelectionNonempty(_MultipleSelection):
     """Selection that is guaranteed to have an option available."""


### PR DESCRIPTION
Fixes #2075

This technically changes the event sequence if the index is 0 and we reset the options to a nonempty list - now the index isn’t set to None before it is set back to 0.
