### PR TITLE
Make the CDN configurable

### DIFF
--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -122,7 +122,8 @@ html_template = """
     </script>
 
     <!-- Load IPywidgets bundle for embedding. -->
-    <script 
+    <script
+      data-jupyter-widgets-cdn="https://cdn.jsdelivr.net/npm/"
       src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js" 
       crossorigin="anonymous">
     </script>
@@ -176,6 +177,9 @@ In this example, we used a Python string for the template, and used the
 `format` method to interpolate the state. For embedding in more complex
 documents, you may want to use a templating engine like
 [Jinja2](http://jinja.pocoo.org/).
+
+We also change the CDN from its default of unpkg to use jsdelivr by setting the
+`data-jupyter-widgets-cdn` attribute.
 
 In all embedding functions in `ipywidgets.embed`, the state of all widgets
 known to the widget manager is included by default. You can alternatively
@@ -262,12 +266,16 @@ documentation. An illustration of this is the http://jupyter.org/widgets
 gallery.
 
 The widget embedder attempts to fetch the model and view implementation of the
-custom widget from the npm CDN https://unpkg.com. The URL that is requested
+custom widget from the npm CDN https://unpkg.com by default. The URL that is requested
 for, e.g. the `bqplot` module name, with the semver range `^2.0.0` is
 
 `https://unpkg.com/bqplot@^2.0.0/dist/index.js`
 
 which holds the webpack bundle for the bqplot library.
+
+While the default CDN is using https://unpkg.com it can be configured by
+setting the optional `data-jupyter-widgets-cdn` attribute for script tag which loads `embed-amd.js`,
+as shown in the example above.
 
 The [widget-cookiecutter](https://github.com/jupyter/widget-cookiecutter)
 template project contains a template project for a custom widget library

--- a/packages/html-manager/src/libembed-amd.ts
+++ b/packages/html-manager/src/libembed-amd.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-declare var __widgets_cdn__:string;
-__widgets_cdn__ = (window as any).__widgets_cdn__ || 'https://unpkg.com';
+const __widgets_cdn__ = (window as any).__widgets_cdn__ || 'https://unpkg.com';
 
 import * as libembed from './libembed';
 

--- a/packages/html-manager/src/libembed-amd.ts
+++ b/packages/html-manager/src/libembed-amd.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+declare var __widgets_cdn__:string;
+__widgets_cdn__ = (window as any).__widgets_cdn__ || 'https://unpkg.com';
+
 import * as libembed from './libembed';
 
 /**
@@ -35,14 +38,14 @@ function moduleNameToCDNUrl(moduleName: string, moduleVersion: string) {
         fileName = moduleName.substr(index+1);
         packageName = moduleName.substr(0, index);
     }
-    return `https://unpkg.com/${packageName}@${moduleVersion}/dist/${fileName}`;
+    return `${__widgets_cdn__}/${packageName}@${moduleVersion}/dist/${fileName}`;
 }
 
 function requireLoader(moduleName: string, moduleVersion: string) {
     return requirePromise([`${moduleName}`]).catch((err) => {
         let failedId = err.requireModules && err.requireModules[0];
         if (failedId) {
-            console.log(`Falling back to unpkg.com for ${moduleName}@${moduleVersion}`);
+            console.log(`Falling back to ${__widgets_cdn__} for ${moduleName}@${moduleVersion}`);
             let require = (window as any).requirejs;
             if (require === undefined) {
                 throw new Error("Requirejs is needed, please ensure it is loaded on the page.");

--- a/packages/html-manager/src/libembed-amd.ts
+++ b/packages/html-manager/src/libembed-amd.ts
@@ -1,9 +1,15 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-const __jupyter_widgets_cdn__ = (window as any).__jupyter_widgets_cdn__ || 'https://unpkg.com';
-
 import * as libembed from './libembed';
+
+let cdn = 'https://unpkg.com/';
+
+// find the data-cdn for any script tag, assuming it is only used for embed-amd.js
+const scripts = document.getElementsByTagName('script');
+Array.prototype.forEach.call(scripts, (script) => {
+    cdn = script.getAttribute('data-jupyter-widgets-cdn') || cdn;
+});
 
 /**
  * Load a package using requirejs and return a promise
@@ -37,15 +43,14 @@ function moduleNameToCDNUrl(moduleName: string, moduleVersion: string) {
         fileName = moduleName.substr(index+1);
         packageName = moduleName.substr(0, index);
     }
-    return `${__jupyter_widgets_cdn__}/${packageName}@${moduleVersion}/dist/${fileName}`;
+    return `${cdn}${packageName}@${moduleVersion}/dist/${fileName}`;
 }
 
 function requireLoader(moduleName: string, moduleVersion: string) {
     return requirePromise([`${moduleName}`]).catch((err) => {
         let failedId = err.requireModules && err.requireModules[0];
         if (failedId) {
-            console.log(`Falling back to ${__jupyter_widgets_cdn__} for ` +
-                        `${moduleName}@${moduleVersion}`);
+            console.log(`Falling back to ${cdn} for ${moduleName}@${moduleVersion}`);
             let require = (window as any).requirejs;
             if (require === undefined) {
                 throw new Error("Requirejs is needed, please ensure it is loaded on the page.");

--- a/packages/html-manager/src/libembed-amd.ts
+++ b/packages/html-manager/src/libembed-amd.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-const __widgets_cdn__ = (window as any).__widgets_cdn__ || 'https://unpkg.com';
+const __jupyter_widgets_cdn__ = (window as any).__jupyter_widgets_cdn__ || 'https://unpkg.com';
 
 import * as libembed from './libembed';
 
@@ -37,14 +37,15 @@ function moduleNameToCDNUrl(moduleName: string, moduleVersion: string) {
         fileName = moduleName.substr(index+1);
         packageName = moduleName.substr(0, index);
     }
-    return `${__widgets_cdn__}/${packageName}@${moduleVersion}/dist/${fileName}`;
+    return `${__jupyter_widgets_cdn__}/${packageName}@${moduleVersion}/dist/${fileName}`;
 }
 
 function requireLoader(moduleName: string, moduleVersion: string) {
     return requirePromise([`${moduleName}`]).catch((err) => {
         let failedId = err.requireModules && err.requireModules[0];
         if (failedId) {
-            console.log(`Falling back to ${__widgets_cdn__} for ${moduleName}@${moduleVersion}`);
+            console.log(`Falling back to ${__jupyter_widgets_cdn__} for ` +
+                        `${moduleName}@${moduleVersion}`);
             let require = (window as any).requirejs;
             if (require === undefined) {
                 throw new Error("Requirejs is needed, please ensure it is loaded on the page.");
@@ -53,7 +54,7 @@ function requireLoader(moduleName: string, moduleVersion: string) {
             conf.paths[moduleName] = moduleNameToCDNUrl(moduleName, moduleVersion);
             require.undef(failedId);
             require.config(conf);
-            
+
             return requirePromise([`${moduleName}`]);
        }
     });
@@ -64,7 +65,7 @@ function requireLoader(moduleName: string, moduleVersion: string) {
  *
  * @param element (default document.documentElement) The element containing widget state and views.
  * @param loader (default requireLoader) The function used to look up the modules containing
- * the widgets' models and views classes. (The default loader looks them up on unpkg.com) 
+ * the widgets' models and views classes. (The default loader looks them up on unpkg.com)
  */
 export
 function renderWidgets(element = document.documentElement, loader: (moduleName: string, moduleVersion: string) => Promise<any>  = requireLoader) {


### PR DESCRIPTION
An alternative to #2185 using a custom data-cdn attribute. Note that this in principle will accept this attribute from any script tag.