### PR TITLE
WIP Fix regexp escape issue in embed_minimal_html & Python 3.7 CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
 addons:
   apt_packages:
     - pandoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # http://travis-ci.org/#!/jupyter-widgets/ipywidgets
 language: python
+dist: xenial
 python:
     - 2.7
     - 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - 3.7
 addons:
   apt_packages:
     - pandoc
@@ -37,5 +36,8 @@ matrix:
           env: GROUP=doc
         - python: 3.6
           env: GROUP=js BROWSER=firefox TRAVIS_NODE_VERSION=6.11.0
+        - python: 3.7
+          dist: xenial
+          sudo: true
 after_success:
     - coveralls

--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -238,7 +238,7 @@ def escape_script(s):
     We only replace these three cases so that most html or other content
     involving `<` is readable.
     """
-    return script_escape_re.sub(r'\u003c\1', s)
+    return script_escape_re.sub(u'\u003c\1', s)
 
 @doc_subst(_doc_snippets)
 def embed_snippet(views,

--- a/ipywidgets/tests/test_embed.py
+++ b/ipywidgets/tests/test_embed.py
@@ -79,14 +79,14 @@ class TestEmbed:
     def test_escape(self):
         w = Text('<script A> <ScRipt> </Script> <!-- --> <b>hi</b>')
         code = embed_snippet(w)
-        assert code.find(r'<script A>') == -1
-        assert code.find(r'\u003cscript A> \u003cScRipt> \u003c/Script> \u003c!-- --> <b>hi</b>') >= 0
+        assert code.find(u'<script A>') == -1
+        assert code.find(u'\u003cscript A> \u003cScRipt> \u003c/Script> \u003c!-- --> <b>hi</b>') >= 0
 
         f = StringIO()
         embed_minimal_html(f, w)
         content = f.getvalue()
-        assert content.find(r'<script A>') == -1
-        assert content.find(r'\u003cscript A> \u003cScRipt> \u003c/Script> \u003c!-- --> <b>hi</b>') >= 0
+        assert content.find(u'<script A>') == -1
+        assert content.find(u'\u003cscript A> \u003cScRipt> \u003c/Script> \u003c!-- --> <b>hi</b>') >= 0
 
     def test_embed_data_two_widgets(self):
         w1 = IntText(4)


### PR DESCRIPTION
Aims to fix the regexp escape issue in `embed_minimal_html`

Closes https://github.com/jupyter-widgets/ipywidgets/issues/2277

Also adds Python 3.7 CI as it doesn't appear to be tested.