### PR TITLE
Add support for specifying custom icons in ToggleButtons

### DIFF
--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -23,5 +23,5 @@ from .widget_controller import Controller
 from .interaction import interact, interactive, fixed, interact_manual, interactive_output
 from .widget_link import jslink, jsdlink
 from .widget_layout import Layout
-from .widget_media import Image, Video, Audio
+from .widget_media import Image, Icon, Video, Audio
 from .widget_style import Style

--- a/ipywidgets/widgets/tests/test_widget_icon.py
+++ b/ipywidgets/widgets/tests/test_widget_icon.py
@@ -1,0 +1,54 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""Test Icon widget"""
+
+from ipywidgets import Icon, Button, ToggleButtons, ToggleButton
+from .test_widget_image import get_logo_png, LOGO_PNG_DIGEST, assert_equal_hash
+
+
+def test_icon_fontawesome():
+    icon = Icon.fontawesome('home')
+    assert icon.format == 'fontawesome'
+    assert icon.value.decode('utf-8') == 'home'
+
+def test_icon_filename():
+    with get_logo_png() as LOGO_PNG:
+        icon = Icon.from_file(LOGO_PNG)
+        assert icon.format == 'png'
+        assert_equal_hash(icon.value, LOGO_PNG_DIGEST)
+
+def test_coerce_button():
+    button = Button()
+    button.icon is None
+
+    # backwards compatible with a string value (which indicates a fontawesome icon)
+    button = Button(icon='home')
+    assert button.icon.value.decode('utf-8') == 'home'
+    assert button.icon.format == 'fontawesome'
+
+    # check if no copy is made
+    button2 = Button(icon=button.icon)
+    assert button2.icon is button.icon
+
+def test_coerce_toggle_button():
+    # backwards compatible with a string value (which indicates a fontawesome icon)
+    button = ToggleButton(icon='home')
+    assert button.icon.value.decode('utf-8') == 'home'
+    assert button.icon.format == 'fontawesome'
+
+    # check if no copy is made
+    button2 = ToggleButton(icon=button.icon)
+    assert button2.icon is button.icon
+
+def test_coerce_toggle_buttons():
+    icon1 = 'home'
+    icon2 = Icon.fontawesome('refresh')
+    buttons = ToggleButtons(values=[''] * 2, icons=[icon1, icon2])
+    assert buttons.icons[0].value.decode('utf-8') == 'home'
+    assert buttons.icons[0].format == 'fontawesome'
+    assert buttons.icons[1].value.decode('utf-8') == 'refresh'
+    assert buttons.icons[1].format == 'fontawesome'
+    assert buttons.icons[1] is icon2
+
+

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -8,6 +8,7 @@ Trait types for html widgets.
 import re
 import traitlets
 import datetime as dt
+from ipython_genutils.py3compat import string_types, PY3
 
 
 _color_names = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred ', 'indigo ', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'transparent', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen']
@@ -141,6 +142,29 @@ class InstanceDict(traitlets.Instance):
     def make_dynamic_default(self):
         return self.klass(*(self.default_args or ()),
                           **(self.default_kwargs or {}))
+
+class InstanceString(traitlets.Instance):
+    """An instance trait which coerces a string to a instance.
+
+    The instance is created by the class constructor or the optional
+    factory.
+    """
+
+    def __init__(self, klass, factory=None, **kwargs):
+        super(InstanceString, self).__init__(klass, **kwargs)
+        self.factory = factory or klass
+
+    def validate(self, obj, value):
+        if isinstance(value, string_types):
+            return super(InstanceString, self).validate(obj, self.factory(value))
+        else:
+            return super(InstanceString, self).validate(obj, value)
+
+    def make_dynamic_default(self):
+        if not self.default_args:
+            return None
+        else:
+            return self.factory(*self.default_args, **(self.default_kwargs or {}))
 
 
 # The regexp is taken

--- a/ipywidgets/widgets/widget_bool.py
+++ b/ipywidgets/widgets/widget_bool.py
@@ -9,8 +9,10 @@ Represents a boolean using a widget.
 from .widget_description import DescriptionWidget
 from .widget_core import CoreWidget
 from .valuewidget import ValueWidget
-from .widget import register
-from traitlets import Unicode, Bool, CaselessStrEnum
+from .widget_media import Icon
+from .widget import register, widget_serialization
+from .trait_types import InstanceString
+from traitlets import Unicode, Bool, CaselessStrEnum, Instance
 
 
 class _Bool(DescriptionWidget, ValueWidget, CoreWidget):
@@ -63,7 +65,7 @@ class ToggleButton(_Bool):
     _model_name = Unicode('ToggleButtonModel').tag(sync=True)
 
     tooltip = Unicode(help="Tooltip caption of the toggle button.").tag(sync=True)
-    icon = Unicode('', help= "Font-awesome icon.").tag(sync=True)
+    icon = InstanceString(Icon, Icon.fontawesome, default_value=None, allow_none=True, help= "Optional button icon.").tag(sync=True, **widget_serialization)
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''], default_value='',

--- a/ipywidgets/widgets/widget_bool.py
+++ b/ipywidgets/widgets/widget_bool.py
@@ -58,14 +58,14 @@ class ToggleButton(_Bool):
 	      description displayed next to the button
     tooltip: str
         tooltip caption of the toggle button
-    icon: str
-        font-awesome icon name
+    icon: Icon
+        button icon
     """
     _view_name = Unicode('ToggleButtonView').tag(sync=True)
     _model_name = Unicode('ToggleButtonModel').tag(sync=True)
 
     tooltip = Unicode(help="Tooltip caption of the toggle button.").tag(sync=True)
-    icon = InstanceString(Icon, Icon.fontawesome, default_value=None, allow_none=True, help= "Optional button icon.").tag(sync=True, **widget_serialization)
+    icon = InstanceString(Icon, Icon.fontawesome, default_value=None, allow_none=True, help= "Button icon.").tag(sync=True, **widget_serialization)
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''], default_value='',

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -63,16 +63,6 @@ class Button(DOMWidget, CoreWidget):
         self._click_handlers = CallbackDispatcher()
         self.on_msg(self._handle_button_msg)
 
-    # @validate('icon')
-    # def _validate_icon(self, proposal):
-    #     """Strip 'fa-' if necessary'"""
-    #     value = proposal['value']
-    #     if value.startswith('fa-'):
-    #         warnings.warn("icons names no longer start with 'fa-', "
-    #         "just use the class name itself (for example, 'check' instead of 'fa-check')", DeprecationWarning)
-    #         value = value[3:]
-    #     return value
-
     def on_click(self, callback, remove=False):
         """Register a callback to execute when the button is clicked.
 

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -11,7 +11,8 @@ from .domwidget import DOMWidget
 from .widget import CallbackDispatcher, register, widget_serialization
 from .widget_core import CoreWidget
 from .widget_style import Style
-from .trait_types import Color, InstanceDict
+from .widget_media import Icon
+from .trait_types import Color, InstanceDict, InstanceString
 
 from traitlets import Unicode, Bool, CaselessStrEnum, Instance, validate, default
 import warnings
@@ -49,7 +50,7 @@ class Button(DOMWidget, CoreWidget):
     description = Unicode(help="Button label.").tag(sync=True)
     tooltip = Unicode(help="Tooltip caption of the button.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes.").tag(sync=True)
-    icon = Unicode('', help="Font-awesome icon name, without the 'fa-' prefix.").tag(sync=True)
+    icon = InstanceString(Icon, Icon.fontawesome, default_value=None, allow_none=True, help= "Optional button icon.").tag(sync=True, **widget_serialization)
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''], default_value='',
@@ -62,15 +63,15 @@ class Button(DOMWidget, CoreWidget):
         self._click_handlers = CallbackDispatcher()
         self.on_msg(self._handle_button_msg)
 
-    @validate('icon')
-    def _validate_icon(self, proposal):
-        """Strip 'fa-' if necessary'"""
-        value = proposal['value']
-        if value.startswith('fa-'):
-            warnings.warn("icons names no longer start with 'fa-', "
-            "just use the class name itself (for example, 'check' instead of 'fa-check')", DeprecationWarning)
-            value = value[3:]
-        return value
+    # @validate('icon')
+    # def _validate_icon(self, proposal):
+    #     """Strip 'fa-' if necessary'"""
+    #     value = proposal['value']
+    #     if value.startswith('fa-'):
+    #         warnings.warn("icons names no longer start with 'fa-', "
+    #         "just use the class name itself (for example, 'check' instead of 'fa-check')", DeprecationWarning)
+    #         value = value[3:]
+    #     return value
 
     def on_click(self, callback, remove=False):
         """Register a callback to execute when the button is clicked.

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -39,8 +39,8 @@ class Button(DOMWidget, CoreWidget):
        description displayed next to the button
     tooltip: str
        tooltip caption of the toggle button
-    icon: str
-       font-awesome icon name
+    icon: Icon
+       button icon
     disabled: bool
        whether user interaction is enabled
     """
@@ -50,7 +50,7 @@ class Button(DOMWidget, CoreWidget):
     description = Unicode(help="Button label.").tag(sync=True)
     tooltip = Unicode(help="Tooltip caption of the button.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes.").tag(sync=True)
-    icon = InstanceString(Icon, Icon.fontawesome, default_value=None, allow_none=True, help= "Optional button icon.").tag(sync=True, **widget_serialization)
+    icon = InstanceString(Icon, Icon.fontawesome, default_value=None, allow_none=True, help= "Button icon.").tag(sync=True, **widget_serialization)
 
     button_style = CaselessStrEnum(
         values=['primary', 'success', 'info', 'warning', 'danger', ''], default_value='',

--- a/ipywidgets/widgets/widget_media.py
+++ b/ipywidgets/widgets/widget_media.py
@@ -2,12 +2,13 @@
 # Distributed under the terms of the Modified BSD License.
 
 import mimetypes
+import warnings
 
 from .widget_core import CoreWidget
 from .domwidget import DOMWidget
 from .valuewidget import ValueWidget
 from .widget import register
-from traitlets import Unicode, CUnicode, Bytes, Bool
+from traitlets import Unicode, CUnicode, Bytes, Bool, validate
 from .trait_types import bytes_serialization
 
 
@@ -207,6 +208,18 @@ class Icon(_Media):
 
     def __repr__(self):
         return self._get_repr(Icon)
+
+    @validate('value')
+    def _validate_value(self, proposal):
+        """Strip 'fa-' if necessary'"""
+        format = self.format
+        value = proposal['value']
+        if format == 'fontawesome':
+            if value.decode('utf-8').startswith('fa-'):
+                warnings.warn("icons names no longer start with 'fa-', "
+                "just use the class name itself (for example, 'check' instead of 'fa-check')", DeprecationWarning)
+                value = value[3:]
+        return value
 
 
 @register

--- a/ipywidgets/widgets/widget_media.py
+++ b/ipywidgets/widgets/widget_media.py
@@ -141,7 +141,46 @@ class _Media(DOMWidget, ValueWidget, CoreWidget):
         signature = ', '.join(signature)
         return '%s(%s)' % (class_name, signature)
 
+
+@register
+class Image(_Media):
+    """Displays an image as a widget.
+
+    The `value` of this widget accepts a byte string.  The byte string is the
+    raw image data that you want the browser to display.  You can explicitly
+    define the format of the byte string using the `format` trait (which
+    defaults to "png").
+
+    If you pass `"url"` to the `"format"` trait, `value` will be interpreted
+    as a URL as bytes encoded in UTF-8.
+    """
+    _view_name = Unicode('ImageView').tag(sync=True)
+    _model_name = Unicode('ImageModel').tag(sync=True)
+
+    # Define the custom state properties to sync with the front-end
+    format = Unicode('png', help="The format of the image.").tag(sync=True)
+    width = CUnicode(help="Width of the image in pixels.").tag(sync=True)
+    height = CUnicode(help="Height of the image in pixels.").tag(sync=True)
+
+    @classmethod
+    def from_file(cls, filename, **kwargs):
+        return cls._from_file('image', filename, **kwargs)
+
+    def __repr__(self):
+        return self._get_repr(Image)
+
+
+@register
 class Icon(_Media):
+    """Display a fontawesome icon or image.
+
+    Icon is a superset of Image from the user perspective, but provides a
+    different API on the front-end. Icon is used for buttons etc.
+
+    The most common way to use Icon is to call the `Icon.fontawesome` factory
+    method.
+
+    """
     _view_name = Unicode('IconView').tag(sync=True)
     _model_name = Unicode('IconModel').tag(sync=True)
 
@@ -168,35 +207,6 @@ class Icon(_Media):
 
     def __repr__(self):
         return self._get_repr(Icon)
-
-@register
-class Image(_Media):
-    """Displays an image as a widget.
-
-    '', help="Font-awesome icon name, without the 'fa-' prefix."
-
-    The `value` of this widget accepts a byte string.  The byte string is the
-    raw image data that you want the browser to display.  You can explicitly
-    define the format of the byte string using the `format` trait (which
-    defaults to "png").
-
-    If you pass `"url"` to the `"format"` trait, `value` will be interpreted
-    as a URL as bytes encoded in UTF-8.
-    """
-    _view_name = Unicode('ImageView').tag(sync=True)
-    _model_name = Unicode('ImageModel').tag(sync=True)
-
-    # Define the custom state properties to sync with the front-end
-    format = Unicode('png', help="The format of the image.").tag(sync=True)
-    width = CUnicode(help="Width of the image in pixels.").tag(sync=True)
-    height = CUnicode(help="Height of the image in pixels.").tag(sync=True)
-
-    @classmethod
-    def from_file(cls, filename, **kwargs):
-        return cls._from_file('image', filename, **kwargs)
-
-    def __repr__(self):
-        return self._get_repr(Image)
 
 
 @register

--- a/ipywidgets/widgets/widget_media.py
+++ b/ipywidgets/widgets/widget_media.py
@@ -141,10 +141,39 @@ class _Media(DOMWidget, ValueWidget, CoreWidget):
         signature = ', '.join(signature)
         return '%s(%s)' % (class_name, signature)
 
+class Icon(_Media):
+    _view_name = Unicode('IconView').tag(sync=True)
+    _model_name = Unicode('IconModel').tag(sync=True)
+
+    # Define the custom state properties to sync with the front-end
+    format = Unicode('png', help="The format of the icon.").tag(sync=True)
+    width = CUnicode(help="Width of the icon in pixels.").tag(sync=True)
+    height = CUnicode(help="Height of the icon in pixels.").tag(sync=True)
+
+    @classmethod
+    def from_file(cls, filename, **kwargs):
+        return cls._from_file('image', filename, **kwargs)
+
+    @classmethod
+    def fontawesome(cls, name, **kwargs):
+        """Creates an fontawasome icon (without the fa-prefix)
+
+        Example:
+
+        >>> icon = Icon.fontawesome('home')
+        >>> button = Button(icon=icon, description='Home')
+
+        """
+        return cls(value=name.encode('utf-8'), format='fontawesome', **kwargs)
+
+    def __repr__(self):
+        return self._get_repr(Icon)
 
 @register
 class Image(_Media):
     """Displays an image as a widget.
+
+    '', help="Font-awesome icon name, without the 'fa-' prefix."
 
     The `value` of this widget accepts a byte string.  The byte string is the
     raw image data that you want the browser to display.  You can explicitly

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -164,7 +164,7 @@ class _Selection(DescriptionWidget, ValueWidget, CoreWidget):
     _options_full = None
 
     # This being read-only means that it cannot be changed by the user.
-    _options_labels = TypedTuple(trait=Unicode(), read_only=True, help="The labels for the options.").tag(sync=True)
+    _options_labels = TypedTuple(trait=Unicode, read_only=True, help="The labels for the options.").tag(sync=True)
 
     disabled = Bool(help="Enable or disable user changes").tag(sync=True)
 
@@ -432,7 +432,7 @@ class ToggleButtons(_Selection):
     _model_name = Unicode('ToggleButtonsModel').tag(sync=True)
 
     tooltips = TypedTuple(Unicode(), help="Tooltips for each button.").tag(sync=True)
-    icons = TypedTuple(trait=InstanceString(Icon, Icon.fontawesome), help="Icons names for each button (FontAwesome names without the fa- prefix).").tag(sync=True, **widget_serialization)
+    icons = TypedTuple(trait=InstanceString(Icon, Icon.fontawesome), help="Icons for each button.").tag(sync=True, **widget_serialization)
     style = InstanceDict(ToggleButtonsStyle).tag(sync=True, **widget_serialization)
 
     button_style = CaselessStrEnum(

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -17,10 +17,11 @@ from .widget_description import DescriptionWidget, DescriptionStyle
 from .valuewidget import ValueWidget
 from .widget_core import CoreWidget
 from .widget_style import Style
-from .trait_types import InstanceDict, TypedTuple
+from .widget_media import Icon
+from .trait_types import InstanceDict, TypedTuple, InstanceString
 from .widget import register, widget_serialization
 from .docutils import doc_subst
-from traitlets import (Unicode, Bool, Int, Any, Dict, TraitError, CaselessStrEnum,
+from traitlets import (Unicode, Bool, Int, Any, Dict, List, TraitError, CaselessStrEnum,
                        Tuple, Union, observe, validate)
 from ipython_genutils.py3compat import unicode_type
 
@@ -431,7 +432,7 @@ class ToggleButtons(_Selection):
     _model_name = Unicode('ToggleButtonsModel').tag(sync=True)
 
     tooltips = TypedTuple(Unicode(), help="Tooltips for each button.").tag(sync=True)
-    icons = TypedTuple(Unicode(), help="Icons names for each button (FontAwesome names without the fa- prefix).").tag(sync=True)
+    icons = TypedTuple(trait=InstanceString(Icon, Icon.fontawesome), help="Icons names for each button (FontAwesome names without the fa- prefix).").tag(sync=True, **widget_serialization)
     style = InstanceDict(ToggleButtonsStyle).tag(sync=True, **widget_serialization)
 
     button_style = CaselessStrEnum(

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -416,9 +416,9 @@ class ToggleButtons(_Selection):
         same length as `options`.
 
     icons: list
-        Icons to show on the buttons. This must be the name
-        of a font-awesome icon. See `http://fontawesome.io/icons/`
-        for a list of icons.
+        Icons to show on the buttons. This should either be the name
+        of a font-awesome icon or a string following the data URI scheme. See
+        `http://fontawesome.io/icons/` for a list of font-awesome icons.
 
     button_style: str
         One of 'primary', 'success', 'info', 'warning' or
@@ -578,7 +578,7 @@ class SelectionSlider(_SelectionNonempty):
 class SelectionRangeSlider(_MultipleSelectionNonempty):
     """
     Slider to select multiple contiguous items from a list.
-    
+
     The index, value, and label attributes contain the start and end of
     the selection range, not all items in the range.
 

--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -264,6 +264,10 @@
     width: var(--jp-widgets-inline-width-short);
 }
 
+.widget-button-icon {
+    cursor: pointer;
+}
+
 /* Widget Label Styling */
 
 /* Override Bootstrap label css */

--- a/packages/controls/src/index.ts
+++ b/packages/controls/src/index.ts
@@ -8,6 +8,7 @@ export * from './widget_bool';
 export * from './widget_button';
 export * from './widget_box';
 export * from './widget_image';
+export * from './widget_icon';
 export * from './widget_video';
 export * from './widget_audio';
 export * from './widget_color';

--- a/packages/controls/src/widget_bool.ts
+++ b/packages/controls/src/widget_bool.ts
@@ -215,6 +215,7 @@ class ToggleButtonView extends DOMWidgetView {
                     let icon_placeholder = document.createElement('div');
                     this.el.appendChild(icon_placeholder);
                     this.iconView = <IconView> await this.create_child_view(icon)
+                    this.iconView.el.classList.add('widget-button-icon')
                     if (description.length === 0) {
                         this.iconView.el.classList.add('center');
                     }

--- a/packages/controls/src/widget_bool.ts
+++ b/packages/controls/src/widget_bool.ts
@@ -212,13 +212,22 @@ class ToggleButtonView extends DOMWidgetView {
             } else {
                 this.el.textContent = '';
                 if (icon) {
+                    let icon_placeholder = document.createElement('div');
+                    this.el.appendChild(icon_placeholder);
                     this.iconView = <IconView> await this.create_child_view(icon)
                     if (description.length === 0) {
                         this.iconView.el.classList.add('center');
                     }
-                    this.el.appendChild(this.iconView.el);
-                    this.iconView.listenTo(icon, 'change', () => this.update())
-                }
+                    /*
+                    since the await above is async, in the mean time there could
+                    have been another update executed. This could have removed
+                    the icon, which means that the placeholders parent is not this.el
+                    */
+                    if(icon_placeholder.parentNode == this.el) {
+                        this.el.replaceChild(this.iconView.el, icon_placeholder);
+                        this.iconView.listenTo(icon, 'change', () => this.update())
+                    }
+            }
                 this.el.appendChild(document.createTextNode(description));
             }
         }

--- a/packages/controls/src/widget_button.ts
+++ b/packages/controls/src/widget_button.ts
@@ -98,12 +98,21 @@ class ButtonView extends DOMWidgetView {
             }
             this.el.textContent = '';
             if (icon) {
+                let icon_placeholder = document.createElement('div');
+                this.el.appendChild(icon_placeholder);
                 this.iconView = <IconView> await this.create_child_view(icon)
                 if (description.length === 0 && this.iconView) {
                     this.iconView.el.classList.add('center');
                 }
-                this.el.appendChild(this.iconView.el);
-                this.iconView.listenTo(icon, 'change', () => this.update())
+                /*
+                since the await above is async, in the mean time there could
+                have been another update executed. This could have removed
+                the icon, which means that the placeholders parent is not this.el
+                */
+                if(icon_placeholder.parentNode == this.el) {
+                    this.el.replaceChild(this.iconView.el, icon_placeholder);
+                    this.iconView.listenTo(icon, 'change', () => this.update())
+                }
             }
             this.el.appendChild(document.createTextNode(description));
         }

--- a/packages/controls/src/widget_button.ts
+++ b/packages/controls/src/widget_button.ts
@@ -101,6 +101,7 @@ class ButtonView extends DOMWidgetView {
                 let icon_placeholder = document.createElement('div');
                 this.el.appendChild(icon_placeholder);
                 this.iconView = <IconView> await this.create_child_view(icon)
+                this.iconView.el.classList.add('widget-button-icon')
                 if (description.length === 0 && this.iconView) {
                     this.iconView.el.classList.add('center');
                 }

--- a/packages/controls/src/widget_icon.ts
+++ b/packages/controls/src/widget_icon.ts
@@ -1,0 +1,131 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+    DOMWidgetView
+} from '@jupyter-widgets/base';
+
+import {
+    CoreDOMWidgetModel
+} from './widget_core';
+
+import * as _ from 'underscore';
+
+export
+class IconModel extends CoreDOMWidgetModel {
+    defaults() {
+        return _.extend(super.defaults(), {
+            _model_name: 'IconModel',
+            _view_name: 'IconView',
+            format: 'png',
+            width: '',
+            height: '',
+            value: new DataView(new ArrayBuffer(0))
+        });
+    }
+
+    static serializers = {
+        ...CoreDOMWidgetModel.serializers,
+        value: {serialize: (value, manager) => {
+            return new DataView(value.buffer.slice(0));
+        }}
+    };
+}
+
+export
+class IconView extends DOMWidgetView {
+    render() {
+        /**
+         * Called when view is rendered.
+         */
+        super.render();
+        this.pWidget.addClass('jupyter-widgets');
+        this.pWidget.addClass('widget-image');
+        this.update(); // Set defaults.
+    }
+
+    update() {
+        /**
+         * Update the contents of this view
+         *
+         * Called when the model is changed.  The model may have been
+         * changed by another view or by a state update from the back-end.
+         */
+
+        let format = this.model.get('format');
+        let value = this.model.get('value');
+        if(this.img) {
+            this.el.removeChild(this.img)
+            if (this.img.src) {
+                URL.revokeObjectURL(this.img.src);
+            }
+            this.img = null;
+        }
+        // remove the fontawesome classes
+        Array.prototype.slice.call(this.el.classList).forEach((name) => {
+            if(name === 'fa' || name.startsWith('fa-'))
+                this.el.classList.remove(name)
+        });
+        if (format === 'fontawesome') {
+            let iconName = (new TextDecoder('utf-8')).decode(value.buffer);
+            this.el.classList.add('fa');
+            this.el.classList.add('fa-' + iconName);
+        } else {
+
+            let url;
+            if (format !== 'url') {
+                let blob = new Blob([value], {type: `image/${this.model.get('format')}`});
+                url = URL.createObjectURL(blob);
+            } else {
+                url = (new TextDecoder('utf-8')).decode(value.buffer);
+            }
+
+            this.img = document.createElement('img');
+            this.img.src = url;
+            // Clean up the old objectURL
+            // let oldurl = this.el.src;
+            // this.el.src = url;
+            // if (oldurl && typeof oldurl !== 'string') {
+            //     URL.revokeObjectURL(oldurl);
+            // }
+            let width = this.model.get('width');
+            if (width !== undefined && width.length > 0) {
+                this.img.setAttribute('width', width);
+            } else {
+                this.img.removeAttribute('width');
+            }
+
+            let height = this.model.get('height');
+            if (height !== undefined && height.length > 0) {
+                this.img.setAttribute('height', height);
+            } else {
+                this.img.removeAttribute('height');
+            }
+            this.el.appendChild(this.img);
+            }
+        return super.update();
+    }
+
+    remove() {
+        if (this.img && this.img.src) {
+            URL.revokeObjectURL(this.img.src);
+        }
+        super.remove();
+    }
+
+    /**
+     * The default tag name.
+     *
+     * #### Notes
+     * This is a read-only attribute.
+     */
+    get tagName() {
+        // We can't make this an attribute with a default value
+        // since it would be set after it is needed in the
+        // constructor.
+        return 'span';
+    }
+
+    el: HTMLElement;
+    img: HTMLImageElement;
+}

--- a/packages/controls/src/widget_icon.ts
+++ b/packages/controls/src/widget_icon.ts
@@ -82,12 +82,6 @@ class IconView extends DOMWidgetView {
 
             this.img = document.createElement('img');
             this.img.src = url;
-            // Clean up the old objectURL
-            // let oldurl = this.el.src;
-            // this.el.src = url;
-            // if (oldurl && typeof oldurl !== 'string') {
-            //     URL.revokeObjectURL(oldurl);
-            // }
             let width = this.model.get('width');
             if (width !== undefined && width.length > 0) {
                 this.img.setAttribute('width', width);

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -497,10 +497,12 @@ class ToggleButtonsView extends DescriptionView {
             });
         }
 
+        buttons = this.buttongroup.querySelectorAll('button');
         // Select active button.
         items.forEach(function(item: any, index: number) {
-            let item_query = '[data-value="' + encodeURIComponent(item) + '"]';
-            let button = view.buttongroup.querySelector(item_query);
+            // let item_query = '[data-value="' + encodeURIComponent(item) + '"]';
+            // let button = view.buttongroup.querySelector(item_query);
+            let button = buttons[index];
             if (view.model.get('index') === index) {
                 button.classList.add('mod-active');
             } else {
@@ -563,7 +565,12 @@ class ToggleButtonsView extends DescriptionView {
      * model to update.
      */
     _handle_click (event) {
-        this.model.set('index', parseInt(event.target.value), {updated_view: this});
+        let clickedButton = event.target;
+        while(clickedButton.nodeName !== 'BUTTON')
+            clickedButton = clickedButton.parentElement;
+        let buttons = Array.prototype.slice.call(this.buttongroup.querySelectorAll('button'));
+        let index = buttons.indexOf(clickedButton);
+        this.model.set('index', index, {updated_view: this});
         this.touch();
         // We also send a clicked event, since the value is only set if it changed.
         // See https://github.com/jupyter-widgets/ipywidgets/issues/763

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -463,11 +463,22 @@ class ToggleButtonsView extends DescriptionView {
                     item_html = utils.escape_html(item);
                 }
 
-                let icon = document.createElement('i');
-                let button = document.createElement('button');
+                let icon
                 if (icons[index]) {
+                  if (icons[index].startsWith('data:')) {
+                    icon = document.createElement('img');
+                    icon.width = '16';
+                    icon.height = '16';
+                    icon.src = icons[index];
+                  } else {
+                    icon = document.createElement('i');
                     icon.className = 'fa fa-' + icons[index];
+                  }
+                } else {
+                  icon = document.createElement('i');
                 }
+
+                let button = document.createElement('button');
                 button.setAttribute('type', 'button');
                 button.className = 'widget-toggle-button jupyter-button';
                 if (previous_bstyle) {

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -440,19 +440,18 @@ class ToggleButtonsView extends DescriptionView {
      * changed by another view or by a state update from the back-end.
      */
     update(options?) {
-        let view = this;
-        let items: string[] = this.model.get('_options_labels');
+        let labels: string[] = this.model.get('_options_labels');
         let icons = this.model.get('icons') || [];
         let previous_icons = this.model.previous('icons') || [];
         let previous_bstyle = ToggleButtonsView.classMap[this.model.previous('button_style')] || '';
-        let tooltips = view.model.get('tooltips') || [];
+        let tooltips = this.model.get('tooltips') || [];
         let disabled = this.model.get('disabled');
         let buttons = this.buttongroup.querySelectorAll('button');
         let values = _.pluck(buttons, 'value');
         let stale = false;
 
-        for (let i = 0, len = items.length; i < len; ++i) {
-            if (values[i] !== items[i] || icons[i] !== previous_icons[i]) {
+        for (let i = 0, len = labels.length; i < len; ++i) {
+            if (values[i] !== labels[i] || icons[i] !== previous_icons[i]) {
                 stale = true;
                 break;
             }
@@ -462,16 +461,16 @@ class ToggleButtonsView extends DescriptionView {
             if(this.iconViews) {
                 this.iconViews.forEach((i) => i.remove())
             }
-            this.iconViews = new Array(items.length)
-            // Add items to the DOM.
+            this.iconViews = new Array(labels.length)
+            // Add labels to the DOM.
             this.buttongroup.textContent = '';
-            items.forEach(async (item: any, index: number) => {
-                let item_html;
-                let empty = item.trim().length === 0 && !icons[index];
+            labels.forEach(async (label: any, index: number) => {
+                let label_html;
+                let empty = label.trim().length === 0 && !icons[index];
                 if (empty) {
-                    item_html = '&nbsp;';
+                    label_html = '&nbsp;';
                 } else {
-                    item_html = utils.escape_html(item);
+                    label_html = utils.escape_html(label);
                 }
 
                 let button = document.createElement('button');
@@ -480,16 +479,15 @@ class ToggleButtonsView extends DescriptionView {
                 if (previous_bstyle) {
                     button.classList.add(previous_bstyle);
                 }
-                button.innerHTML = item_html;
-                button.setAttribute('data-value', encodeURIComponent(item));
+                button.innerHTML = label_html;
+                // button.setAttribute('data-value', encodeURIComponent(label));
                 button.setAttribute('value', index.toString());
-                // let icon = icons[index];
                 button.disabled = disabled;
                 if (tooltips[index]) {
                     button.setAttribute('title', tooltips[index]);
                 }
-                view.update_style_traits(button);
-                view.buttongroup.appendChild(button);
+                this.update_style_traits(button);
+                this.buttongroup.appendChild(button);
                 if(icons[index]) {
                     this.iconViews[index] = <IconView> await this.create_child_view(icons[index]);
                     button.appendChild(this.iconViews[index].el);
@@ -499,11 +497,9 @@ class ToggleButtonsView extends DescriptionView {
 
         buttons = this.buttongroup.querySelectorAll('button');
         // Select active button.
-        items.forEach(function(item: any, index: number) {
-            // let item_query = '[data-value="' + encodeURIComponent(item) + '"]';
-            // let button = view.buttongroup.querySelector(item_query);
+        labels.forEach((label: any, index: number) => {
             let button = buttons[index];
-            if (view.model.get('index') === index) {
+            if (this.model.get('index') === index) {
                 button.classList.add('mod-active');
             } else {
                 button.classList.remove('mod-active');

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -489,9 +489,19 @@ class ToggleButtonsView extends DescriptionView {
                 this.update_style_traits(button);
                 this.buttongroup.appendChild(button);
                 if(icons[index]) {
+                    let icon_placeholder = document.createElement('div');
+                    button.appendChild(icon_placeholder);
                     this.iconViews[index] = <IconView> await this.create_child_view(icons[index]);
                     this.iconViews[index].el.classList.add('widget-button-icon')
-                    button.appendChild(this.iconViews[index].el);
+                    /*
+                    since the await above is async, in the mean time there could
+                    have been another update executed. This could have removed
+                    the icon, which means that the placeholders parent is not this.el
+                    */
+                    if(icon_placeholder.parentNode == button) {
+                        button.replaceChild(this.iconViews[index].el, icon_placeholder);
+                        this.iconViews[index].listenTo(icons[index], 'change', () => this.update())
+                    }
                 }
             });
         }

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -490,6 +490,7 @@ class ToggleButtonsView extends DescriptionView {
                 this.buttongroup.appendChild(button);
                 if(icons[index]) {
                     this.iconViews[index] = <IconView> await this.create_child_view(icons[index]);
+                    this.iconViews[index].el.classList.add('widget-button-icon')
                     button.appendChild(this.iconViews[index].el);
                 }
             });

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -573,6 +573,8 @@ class ToggleButtonsView extends DescriptionView {
      */
     _handle_click (event) {
         let clickedButton = event.target;
+        // The target may actually be a child node of the button, to find it
+        // we find the first button ancestor.
         while(clickedButton.nodeName !== 'BUTTON')
             clickedButton = clickedButton.parentElement;
         let buttons = Array.prototype.slice.call(this.buttongroup.querySelectorAll('button'));

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -163,7 +163,7 @@ Attribute        | Type             | Default          | Help
 `button_style`   | string (one of `'primary'`, `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the button.
 `description`    | string           | `''`             | Button label.
 `disabled`       | boolean          | `false`          | Enable or disable user changes.
-`icon`           | string           | `''`             | Font-awesome icon name, without the 'fa-' prefix.
+`icon`           | `null` or reference to Icon widget | reference to new instance | Button icon.
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to ButtonStyle widget | reference to new instance | 
 `tooltip`        | string           | `''`             | Tooltip caption of the button.
@@ -526,6 +526,23 @@ Attribute        | Type             | Default          | Help
 `placeholder`    | string           | `'\u200b'`       | Placeholder text to display when nothing has been typed
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | string           | `''`             | String value
+
+### IconModel (@jupyter-widgets/controls, 1.4.0); IconView (@jupyter-widgets/controls, 1.4.0)
+
+Attribute        | Type             | Default          | Help
+-----------------|------------------|------------------|----
+`_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
+`_model_module`  | string           | `'@jupyter-widgets/controls'` | 
+`_model_module_version` | string           | `'1.4.0'`        | 
+`_model_name`    | string           | `'IconModel'`    | 
+`_view_module`   | string           | `'@jupyter-widgets/controls'` | 
+`_view_module_version` | string           | `'1.4.0'`        | 
+`_view_name`     | string           | `'IconView'`     | 
+`format`         | string           | `'png'`          | The format of the icon.
+`height`         | string           | `''`             | Height of the icon in pixels.
+`layout`         | reference to Layout widget | reference to new instance | 
+`value`          | Bytes            | `b''`            | The media data as a byte string.
+`width`          | string           | `''`             | Width of the icon in pixels.
 
 ### ImageModel (@jupyter-widgets/controls, 1.4.0); ImageView (@jupyter-widgets/controls, 1.4.0)
 
@@ -913,7 +930,7 @@ Attribute        | Type             | Default          | Help
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
 `disabled`       | boolean          | `false`          | Enable or disable user changes.
-`icon`           | string           | `''`             | Font-awesome icon.
+`icon`           | `null` or reference to Icon widget | reference to new instance | Button icon.
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `tooltip`        | string           | `''`             | Tooltip caption of the toggle button.
@@ -935,7 +952,7 @@ Attribute        | Type             | Default          | Help
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
 `disabled`       | boolean          | `false`          | Enable or disable user changes
-`icons`          | array of string  | `[]`             | Icons names for each button (FontAwesome names without the fa- prefix).
+`icons`          | array of reference to Icon widget | `[]`             | Icons for each button.
 `index`          | `null` or number (integer) | `null`           | Selected index
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to ToggleButtonsStyle widget | reference to new instance | 


### PR DESCRIPTION
This adds support for specifying custom icons via the data URI mechanism in ToggleButtons. Here is a preview:

<img width="1053" alt="screen shot 2018-08-25 at 16 29 33" src="https://user-images.githubusercontent.com/314716/44622315-179b4000-a884-11e8-8164-102e21e6f311.png">

A few open questions:

* One thing I wasn't quite sure about is how the icon size should be handled, and how to make sure the icons are properly centered (in the example above there is a slight vertical offset for the two custom icons) - I'm not familiar enough with the notebook CSS.

* What is the mechanism for adding tests? I can't see any tests currently for ToggleButtons currently?

* I can add the same mechanism for ToggleButton once things are polished with ToggleButtons.

_Impremented during the JupyterCon 2018 sprint_