### PR TITLE
Fix Image display inconsistency between classic and lab

### DIFF
--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -1074,3 +1074,11 @@
     /* Make it possible to have absolutely-positioned elements in the html */
     position: relative;
 }
+
+
+/* Image widget  */
+
+.widget-image {
+    max-width: 100%;
+    height: auto;
+}


### PR DESCRIPTION
Display of an image widget is different in classic notebook and lab. This PR fixes that by adding the CSS necessary to make an Image widget display in Lab as it does in notebook. Though one could argue as to which behavior is better, the behavior in classic notebook has been present for a long time and so I think the right fix is to make lab behave the same way.

## Explanation

### Input image

All of the examples below use a 600 x 300 image of a gaussian as input; a copy is below.

![gaussian_600_x_300](https://user-images.githubusercontent.com/1147167/45600610-35f8e500-b9c5-11e8-9f2a-c515c69ef207.png)

### plain `Image` widget output differs

The code cell below generates different output in classic than in lab:

```python
i = Image(value=b)
i.width = 100
i.height = 150
i
```

| Classic notebook | Lab  |
| ----------------- | ---- |
| Preserves aspect ratio | Is 100 x 150 |
|             <img width="160" alt="untitled" src="https://user-images.githubusercontent.com/1147167/45600431-39d73800-b9c2-11e8-893b-e54f6bdf9548.png">               |      <img width="166" alt="jupyterlab" src="https://user-images.githubusercontent.com/1147167/45600428-2c21b280-b9c2-11e8-97b0-7ac887c59cce.png">      |

I believe the root cause is this CSS snippet from [outputarea.less in classic notebook](https://github.com/jupyter/notebook/blob/master/notebook/static/notebook/less/outputarea.less#L70):

```css
div.output_area img, div.output_area svg {
  max-width: 100%;
  height: auto;
}
```

In this case, `height: auto` overrides `img height='150'` and the aspect ratio is preserved.

### `Image` in a `Box` output differs

This code snippet also generates different results in classic than in lab:

```python
i2 = Image(value=b)
box2 = Box()
i2.width = 500
box2.layout.width = '200px'
box2.children = [i2]
box2
```
| Classic notebook | Lab  |
| ----------------- | ---- |
| Squeezes image | 200px wide chunk displayed, image distorted |
|       <img width="306" alt="untitled" src="https://user-images.githubusercontent.com/1147167/45600529-b4548780-b9c3-11e8-9a92-10e0891f62d8.png">       |         <img width="307" alt="jupyterlab" src="https://user-images.githubusercontent.com/1147167/45600535-bfa7b300-b9c3-11e8-9c3f-bf07c89f8663.png">       |

Again, I believe the difference is due to the CSS snippet above. In this case, in the classic notebook, the maximum width of the image is set to `100%`, forcing it to fit inside the box. In lab, one can scroll to see the rest of the image because the `Box` has `overflow: visible`.



