### PR TITLE
Expose JupyterLab Widget Manager

### DIFF
--- a/packages/jupyterlab-manager/src/index.ts
+++ b/packages/jupyterlab-manager/src/index.ts
@@ -2,9 +2,23 @@
 // Distributed under the terms of the Modified BSD License.
 
 import WidgetManagerProvider from './plugin';
+import * as output from './output';
 
 export default WidgetManagerProvider;
 
 export {
   INBWidgetExtension
 } from './plugin';
+
+export {
+  WidgetManager
+} from './manager';
+
+export {
+  WidgetRenderer
+} from './renderer';
+
+export {
+  output
+};
+


### PR DESCRIPTION
This exposes jupyterlab-manager's `Output` and `Manager` implementation.

This is required by https://github.com/QuantStack/voila/pull/46 and the corresponding PR to thebelab to support the output widget and the `@interact` magic.