### PR TITLE
WIP: reflect update message back (multi user widgets)

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -668,6 +668,8 @@ class Widget(LoggingHasTraits):
                     _put_buffers(state, data['buffer_paths'], msg['buffers'])
                 self.set_state(state)
                 # we send back the state to all other sessions, but only when there are multiple
+                # this allows all front-ends to sync up to the front-end that caused the state change
+                # for discussion, see: https://github.com/jupyter/jupyter_client/issues/263
                 if msg['metadata'].get('session_count', 1) > 1:
                     kernel = self.comm.kernel
                     kernel.session.send(kernel.iopub_socket, 'reflect:comm_msg', content=msg['content'], parent=kernel._parent_header, ident=self.comm.topic)

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -667,6 +667,10 @@ class Widget(LoggingHasTraits):
                 if 'buffer_paths' in data:
                     _put_buffers(state, data['buffer_paths'], msg['buffers'])
                 self.set_state(state)
+                # we send back the state to all other sessions, but only when there are multiple
+                if msg['metadata'].get('session_count', 1) > 1:
+                    kernel = self.comm.kernel
+                    kernel.session.send(kernel.iopub_socket, 'reflect:comm_msg', content=msg['content'], parent=kernel._parent_header, ident=self.comm.topic)
 
         # Handle a state request.
         elif method == 'request_state':


### PR DESCRIPTION
This will allow multiple front-ends to be connected to 1 kernel, and all other front-ends to receive updates from another front-end. 
# Requires
https://github.com/jupyter/notebook/pull/4028
# Example 
opening the same notebook twice:
![multi-user-widgets](https://user-images.githubusercontent.com/1765949/45961406-b9967f80-c01e-11e8-9269-957f355354da.gif)

