### PR TITLE
Add jupyter-widgets CSS class to error messages

### DIFF
--- a/packages/html-manager/src/output_renderers.ts
+++ b/packages/html-manager/src/output_renderers.ts
@@ -28,9 +28,11 @@ export class WidgetRenderer extends Widget implements IRenderMime.IRenderer {
                 console.log('Error displaying widget');
                 console.log(err);
                 this.node.textContent = 'Error displaying widget';
+                this.addClass('jupyter-widgets');
             }
         } else {
             this.node.textContent = 'Error creating widget: could not find model';
+            this.addClass('jupyter-widgets');
             return Promise.resolve();
         }
     }

--- a/packages/jupyterlab-manager/src/renderer.ts
+++ b/packages/jupyterlab-manager/src/renderer.ts
@@ -54,9 +54,11 @@ class WidgetRenderer extends Panel implements IRenderMime.IRenderer, IDisposable
         console.log('Error displaying widget');
         console.log(err);
         this.node.textContent = 'Error displaying widget';
+        this.addClass('jupyter-widgets');
       }
     } else {
       this.node.textContent = 'Error creating widget: could not find model';
+      this.addClass('jupyter-widgets');
       return Promise.resolve();
     }
   }


### PR DESCRIPTION
Fixes #2076.

Went for the simpler solution for now, as the most important is to better see these error messages when using the Dark Theme in JupyterLab.

### Before

![image](https://user-images.githubusercontent.com/591645/40076593-4b4d4696-584d-11e8-83e3-9f69ea873969.png)

### After

![image](https://user-images.githubusercontent.com/591645/43996694-74febf9a-9dc8-11e8-81f1-5d1c8030063f.png)
