### PR TITLE
Add a click method to the Button Widget

### DIFF
--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -85,6 +85,14 @@ class Button(DOMWidget, CoreWidget):
         """
         self._click_handlers.register_callback(callback, remove=remove)
 
+    def click(self):
+        """Programmatically trigger a click event.
+
+        This will call the callbacks registered to the clicked button
+        widget instance.
+        """
+        self._click_handlers(self)
+
     def _handle_button_msg(self, _, content, buffers):
         """Handle a msg from the front-end.
 
@@ -94,4 +102,4 @@ class Button(DOMWidget, CoreWidget):
             Content of the msg.
         """
         if content.get('event', '') == 'click':
-            self._click_handlers(self)
+            self.click()


### PR DESCRIPTION
Add a `click` method so the callbacks for a `Button` can be triggered programmatically in Python.

There is already some discussion in https://github.com/jupyter-widgets/ipywidgets/issues/1896. This PR provides a more user-friendly way to achieve this :)

![widget-button-click](https://user-images.githubusercontent.com/591645/45449662-0d779f00-b6d6-11e8-988f-197db43b9344.gif)

#### Example

```python
# In[1]:

from ipywidgets import Button, Output

b = Button(description='Click')
out = Output()

@out.capture()
def on_button_clicked1(b):
    print("Button clicked 1")

@out.capture()
def on_button_clicked2(b):
    print("Button clicked 2")
    
b.on_click(on_button_clicked1)
b.on_click(on_button_clicked2)

with out:
    display(b)

out

# In[2]:

b.click()
```