### PR TITLE
Link JL extensions in dev-install script

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -52,5 +52,8 @@ echo -n "ipywidgets"
 pip install -v -e .
 
 if test "$skip_jupyter_lab" != yes; then
+    jupyter labextension link ./packages/base
+    jupyter labextension link ./packages/controls
+    jupyter labextension link ./packages/output
     jupyter labextension install ./packages/jupyterlab-manager
 fi


### PR DESCRIPTION
Looks like the `base`, `controls` and `output` packages need to be linked, so the changes can be picked up automatically when developing in JupyterLab.