### PR TITLE
The widget renderer should call its parent’s dispose method.

### DIFF
--- a/packages/jupyterlab-manager/src/renderer.ts
+++ b/packages/jupyterlab-manager/src/renderer.ts
@@ -78,6 +78,7 @@ class WidgetRenderer extends Panel implements IRenderMime.IRenderer, IDisposable
     if (this.isDisposed) {
       return;
     }
+    super.dispose();
     this._manager = null;
   }
 


### PR DESCRIPTION
As it was, any child widget was never getting disposed. Now, the widget renderer parent (a panel) will dispose its children (i.e., any widget that is rendered). This also should ensure that all widget remove methods are called.

Fixes #2171