### PR TITLE
Add kernel.py file containing kernel-related routines

### DIFF
--- a/ipywidgets/__init__.py
+++ b/ipywidgets/__init__.py
@@ -31,9 +31,6 @@ def register_comm_target():
 
 # deprecated alias
 handle_kernel = register_comm_target
+_handle_ipython = register_comm_target
 
-def _handle_ipython():
-    """Register with the comm target at import if running in IPython"""
-    register_comm_target()
-
-_handle_ipython()
+register_comm_target()

--- a/ipywidgets/__init__.py
+++ b/ipywidgets/__init__.py
@@ -20,33 +20,20 @@ accessible as a `value` attribute.
 
 import os
 
-from IPython import get_ipython
 from ._version import version_info, __version__, __protocol_version__, __jupyter_widgets_controls_version__, __jupyter_widgets_base_version__
 from .widgets import *
 from traitlets import link, dlink
 
 
-def load_ipython_extension(ip):
-    """Set up IPython to work with widgets"""
-    if not hasattr(ip, 'kernel'):
-        return
-    register_comm_target(ip.kernel)
-
-
-def register_comm_target(kernel=None):
+def register_comm_target():
     """Register the jupyter.widget comm target"""
-    if kernel is None:
-        kernel = get_ipython().kernel
-    kernel.comm_manager.register_target('jupyter.widget', Widget.handle_comm_opened)
+    register_target('jupyter.widget', Widget.handle_comm_opened)
 
 # deprecated alias
 handle_kernel = register_comm_target
 
 def _handle_ipython():
     """Register with the comm target at import if running in IPython"""
-    ip = get_ipython()
-    if ip is None:
-        return
-    load_ipython_extension(ip)
+    register_comm_target()
 
 _handle_ipython()

--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -7,6 +7,8 @@ from .valuewidget import ValueWidget
 
 from .trait_types import Color, Datetime, NumberFormat
 
+from .kernel import register_target, get_kernel, Comm, display, clear_output
+
 from .widget_core import CoreWidget
 from .widget_bool import Checkbox, ToggleButton, Valid
 from .widget_button import Button, ButtonStyle

--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -7,7 +7,7 @@ from .valuewidget import ValueWidget
 
 from .trait_types import Color, Datetime, NumberFormat
 
-from .kernel import register_target, get_kernel, Comm, display, clear_output
+from .kernel import register_target, get_ipython, Comm, display, clear_output
 
 from .widget_core import CoreWidget
 from .widget_bool import Checkbox, ToggleButton, Valid

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -18,11 +18,9 @@ except ImportError:
     from inspect import getargspec as check_argspec # py2
 import sys
 
-from IPython.core.getipython import get_ipython
 from . import (ValueWidget, Text,
     FloatSlider, IntSlider, Checkbox, Dropdown,
-    VBox, Button, DOMWidget, Output)
-from IPython.display import display, clear_output
+    VBox, Button, DOMWidget, Output, get_kernel, display, clear_output)
 from ipython_genutils.py3compat import string_types, unicode_type
 from traitlets import HasTraits, Any, Unicode, observe
 from numbers import Real, Integral
@@ -253,7 +251,7 @@ class interactive(VBox):
                 if self.auto_display and self.result is not None:
                     display(self.result)
         except Exception as e:
-            ip = get_ipython()
+            ip = get_kernel()
             if ip is None:
                 self.log.warn("Exception in interact callback: %s", e, exc_info=True)
             else:

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -20,7 +20,7 @@ import sys
 
 from . import (ValueWidget, Text,
     FloatSlider, IntSlider, Checkbox, Dropdown,
-    VBox, Button, DOMWidget, Output, get_kernel, display, clear_output)
+    VBox, Button, DOMWidget, Output, get_ipython, display, clear_output)
 from ipython_genutils.py3compat import string_types, unicode_type
 from traitlets import HasTraits, Any, Unicode, observe
 from numbers import Real, Integral
@@ -251,7 +251,7 @@ class interactive(VBox):
                 if self.auto_display and self.result is not None:
                     display(self.result)
         except Exception as e:
-            ip = get_kernel()
+            ip = get_ipython()
             if ip is None:
                 self.log.warn("Exception in interact callback: %s", e, exc_info=True)
             else:

--- a/ipywidgets/widgets/kernel.py
+++ b/ipywidgets/widgets/kernel.py
@@ -21,4 +21,4 @@ if (ipython is not None and hasattr(ipython, "kernel")):
 else:
     register_target = mock_register
 
-get_kernel = get_ipython
+get_ipython = get_ipython

--- a/ipywidgets/widgets/kernel.py
+++ b/ipywidgets/widgets/kernel.py
@@ -1,0 +1,19 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""Utils functions for retrieving IPython kernel and display logic."""
+
+from ipykernel.comm import Comm
+from IPython import get_ipython
+from IPython.display import display, clear_output
+
+def mock_register(*args, **kwargs):
+    pass
+
+ipython = get_ipython()
+if (ipython is not None and hasattr(ipython, "kernel")):
+    register_target = get_ipython().kernel.comm_manager.register_target
+else:
+    register_target = mock_register
+
+get_kernel = get_ipython

--- a/ipywidgets/widgets/kernel.py
+++ b/ipywidgets/widgets/kernel.py
@@ -1,7 +1,12 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-"""Utils functions for retrieving IPython kernel and display logic."""
+"""
+Utils functions for retrieving IPython kernel and display logic.
+This is helpful for other Python kernels like xeus-python, so that they can
+mock `ipywidgets.kernel` module functions instead of mocking IPython and
+ipykernel
+"""
 
 from ipykernel.comm import Comm
 from IPython import get_ipython

--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -9,19 +9,19 @@ from ipywidgets import widget_output
 class TestOutputWidget(TestCase):
 
     @contextmanager
-    def _mocked_kernel(self, get_kernel, clear_output):
-        """ Context manager that monkeypatches get_kernel and clear_output """
+    def _mocked_ipython(self, get_ipython, clear_output):
+        """ Context manager that monkeypatches get_ipython and clear_output """
         original_clear_output = widget_output.clear_output
-        original_get_kernel = widget_output.get_kernel
-        widget_output.get_kernel = get_kernel
+        original_get_ipython = widget_output.get_ipython
+        widget_output.get_ipython = get_ipython
         widget_output.clear_output = clear_output
         try:
             yield
         finally:
             widget_output.clear_output = original_clear_output
-            widget_output.get_kernel = original_get_kernel
+            widget_output.get_ipython = original_get_ipython
 
-    def _mock_get_kernel(self, msg_id):
+    def _mock_get_ipython(self, msg_id):
         """ Returns a mock IPython application with a mocked kernel """
         kernel = type(
             'mock_kernel',
@@ -35,12 +35,12 @@ class TestOutputWidget(TestCase):
             etype, evalue, tb = exc_tuple
             raise etype(evalue)
 
-        kernel = type(
-            'mock_kernel',
+        ipython = type(
+            'mock_ipython',
             (object, ),
             {'kernel': kernel, 'showtraceback': showtraceback}
         )
-        return kernel
+        return ipython
 
     def _mock_clear_output(self):
         """ Mock function that records calls to it """
@@ -54,10 +54,10 @@ class TestOutputWidget(TestCase):
 
     def test_set_msg_id_when_capturing(self):
         msg_id = 'msg-id'
-        get_kernel = self._mock_get_kernel(msg_id)
+        get_ipython = self._mock_get_ipython(msg_id)
         clear_output = self._mock_clear_output()
 
-        with self._mocked_kernel(get_kernel, clear_output):
+        with self._mocked_ipython(get_ipython, clear_output):
             widget = widget_output.Output()
             assert widget.msg_id == ''
             with widget:
@@ -66,10 +66,10 @@ class TestOutputWidget(TestCase):
 
     def test_clear_output(self):
         msg_id = 'msg-id'
-        get_kernel = self._mock_get_kernel(msg_id)
+        get_ipython = self._mock_get_ipython(msg_id)
         clear_output = self._mock_clear_output()
 
-        with self._mocked_kernel(get_kernel, clear_output):
+        with self._mocked_ipython(get_ipython, clear_output):
             widget = widget_output.Output()
             widget.clear_output(wait=True)
 
@@ -78,13 +78,13 @@ class TestOutputWidget(TestCase):
 
     def test_capture_decorator(self):
         msg_id = 'msg-id'
-        get_kernel = self._mock_get_kernel(msg_id)
+        get_ipython = self._mock_get_ipython(msg_id)
         clear_output = self._mock_clear_output()
         expected_argument = 'arg'
         expected_keyword_argument = True
         captee_calls = []
 
-        with self._mocked_kernel(get_kernel, clear_output):
+        with self._mocked_ipython(get_ipython, clear_output):
             widget = widget_output.Output()
             assert widget.msg_id == ''
 
@@ -110,10 +110,10 @@ class TestOutputWidget(TestCase):
 
     def test_capture_decorator_clear_output(self):
         msg_id = 'msg-id'
-        get_kernel = self._mock_get_kernel(msg_id)
+        get_ipython = self._mock_get_ipython(msg_id)
         clear_output = self._mock_clear_output()
 
-        with self._mocked_kernel(get_kernel, clear_output):
+        with self._mocked_ipython(get_ipython, clear_output):
             widget = widget_output.Output()
 
             @widget.capture(clear_output=True, wait=True)
@@ -130,10 +130,10 @@ class TestOutputWidget(TestCase):
 
     def test_capture_decorator_no_clear_output(self):
         msg_id = 'msg-id'
-        get_kernel = self._mock_get_kernel(msg_id)
+        get_ipython = self._mock_get_ipython(msg_id)
         clear_output = self._mock_clear_output()
 
-        with self._mocked_kernel(get_kernel, clear_output):
+        with self._mocked_ipython(get_ipython, clear_output):
             widget = widget_output.Output()
 
             @widget.capture(clear_output=False)

--- a/ipywidgets/widgets/tests/test_widget_output.py
+++ b/ipywidgets/widgets/tests/test_widget_output.py
@@ -9,19 +9,19 @@ from ipywidgets import widget_output
 class TestOutputWidget(TestCase):
 
     @contextmanager
-    def _mocked_ipython(self, get_ipython, clear_output):
-        """ Context manager that monkeypatches get_ipython and clear_output """
+    def _mocked_kernel(self, get_kernel, clear_output):
+        """ Context manager that monkeypatches get_kernel and clear_output """
         original_clear_output = widget_output.clear_output
-        original_get_ipython = widget_output.get_ipython
-        widget_output.get_ipython = get_ipython
+        original_get_kernel = widget_output.get_kernel
+        widget_output.get_kernel = get_kernel
         widget_output.clear_output = clear_output
         try:
             yield
         finally:
             widget_output.clear_output = original_clear_output
-            widget_output.get_ipython = original_get_ipython
+            widget_output.get_kernel = original_get_kernel
 
-    def _mock_get_ipython(self, msg_id):
+    def _mock_get_kernel(self, msg_id):
         """ Returns a mock IPython application with a mocked kernel """
         kernel = type(
             'mock_kernel',
@@ -35,12 +35,12 @@ class TestOutputWidget(TestCase):
             etype, evalue, tb = exc_tuple
             raise etype(evalue)
 
-        ipython = type(
-            'mock_ipython',
+        kernel = type(
+            'mock_kernel',
             (object, ),
             {'kernel': kernel, 'showtraceback': showtraceback}
         )
-        return ipython
+        return kernel
 
     def _mock_clear_output(self):
         """ Mock function that records calls to it """
@@ -54,10 +54,10 @@ class TestOutputWidget(TestCase):
 
     def test_set_msg_id_when_capturing(self):
         msg_id = 'msg-id'
-        get_ipython = self._mock_get_ipython(msg_id)
+        get_kernel = self._mock_get_kernel(msg_id)
         clear_output = self._mock_clear_output()
 
-        with self._mocked_ipython(get_ipython, clear_output):
+        with self._mocked_kernel(get_kernel, clear_output):
             widget = widget_output.Output()
             assert widget.msg_id == ''
             with widget:
@@ -66,10 +66,10 @@ class TestOutputWidget(TestCase):
 
     def test_clear_output(self):
         msg_id = 'msg-id'
-        get_ipython = self._mock_get_ipython(msg_id)
+        get_kernel = self._mock_get_kernel(msg_id)
         clear_output = self._mock_clear_output()
 
-        with self._mocked_ipython(get_ipython, clear_output):
+        with self._mocked_kernel(get_kernel, clear_output):
             widget = widget_output.Output()
             widget.clear_output(wait=True)
 
@@ -78,13 +78,13 @@ class TestOutputWidget(TestCase):
 
     def test_capture_decorator(self):
         msg_id = 'msg-id'
-        get_ipython = self._mock_get_ipython(msg_id)
+        get_kernel = self._mock_get_kernel(msg_id)
         clear_output = self._mock_clear_output()
         expected_argument = 'arg'
         expected_keyword_argument = True
         captee_calls = []
 
-        with self._mocked_ipython(get_ipython, clear_output):
+        with self._mocked_kernel(get_kernel, clear_output):
             widget = widget_output.Output()
             assert widget.msg_id == ''
 
@@ -110,10 +110,10 @@ class TestOutputWidget(TestCase):
 
     def test_capture_decorator_clear_output(self):
         msg_id = 'msg-id'
-        get_ipython = self._mock_get_ipython(msg_id)
+        get_kernel = self._mock_get_kernel(msg_id)
         clear_output = self._mock_clear_output()
 
-        with self._mocked_ipython(get_ipython, clear_output):
+        with self._mocked_kernel(get_kernel, clear_output):
             widget = widget_output.Output()
 
             @widget.capture(clear_output=True, wait=True)
@@ -130,10 +130,10 @@ class TestOutputWidget(TestCase):
 
     def test_capture_decorator_no_clear_output(self):
         msg_id = 'msg-id'
-        get_ipython = self._mock_get_ipython(msg_id)
+        get_kernel = self._mock_get_kernel(msg_id)
         clear_output = self._mock_clear_output()
 
-        with self._mocked_ipython(get_ipython, clear_output):
+        with self._mocked_kernel(get_kernel, clear_output):
             widget = widget_output.Output()
 
             @widget.capture(clear_output=False)

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 import collections
 import sys
 
-from .kernel import get_kernel, Comm, display
+from .kernel import get_ipython, Comm, display
 from traitlets.utils.importstring import import_item
 from traitlets import (
     HasTraits, Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default, Container,
@@ -182,7 +182,7 @@ class CallbackDispatcher(LoggingHasTraits):
             try:
                 local_value = callback(*args, **kwargs)
             except Exception as e:
-                ip = get_kernel()
+                ip = get_ipython()
                 if ip is None:
                     self.log.warning("Exception in callback %s: %s", callback, e, exc_info=True)
                 else:
@@ -213,7 +213,7 @@ def _show_traceback(method):
         try:
             return(method(self, *args, **kwargs))
         except Exception as e:
-            ip = get_kernel()
+            ip = get_ipython()
             if ip is None:
                 self.log.warning("Exception in widget method %s: %s", method, e, exc_info=True)
             else:

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -11,14 +11,12 @@ from contextlib import contextmanager
 import collections
 import sys
 
-from IPython.core.getipython import get_ipython
-from ipykernel.comm import Comm
+from .kernel import get_kernel, Comm, display
 from traitlets.utils.importstring import import_item
 from traitlets import (
     HasTraits, Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default, Container,
     Undefined)
 from ipython_genutils.py3compat import string_types, PY3
-from IPython.display import display
 from json import loads as jsonloads, dumps as jsondumps
 
 from base64 import standard_b64decode, standard_b64encode
@@ -184,7 +182,7 @@ class CallbackDispatcher(LoggingHasTraits):
             try:
                 local_value = callback(*args, **kwargs)
             except Exception as e:
-                ip = get_ipython()
+                ip = get_kernel()
                 if ip is None:
                     self.log.warning("Exception in callback %s: %s", callback, e, exc_info=True)
                 else:
@@ -215,7 +213,7 @@ def _show_traceback(method):
         try:
             return(method(self, *args, **kwargs))
         except Exception as e:
-            ip = get_ipython()
+            ip = get_kernel()
             if ip is None:
                 self.log.warning("Exception in widget method %s: %s", method, e, exc_info=True)
             else:
@@ -388,7 +386,7 @@ class Widget(LoggingHasTraits):
 
     _view_count = Int(None, allow_none=True,
         help="EXPERIMENTAL: The number of views of the model displayed in the frontend. This attribute is experimental and may change or be removed in the future. None signifies that views will not be tracked. Set this to 0 to start tracking view creation/deletion.").tag(sync=True)
-    comm = Instance('ipykernel.comm.Comm', allow_none=True)
+    comm = Instance(Comm, allow_none=True)
 
     keys = List(help="The traits which are synced.")
 

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -12,7 +12,7 @@ from functools import wraps
 from .domwidget import DOMWidget
 from .trait_types import TypedTuple
 from .widget import register
-from .kernel import get_kernel
+from .kernel import get_ipython
 from .._version import __jupyter_widgets_output_version__
 
 from traitlets import Unicode, Dict
@@ -105,13 +105,13 @@ class Output(DOMWidget):
     def __enter__(self):
         """Called upon entering output widget context manager."""
         self._flush()
-        ip = get_kernel()
+        ip = get_ipython()
         if ip and hasattr(ip, 'kernel') and hasattr(ip.kernel, '_parent_header'):
             self.msg_id = ip.kernel._parent_header['header']['msg_id']
 
     def __exit__(self, etype, evalue, tb):
         """Called upon exiting output widget context manager."""
-        ip = get_kernel()
+        ip = get_ipython()
         if etype is not None:
             if ip:
                 ip.showtraceback((etype, evalue, tb), tb_offset=0)

--- a/ipywidgets/widgets/widget_output.py
+++ b/ipywidgets/widgets/widget_output.py
@@ -12,12 +12,12 @@ from functools import wraps
 from .domwidget import DOMWidget
 from .trait_types import TypedTuple
 from .widget import register
+from .kernel import get_kernel
 from .._version import __jupyter_widgets_output_version__
 
 from traitlets import Unicode, Dict
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.display import clear_output
-from IPython import get_ipython
 
 
 @register
@@ -31,7 +31,7 @@ class Output(DOMWidget):
     context will be captured and displayed in the widget instead of the standard output
     area.
 
-    You can also use the .capture() method to decorate a function or a method. Any output 
+    You can also use the .capture() method to decorate a function or a method. Any output
     produced by the function will then go to the output widget. This is useful for
     debugging widget callbacks, for example.
 
@@ -105,13 +105,13 @@ class Output(DOMWidget):
     def __enter__(self):
         """Called upon entering output widget context manager."""
         self._flush()
-        ip = get_ipython()
+        ip = get_kernel()
         if ip and hasattr(ip, 'kernel') and hasattr(ip.kernel, '_parent_header'):
             self.msg_id = ip.kernel._parent_header['header']['msg_id']
 
     def __exit__(self, etype, evalue, tb):
         """Called upon exiting output widget context manager."""
-        ip = get_ipython()
+        ip = get_kernel()
         if etype is not None:
             if ip:
                 ip.showtraceback((etype, evalue, tb), tb_offset=0)


### PR DESCRIPTION
We need those changes for `xeus_python`. We implemented widgets support, but it enforces us to mock IPython an ipykernel at different places: `IPython.display.display`, `IPython.display.clear_output`, `IPython.get_ipython`, `ipykernel.comm.Comm`. See https://github.com/QuantStack/xeus-python/blob/master/src/xinterpreter.cpp#L41.
Those changes help by putting all those imports in one place: `kernel.py`. So that we just need to mock `ipywidgets.kernel` in `xeus_python`.