### PR TITLE
Fix JS remove_buffers check for data views

### DIFF
--- a/packages/base/src/utils.ts
+++ b/packages/base/src/utils.ts
@@ -167,12 +167,12 @@ function remove_buffers(state): {state: any, buffers: ArrayBuffer[], buffer_path
             for (let i = 0; i < obj.length; i++) {
                 let value = obj[i];
                 if (value) {
-                    if (value.buffer instanceof ArrayBuffer || value instanceof ArrayBuffer) {
+                    if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
                         if (!is_cloned) {
                             obj = obj.slice();
                             is_cloned = true;
                         }
-                        buffers.push(value instanceof ArrayBuffer ? value : value.buffer);
+                        buffers.push(ArrayBuffer.isView(value) ? value.buffer : value);
                         buffer_paths.push(path.concat([i]));
                         // easier to just keep the array, but clear the entry, otherwise we have to think
                         // about array length, much easier this way
@@ -196,16 +196,16 @@ function remove_buffers(state): {state: any, buffers: ArrayBuffer[], buffer_path
                 if (obj.hasOwnProperty(key)) {
                     let value = obj[key];
                     if (value) {
-                        if (value.buffer instanceof ArrayBuffer || value instanceof ArrayBuffer) {
+                        if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
                             if (!is_cloned) {
                                 obj = {...obj};
                                 is_cloned = true;
                             }
-                            buffers.push(value instanceof ArrayBuffer ? value : value.buffer);
+                            buffers.push(ArrayBuffer.isView(value) ? value.buffer : value);
                             buffer_paths.push(path.concat([key]));
                             delete obj[key]; // for objects/dicts we just delete them
                         } else {
-                            let new_value  = remove(value, path.concat([key]));
+                            let new_value = remove(value, path.concat([key]));
                             // only assigned when the value changes, we may serialize objects that don't support assignment
                             if (new_value !== value) {
                                 if (!is_cloned) {

--- a/packages/base/test/src/index.ts
+++ b/packages/base/test/src/index.ts
@@ -3,3 +3,4 @@
 
 import './manager_test';
 import './widget_test';
+import './utils_test';

--- a/packages/base/test/src/utils_test.ts
+++ b/packages/base/test/src/utils_test.ts
@@ -1,0 +1,115 @@
+import {
+    expect
+} from 'chai';
+
+import * as utils from '../../lib/utils';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+
+describe('remove_buffers', function() {
+    const floatArray = new Float32Array([1.2, 3.14, 2.78, 5, 77.0001]);
+
+    const uintArray = new Uint8Array([1, 2, 3, 4, 5]);
+
+    it('extracts a Float32Array', function() {
+        const rawState = {
+            buffer: floatArray,
+        };
+        const {state, buffers, buffer_paths} = utils.remove_buffers(rawState);
+        expect(state).to.eql({});
+        expect(buffers).to.deep.equal([floatArray.buffer]);
+        expect(buffer_paths).to.deep.equal([['buffer']]);
+    });
+
+    it('extracts a Uint8Array', function() {
+        const rawState = {
+            buffer: uintArray,
+        };
+        const {state, buffers, buffer_paths} = utils.remove_buffers(rawState);
+        expect(state).to.eql({});
+        expect(buffers).to.deep.equal([uintArray.buffer]);
+        expect(buffer_paths).to.deep.equal([['buffer']]);
+    });
+
+    it('extracts a DataView', function() {
+        const rawState = {
+            buffer: new DataView(floatArray.buffer),
+        };
+        const {state, buffers, buffer_paths} = utils.remove_buffers(rawState);
+        expect(state).to.eql({});
+        expect(buffers).to.deep.equal([floatArray.buffer]);
+        expect(buffer_paths).to.deep.equal([['buffer']]);
+    });
+
+    it('extracts an ArrayBuffer', function() {
+        const rawState = {
+            buffer: floatArray.buffer,
+        };
+        const {state, buffers, buffer_paths} = utils.remove_buffers(rawState);
+        expect(state).to.eql({});
+        expect(buffers).to.deep.equal([floatArray.buffer]);
+        expect(buffer_paths).to.deep.equal([['buffer']]);
+    });
+
+    it('extracts buffers from an array', function() {
+        const rawState = [uintArray, floatArray.buffer];
+        const {state, buffers, buffer_paths} = utils.remove_buffers(rawState);
+        expect(state).to.deep.equal([null, null]);
+        expect(buffers).to.deep.equal([uintArray.buffer, floatArray.buffer]);
+        expect(buffer_paths).to.deep.equal([[0], [1]]);
+    });
+
+    describe('nested structures', function() {
+
+        it('array in object', function() {
+            let rawState = {
+                buffers: [uintArray, floatArray.buffer]
+            };
+            let {state, buffers, buffer_paths} = utils.remove_buffers(rawState);
+            expect(state).to.deep.equal({buffers: [null, null]});
+            expect(buffers).to.deep.equal([uintArray.buffer, floatArray.buffer]);
+            expect(buffer_paths).to.deep.equal([['buffers', 0], ['buffers', 1]]);
+        });
+
+        it('object in array', function() {
+            let rawState = [
+                { buffer: uintArray },
+                { buffer: floatArray.buffer },
+            ];
+            let {state, buffers, buffer_paths} = utils.remove_buffers(rawState);
+            expect(state).to.deep.equal([{}, {}]);
+            expect(buffers).to.deep.equal([uintArray.buffer, floatArray.buffer]);
+            expect(buffer_paths).to.deep.equal([[0, 'buffer'], [1, 'buffer']]);
+        });
+
+        it('array in array', function() {
+            let rawState = ['string', 45, [uintArray, floatArray.buffer]];
+            let {state, buffers, buffer_paths} = utils.remove_buffers(rawState);
+            expect(state).to.deep.equal(['string', 45, [null, null]]);
+            expect(buffers).to.deep.equal([uintArray.buffer, floatArray.buffer]);
+            expect(buffer_paths).to.deep.equal([[2, 0], [2, 1]]);
+        });
+
+        it('object in object', function() {
+            let rawState = {
+                a: 'string',
+                b: 45,
+                buffers: {
+                    bufferA: uintArray,
+                    bufferB: floatArray.buffer,
+                },
+            };
+            let {state, buffers, buffer_paths} = utils.remove_buffers(rawState);
+            expect(state).to.deep.equal({a: 'string', b: 45, buffers: {}});
+            expect(buffers).to.deep.equal([uintArray.buffer, floatArray.buffer]);
+            expect(buffer_paths).to.deep.equal(
+                [['buffers', 'bufferA'], ['buffers', 'bufferB']]
+            );
+        });
+
+    });
+
+});


### PR DESCRIPTION
Uses `ArrayBuffer.isView(value)` instead of `value.buffer instanceof ArrayBuffer` to check if `value` is a typed array or a `DataView`.

Fixes #1748.