### PR TITLE
Play widget: expose playing and repeat 

### DIFF
--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -228,7 +228,7 @@ class Play(_BoundedInt):
     _model_name = Unicode('PlayModel').tag(sync=True)
 
     playing = Bool(help="Whether the control is currently playing.").tag(sync=True)
-    _repeat = Bool(help="Whether the control will repeat in a continous loop.").tag(sync=True)
+    repeat = Bool(help="Whether the control will repeat in a continous loop.").tag(sync=True)
 
     interval = CInt(100, help="The time between two animation steps (ms).").tag(sync=True)
     step = CInt(1, help="Increment step").tag(sync=True)

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -224,16 +224,17 @@ class _IntRange(_Int):
 class Play(_BoundedInt):
     """Play/repeat buttons to step through values automatically, and optionally loop.
     """
-    interval = CInt(100, help="The time between two animation steps (ms).").tag(sync=True)
-    step = CInt(1, help="Increment step").tag(sync=True)
-    disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
-
     _view_name = Unicode('PlayView').tag(sync=True)
     _model_name = Unicode('PlayModel').tag(sync=True)
 
-    _playing = Bool(help="Whether the control is currently playing.").tag(sync=True)
+    playing = Bool(help="Whether the control is currently playing.").tag(sync=True)
     _repeat = Bool(help="Whether the control will repeat in a continous loop.").tag(sync=True)
+
+    interval = CInt(100, help="The time between two animation steps (ms).").tag(sync=True)
+    step = CInt(1, help="Increment step").tag(sync=True)
+    disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
     show_repeat = Bool(True, help="Show the repeat toggle button in the widget.").tag(sync=True)
+
 
 class _BoundedIntRange(_IntRange):
     max = CInt(100, help="Max value").tag(sync=True)

--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -776,7 +776,7 @@ class PlayModel extends BoundedIntModel {
         return _.extend(super.defaults(), {
             _model_name: 'PlayModel',
             _view_name: 'PlayView',
-            _repeat: false,
+            repeat: false,
             playing: false,
             show_repeat: true,
             interval: 100,
@@ -797,7 +797,7 @@ class PlayModel extends BoundedIntModel {
             this.set('value', next_value);
             this.schedule_next();
         } else {
-            if (this.get('_repeat')) {
+            if (this.get('repeat')) {
                 this.set('value', this.get('min'));
                 this.schedule_next();
             } else {
@@ -847,7 +847,7 @@ class PlayModel extends BoundedIntModel {
     }
 
     repeat(): void {
-        this.set('_repeat', !this.get('_repeat'));
+        this.set('repeat', !this.get('repeat'));
         this.save_changes();
     }
 
@@ -896,10 +896,10 @@ class PlayView extends DOMWidgetView {
         this.repeatButton.onclick = this.model.repeat.bind(this.model);
 
         this.listenTo(this.model, 'change:playing', this.onPlayingChanged);
-        this.listenTo(this.model, 'change:_repeat', this.update_repeat);
-        this.listenTo(this.model, 'change:show_repeat', this.update_repeat);
+        this.listenTo(this.model, 'change:repeat', this.updateRepeat);
+        this.listenTo(this.model, 'change:show_repeat', this.updateRepeat);
         this.updatePlaying();
-        this.update_repeat();
+        this.updateRepeat();
         this.update();
     }
 
@@ -939,8 +939,8 @@ class PlayView extends DOMWidgetView {
         }
     }
 
-    update_repeat(): void {
-        const repeat = this.model.get('_repeat');
+    updateRepeat(): void {
+        const repeat = this.model.get('repeat');
         this.repeatButton.style.display = this.model.get('show_repeat') ? this.playButton.style.display : 'none';
         if (repeat) {
             this.repeatButton.classList.add('mod-active');

--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -801,28 +801,33 @@ class PlayModel extends BoundedIntModel {
                 this.set('value', this.get('min'));
                 this.schedule_next();
             } else {
-                this.set('playing', false);
+                this.pause();
             }
         }
         this.save_changes();
     }
 
     schedule_next(): void {
-        window.setTimeout(this.loop.bind(this), this.get('interval'));
+        this._timerId = window.setTimeout(this.loop.bind(this), this.get('interval'));
     }
 
     stop(): void {
-        this.set('playing', false);
+        this.pause();
         this.set('value', this.get('min'));
         this.save_changes();
     }
 
     pause(): void {
+        window.clearTimeout(this._timerId);
+        this._timerId = null;
         this.set('playing', false);
         this.save_changes();
     }
 
     animate(): void {
+        if (this._timerId !== null) {
+            return;
+        }
         if (this.get('value') === this.get('max')) {
             // if the value is at the end, reset it first, and then schedule the next
             this.set('value', this.get('min'));
@@ -845,6 +850,8 @@ class PlayModel extends BoundedIntModel {
         this.set('_repeat', !this.get('_repeat'));
         this.save_changes();
     }
+
+    private _timerId: number | null = null;
 }
 
 export

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -784,7 +784,6 @@ Attribute        | Type             | Default          | Help
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
 `_model_module_version` | string           | `'1.5.0'`        | 
 `_model_name`    | string           | `'PlayModel'`    | 
-`_repeat`        | boolean          | `false`          | Whether the control will repeat in a continous loop.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'1.5.0'`        | 
 `_view_name`     | string           | `'PlayView'`     | 
@@ -795,6 +794,7 @@ Attribute        | Type             | Default          | Help
 `max`            | number (integer) | `100`            | Max value
 `min`            | number (integer) | `0`              | Min value
 `playing`        | boolean          | `false`          | Whether the control is currently playing.
+`repeat`         | boolean          | `false`          | Whether the control will repeat in a continous loop.
 `show_repeat`    | boolean          | `true`           | Show the repeat toggle button in the widget.
 `step`           | number (integer) | `1`              | Increment step
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -784,7 +784,6 @@ Attribute        | Type             | Default          | Help
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
 `_model_module_version` | string           | `'1.5.0'`        | 
 `_model_name`    | string           | `'PlayModel'`    | 
-`_playing`       | boolean          | `false`          | Whether the control is currently playing.
 `_repeat`        | boolean          | `false`          | Whether the control will repeat in a continous loop.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'1.5.0'`        | 
@@ -795,6 +794,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `max`            | number (integer) | `100`            | Max value
 `min`            | number (integer) | `0`              | Min value
+`playing`        | boolean          | `false`          | Whether the control is currently playing.
 `show_repeat`    | boolean          | `true`           | Show the repeat toggle button in the widget.
 `step`           | number (integer) | `1`              | Increment step
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations

--- a/packages/schema/jupyterwidgetmodels.v8.md
+++ b/packages/schema/jupyterwidgetmodels.v8.md
@@ -717,7 +717,7 @@ Attribute        | Type             | Default          | Help
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
 `_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'PlayModel'`    | 
-`_playing`       | boolean          | `false`          | Whether the control is currently playing.
+`playing`       | boolean          | `false`          | Whether the control is currently playing.
 `_repeat`        | boolean          | `false`          | Whether the control will repeat in a continous loop.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'1.4.0'`        | 

--- a/packages/schema/jupyterwidgetmodels.v8.md
+++ b/packages/schema/jupyterwidgetmodels.v8.md
@@ -718,7 +718,7 @@ Attribute        | Type             | Default          | Help
 `_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'PlayModel'`    | 
 `playing`       | boolean          | `false`          | Whether the control is currently playing.
-`_repeat`        | boolean          | `false`          | Whether the control will repeat in a continous loop.
+`repeat`         | boolean          | `false`          | Whether the control will repeat in a continous loop.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'PlayView'`     | 


### PR DESCRIPTION
Fixes #1897.

Compared to the other widgets, there is no straightforward way to control the `Play` widget programmatically, except for `_playing` attribute as discussed in https://github.com/jupyter-widgets/ipywidgets/issues/1897.

Since the animation logic is happening on the frontend, this change is mostly about triggering the `click` method for the corresponding buttons. 

![play_stop_pause_methods](https://user-images.githubusercontent.com/591645/49545844-16e06400-f8df-11e8-945a-2406dece8972.gif)
