### PR TITLE
Make `d3-format` dependency consistent with JLab's

### DIFF
--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -75,7 +75,7 @@
     "@phosphor/messaging": "^1.2.1",
     "@phosphor/signaling": "^1.2.0",
     "@phosphor/widgets": "^1.3.0",
-    "d3-format": "^0.5.1",
+    "d3-format": "^1.3.0",
     "jquery": "^3.1.1",
     "jquery-ui": "^1.12.1",
     "underscore": "^1.8.3"


### PR DESCRIPTION
Follows-up and closes (#2184)