### PR TITLE
Improved dev experience, add watch commands

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -52,8 +52,8 @@ echo -n "ipywidgets"
 pip install -v -e .
 
 if test "$skip_jupyter_lab" != yes; then
-    jupyter labextension link ./packages/base
-    jupyter labextension link ./packages/controls
-    jupyter labextension link ./packages/output
+    jupyter labextension link ./packages/base --no-build
+    jupyter labextension link ./packages/controls --no-build
+    jupyter labextension link ./packages/output --no-build
     jupyter labextension install ./packages/jupyterlab-manager
 fi

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -29,7 +29,8 @@
     "test:unit:firefox": "npm run test:unit:default -- --browsers=Firefox",
     "test:unit:chrome": "npm run test:unit:default -- --browsers=Chrome",
     "test:unit:ie": "npm run test:unit:default -- --browsers=IE",
-    "prepublish": "npm run clean && npm run build"
+    "prepublish": "npm run clean && npm run build",
+    "watch": "tsc -w --project src"
   },
   "devDependencies": {
     "@types/expect.js": "^0.3.29",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -31,7 +31,8 @@
     "test:unit:firefox": "npm run test:unit:default -- --browsers=Firefox",
     "test:unit:chrome": "npm run test:unit:default -- --browsers=Chrome",
     "test:unit:ie": "npm run test:unit:default -- --browsers=IE",
-    "prepublish": "npm run clean && npm run build"
+    "prepublish": "npm run clean && npm run build",
+    "watch": "tsc -w --project src"
   },
   "devDependencies": {
     "@jupyterlab/services": "^2.0.0 || ^3.0.0",

--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -32,7 +32,8 @@
     "test:unit": "npm run test:unit:firefox && npm run test:unit:chrome",
     "test:unit:chrome": "npm run test:unit:default -- --browsers=Chrome",
     "test:unit:default": "npm run build:test && karma start test/karma.conf.js --log-level debug --browsers=Firefox",
-    "test:unit:firefox": "npm run test:unit:default -- --browsers=Firefox"
+    "test:unit:firefox": "npm run test:unit:default -- --browsers=Firefox",
+    "watch": "tsc -w --project src"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.2.2",

--- a/packages/jupyterlab-manager/package.json
+++ b/packages/jupyterlab-manager/package.json
@@ -31,7 +31,8 @@
     "clean": "rimraf docs && rimraf lib",
     "docs": "typedoc --mode file --module commonjs --excludeNotExported --target es5 --moduleResolution node --out docs/ src",
     "lint": "tslint --project tslint.json --format stylish",
-    "prepublish": "npm run clean && npm run build"
+    "prepublish": "npm run clean && npm run build",
+    "watch": "tsc -w --project src"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.2.2",

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -10,7 +10,8 @@
     "build": "npm run build:src",
     "lint": "tslint --project tslint.json --format stylish",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublish": "npm run clean && npm run build"
+    "prepublish": "npm run clean && npm run build",
+    "watch": "tsc -w --project src"
   },
   "files": [
     "lib/**/*.d.ts",

--- a/widgetsnbextension/package.json
+++ b/widgetsnbextension/package.json
@@ -8,7 +8,8 @@
     "clean": "rimraf widgetsnbextension/static",
     "build": "webpack",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublish": "npm run clean && npm run build"
+    "prepublish": "npm run clean && npm run build",
+    "watch": "webpack --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
My workflow is as follows:
from root I have two terminals open:
```
$ (cd packages/base; npm run watch)
$ (cd widgetsnbextension; npm run watch)
```
A change in base is propagated in about ~1 second.
