### PR TITLE
Enable noImplicitAny compiler check, fix tslint errors.

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -44,6 +44,7 @@
     "lodash": "^4.17.4"
   },
   "devDependencies": {
+    "@types/base64-js": "^1.2.5",
     "@types/expect.js": "^0.3.29",
     "@types/mocha": "^2.2.41",
     "chai": "^4.0.0",

--- a/packages/base/src/backbone-patch.ts
+++ b/packages/base/src/backbone-patch.ts
@@ -43,18 +43,19 @@ import * as utils from './utils';
 // anyone who needs to know about the change in state. The heart of the beast.
 // This *MUST* be called with the model as the `this` context.
 export
-function set(key, val, options) {
+function set(key: string|{}, val: any, options: any) {
+    /* tslint:disable:no-invalid-this */
     if (key == null) {
         return this;
     }
 
     // Handle both `"key", value` and `{key: value}` -style arguments.
-    let attrs;
+    let attrs: any;
     if (typeof key === 'object') {
         attrs = key;
         options = val;
     } else {
-        (attrs = {})[key] = val;
+        (attrs = {} as {[key: string]: any})[key as string] = val;
     }
 
     options || (options = {});
@@ -124,4 +125,5 @@ function set(key, val, options) {
     this._pending = false;
     this._changing = false;
     return this;
+    /* tslint:enable:no-invalid-this */
 }

--- a/packages/base/src/manager-base.ts
+++ b/packages/base/src/manager-base.ts
@@ -561,7 +561,7 @@ interface IStateOptions {
  */
 export
 function serialize_state(models: WidgetModel[], options: IStateOptions = {}) {
-    const state = {};
+    const state: {[key: string]: any} = {};
     models.forEach(model => {
         const model_id = model.model_id;
         const split = utils.remove_buffers(model.serialize(model.get_state(options.drop_defaults)));

--- a/packages/base/src/manager-base.ts
+++ b/packages/base/src/manager-base.ts
@@ -25,6 +25,7 @@ const PROTOCOL_MAJOR_VERSION = PROTOCOL_VERSION.split('.', 1)[0];
  * Either a comm or a model_id must be provided.
  */
 export
+// tslint:disable-next-line:interface-name
 interface ModelOptions {
     /**
      * Target name of the widget model to create.
@@ -77,6 +78,7 @@ interface ModelOptions {
  * Either a comm or a model_id must be provided.
  */
 export
+// tslint:disable-next-line:interface-name
 interface WidgetOptions {
     /**
      * Target name of the widget model to create.
@@ -397,12 +399,12 @@ abstract class ManagerBase<T> {
      * current manager state, and then attempts to redisplay the widgets in the
      * state.
      */
-    set_state(state): Promise<WidgetModel[]> {
+    set_state(state: any): Promise<WidgetModel[]> {
         // Check to make sure that it's the same version we are parsing.
         if (!(state.version_major && state.version_major <= 2)) {
             throw 'Unsupported widget state format';
         }
-        let models = state.state;
+        let models = state.state as any;
         // Recreate all the widget models for the given widget manager state.
         let all_models = this._get_comm_info().then(live_comms => {
             /* Note: It is currently safe to just loop over the models in any order,
@@ -422,9 +424,9 @@ abstract class ManagerBase<T> {
                 let model = models[model_id];
                 let modelState = model.state;
                 if (model.buffers) {
-                    let bufferPaths = model.buffers.map(b => b.path);
+                    let bufferPaths = model.buffers.map((b: any) => b.path);
                     // put_buffers expects buffers to be DataViews
-                    let buffers = model.buffers.map(b => new DataView(decode[b.encoding](b.data)));
+                    let buffers = model.buffers.map((b: any) => new DataView(decode[b.encoding](b.data)));
                     utils.put_buffers(model.state, bufferPaths, buffers);
                 }
 
@@ -511,7 +513,7 @@ abstract class ManagerBase<T> {
         metadata?: any,
         buffers?: ArrayBuffer[] | ArrayBufferView[]):
         Promise<IClassicComm>;
-    protected abstract _get_comm_info();
+    protected abstract _get_comm_info(): Promise<{}>;
 
     /**
      * Filter serialized widget state to remove any ID's already present in manager.

--- a/packages/base/src/nativeview.ts
+++ b/packages/base/src/nativeview.ts
@@ -35,7 +35,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 import * as Backbone from 'backbone';
 
 // Caches a local reference to `Element.prototype` for faster access.
-const ElementProto: Element = Element.prototype; // : typeof Element = (typeof Element !== 'undefined' && Element.prototype) || {};
+const ElementProto: any = Element.prototype; // : typeof Element = (typeof Element !== 'undefined' && Element.prototype) || {};
 
 // Find the right `Element#matches` for IE>=9 and modern browsers.
 let matchesSelector = ElementProto.matches ||
@@ -43,13 +43,15 @@ let matchesSelector = ElementProto.matches ||
     ElementProto['mozMatchesSelector'] ||
     ElementProto['msMatchesSelector'] ||
     ElementProto['oMatchesSelector'] ||
-    function matches(selector) {
+    function matches(selector: string) {
+        /* tslint:disable:no-invalid-this */
         let matches = (this.document || this.ownerDocument).querySelectorAll(selector);
         let i = matches.length;
         while (--i >= 0 && matches.item(i) !== this) {
           continue;
         }
         return i > -1;
+        /* tslint:enable:no-invalid-this */
     };
 
 interface IDOMEvent {
@@ -75,7 +77,7 @@ class NativeView<T extends Backbone.Model> extends Backbone.View<T> {
 
     // Set a hash of attributes to the view's `el`. We use the "prop" version
     // if available, falling back to `setAttribute` for the catch-all.
-    _setAttributes(attrs) {
+    _setAttributes(attrs: {[key: string]: string}) {
       for (let attr in attrs) {
         attr in this.el ? this.el[attr] = attrs[attr] : this.el.setAttribute(attr, attrs[attr]);
       }
@@ -90,12 +92,12 @@ class NativeView<T extends Backbone.Model> extends Backbone.View<T> {
      * the event's `delegateTarget` property is set to it and the return the
      * result of calling bound `listener` with the parameters given to the
      * handler.
-     * 
-     * This does not properly handle selectors for things like focus and blur (see 
+     *
+     * This does not properly handle selectors for things like focus and blur (see
      * https://github.com/jquery/jquery/blob/7d21f02b9ec9f655583e898350badf89165ed4d5/src/event.js#L442
      * for some similar exceptional cases).
      */
-    delegate(eventName, selector, listener) {
+    delegate(eventName: string, selector: any, listener: any) {
       if (typeof selector !== 'string') {
         listener = selector;
         selector = null;
@@ -109,11 +111,11 @@ class NativeView<T extends Backbone.Model> extends Backbone.View<T> {
       }
 
       let root = this.el;
-      let handler = selector ? function (e) {
-        let node = e.target || e.srcElement;
+      let handler = selector ? function (e: Event) {
+        let node = (e.target as Node) || e.srcElement;
         for (; node && node !== root; node = node.parentNode) {
           if (matchesSelector.call(node, selector)) {
-            e.delegateTarget = node;
+            (e as any).delegateTarget = node;
             if (listener.handleEvent) {
                 return listener.handleEvent(e);
             } else {
@@ -130,7 +132,7 @@ class NativeView<T extends Backbone.Model> extends Backbone.View<T> {
 
     // Remove a single delegated event. Either `eventName` or `selector` must
     // be included, `selector` and `listener` are optional.
-    undelegate(eventName, selector, listener) {
+    undelegate(eventName: string, selector?: any, listener?: any) {
       if (typeof selector === 'function') {
         listener = selector;
         selector = null;

--- a/packages/base/src/services-shim.ts
+++ b/packages/base/src/services-shim.ts
@@ -7,7 +7,6 @@
  * embed live widgets in a context outside of the notebook.
  */
 
-import * as utils from './utils';
 import {
     Kernel, KernelMessage
 } from '@jupyterlab/services';
@@ -99,7 +98,7 @@ namespace shims {
              * Hookup kernel events.
              * @param  {Kernel.IKernel} jsServicesKernel - @jupyterlab/services Kernel.IKernel instance
              */
-            init_kernel(jsServicesKernel) {
+            init_kernel(jsServicesKernel: Kernel.IKernel) {
                 this.kernel = jsServicesKernel; // These aren't really the same.
                 this.jsServicesKernel = jsServicesKernel;
             }
@@ -121,7 +120,7 @@ namespace shims {
              * @param  {(Comm, object) => void} f - callback that is called when the
              *                         comm is made.  Signature of f(comm, msg).
              */
-            register_target(target_name, f) {
+            register_target(target_name: string, f: (comm: Comm, data: {}) => void) {
                 let handle = this.jsServicesKernel.registerCommTarget(target_name,
                 (jsServicesComm, msg) => {
                     // Create the comm.
@@ -144,7 +143,7 @@ namespace shims {
              * Unregisters a comm target
              * @param  {string} target_name
              */
-            unregister_target(target_name, f) {
+            unregister_target(target_name: string, f: (comm: Comm, data: {}) => void) {
                 let handle = this.targets[target_name];
                 handle.dispose();
                 delete this.targets[target_name];
@@ -153,7 +152,7 @@ namespace shims {
             /**
              * Register a comm in the mapping
              */
-            register_comm(comm) {
+            register_comm(comm: Comm) {
               this.comms[comm.comm_id] = Promise.resolve(comm);
               comm.kernel = this.kernel;
               return comm.comm_id;
@@ -288,6 +287,7 @@ namespace shims {
             }
 
             jsServicesComm: Kernel.IComm = null;
+            kernel: Kernel.IKernel = null;
         }
     }
 }

--- a/packages/base/src/tsconfig.json
+++ b/packages/base/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    //"noImplicitAny": true,
+    "noImplicitAny": true,
     "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
     "types": [],
     "noEmitOnError": true,

--- a/packages/base/src/utils.ts
+++ b/packages/base/src/utils.ts
@@ -24,7 +24,7 @@ function difference(a: string[], b: string[]): string[] {
  * Compare two objects deeply to see if they are equal.
  */
 export
-function isEqual(a, b) {
+function isEqual(a: any, b: any) {
     return _isEqual(a, b);
 }
 
@@ -34,7 +34,7 @@ function isEqual(a, b) {
  * This is from code that Typescript 2.4 generates for a polyfill.
  */
 export
-let assign = (Object as any).assign || function(t) {
+let assign = (Object as any).assign || function(t: any) {
     for (let i = 1; i < arguments.length; i++) {
         let s = arguments[i];
         for (let p in s) {
@@ -65,7 +65,7 @@ function uuid(): string {
  */
 export
 class WrappedError extends Error {
-    constructor(message, error) {
+    constructor(message: string, error: any) {
         super(message);
         console.warn('WrappedError has been deprecated!');
         // Keep a stack of the original error messages.
@@ -112,8 +112,8 @@ function resolvePromisesDict<V>(d: Dict<PromiseLike<V>>): Promise<Dict<V>> {
  * the original error that caused the promise to reject.
  */
 export
-function reject(message, log) {
-    return function promiseRejection(error) {
+function reject(message: string, log: boolean) {
+    return function promiseRejection(error: any) {
         if (log) {
             console.error(new Error(message));
         }
@@ -131,7 +131,7 @@ function reject(message, log) {
  * Will lead to {a: 1, b: {data: array1}, c: [0, array2]}
  */
 export
-function put_buffers(state, buffer_paths: (string | number)[][], buffers: DataView[]) {
+function put_buffers(state: any, buffer_paths: (string | number)[][], buffers: DataView[]) {
     for (let i=0; i < buffer_paths.length; i++) {
         let buffer_path = buffer_paths[i];
          // say we want to set state[x][y][z] = buffers[i]
@@ -156,13 +156,13 @@ function put_buffers(state, buffer_paths: (string | number)[][], buffers: DataVi
  * and the buffers associated to those paths (.buffers).
  */
 export
-function remove_buffers(state): {state: any, buffers: ArrayBuffer[], buffer_paths: (string | number)[][]} {
+function remove_buffers(state: any): {state: any, buffers: ArrayBuffer[], buffer_paths: (string | number)[][]} {
     let buffers: ArrayBuffer[] = [];
     let buffer_paths: (string | number)[][] = [];
     // if we need to remove an object from a list, we need to clone that list, otherwise we may modify
     // the internal state of the widget model
     // however, we do not want to clone everything, for performance
-    function remove(obj, path) {
+    function remove(obj: any, path: (string | number)[]) {
         if (obj.toJSON) {
             // We need to get the JSON form of the object before recursing.
             // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior

--- a/packages/base/src/viewlist.ts
+++ b/packages/base/src/viewlist.ts
@@ -15,11 +15,11 @@
  */
 export
 class ViewList<T> {
-    constructor(create_view: (model: any, index: any) => T | Promise<T>, remove_view: (view: T) => void, context) {
+    constructor(create_view: (model: any, index: any) => T | Promise<T>, remove_view: (view: T) => void, context: any) {
         this.initialize(create_view, remove_view, context);
     }
 
-    initialize(create_view: (model: any, index: any) => T | Promise<T>, remove_view: (view: T) => void, context) {
+    initialize(create_view: (model: any, index: any) => T | Promise<T>, remove_view: (view: T) => void, context: any) {
         this._handler_context = context || this;
         this._models = [];
         this.views = []; // list of promises for views
@@ -34,7 +34,7 @@ class ViewList<T> {
      * if you want to perform some action on the list of views, do something like
      * `Promise.all(myviewlist.views).then(function(views) {...});`
      */
-    update(new_models, create_view?: (model: any, index: any) => T | Promise<T>, remove_view?: (view: T) => void, context?): Promise<T[]> {
+    update(new_models: any[], create_view?: (model: any, index: any) => T | Promise<T>, remove_view?: (view: T) => void, context?: any): Promise<T[]> {
         let remove = remove_view || this._remove_view;
         let create = create_view || this._create_view;
         context = context || this._handler_context;

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -28,20 +28,23 @@ import {
     JUPYTER_WIDGETS_VERSION
 } from './version';
 
+import {
+    KernelMessage
+} from '@jupyterlab/services';
+
 /**
  * Replace model ids with models recursively.
  */
 export
-function unpack_models(value, manager): Promise<any> {
-    let unpacked;
+function unpack_models(value: any, manager: managerBase.ManagerBase<any>): Promise<any> {
     if (Array.isArray(value)) {
-        unpacked = [];
+        const unpacked: any[] = [];
         value.forEach((sub_value, key) => {
             unpacked.push(unpack_models(sub_value, manager));
         });
         return Promise.all(unpacked);
     } else if (value instanceof Object) {
-        unpacked = {};
+        const unpacked: {[key: string]: any} = {};
         Object.keys(value).forEach((key) => {
             unpacked[key] = unpack_models(value[key], manager);
         });
@@ -79,9 +82,9 @@ class WidgetModel extends Backbone.Model {
             _model_name: 'WidgetModel',
             _model_module_version: JUPYTER_WIDGETS_VERSION,
             _view_module: '@jupyter-widgets/base',
-            _view_name: null,
+            _view_name: null as string,
             _view_module_version: JUPYTER_WIDGETS_VERSION,
-            _view_count: null,
+            _view_count: null as number,
         };
     }
 
@@ -108,7 +111,7 @@ class WidgetModel extends Backbone.Model {
      *      An ID unique to this model.
      * comm : Comm instance (optional)
      */
-    initialize(attributes, options: {model_id: string, comm?: any, widget_manager: any}) {
+    initialize(attributes: any, options: {model_id: string, comm?: any, widget_manager: any}) {
         super.initialize(attributes, options);
 
         // Attributes should be initialized here, since user initialization may depend on it
@@ -155,7 +158,7 @@ class WidgetModel extends Backbone.Model {
     /**
      * Send a custom msg over the comm.
      */
-    send(content, callbacks, buffers?) {
+    send(content: {}, callbacks: {}, buffers?: ArrayBuffer[] | ArrayBufferView[]) {
         if (this.comm !== undefined) {
             let data = {method: 'custom', content: content};
             this.comm.send(data, callbacks, {}, buffers);
@@ -194,7 +197,7 @@ class WidgetModel extends Backbone.Model {
     /**
      * Handle when a widget comm is closed.
      */
-    _handle_comm_closed(msg) {
+    _handle_comm_closed(msg: KernelMessage.ICommCloseMsg) {
         this.trigger('comm:close');
         this.close(true);
     }
@@ -202,14 +205,16 @@ class WidgetModel extends Backbone.Model {
     /**
      * Handle incoming comm msg.
      */
-    _handle_comm_msg(msg): Promise<void> {
-        let method = msg.content.data.method;
+    _handle_comm_msg(msg: KernelMessage.ICommMsgMsg): Promise<void> {
+        const data = msg.content.data as any;
+        let method = data.method;
+        // tslint:disable-next-line:switch-default
         switch (method) {
             case 'update':
                 this.state_change = this.state_change
                     .then(() => {
-                        let state = msg.content.data.state;
-                        let buffer_paths = msg.content.data.buffer_paths || [];
+                        let state = data.state;
+                        let buffer_paths = data.buffer_paths || [];
                         // Make sure the buffers are DataViews
                         let buffers = (msg.buffers || []).map(b => {
                             if (b instanceof DataView) {
@@ -226,7 +231,7 @@ class WidgetModel extends Backbone.Model {
                     }).catch(utils.reject(`Could not process update msg for model id: ${this.model_id}`, true));
                 return this.state_change;
             case 'custom':
-                this.trigger('msg:custom', msg.content.data.content, msg.buffers);
+                this.trigger('msg:custom', data.content, msg.buffers);
                 return Promise.resolve();
         }
     }
@@ -253,13 +258,13 @@ class WidgetModel extends Backbone.Model {
      * If drop_default is truthy, attributes that are equal to their default
      * values are dropped.
      */
-    get_state(drop_defaults) {
+    get_state(drop_defaults: boolean) {
         let fullState = this.attributes;
         if (drop_defaults) {
             // if defaults is a function, call it
             let d = this.defaults;
             let defaults = (typeof d === 'function') ? d.call(this) : d;
-            let state = {};
+            let state: {[key: string]: any} = {};
             Object.keys(fullState).forEach(key => {
                 if (!(utils.isEqual(fullState[key], defaults[key]))) {
                     state[key] = fullState[key];
@@ -276,7 +281,7 @@ class WidgetModel extends Backbone.Model {
      *
      * execution_state : ('busy', 'idle', 'starting')
      */
-    _handle_status(msg) {
+    _handle_status(msg: KernelMessage.IStatusMsg) {
         if (this.comm !== void 0) {
             if (msg.content.execution_state === 'idle') {
                 this._pending_msgs--;
@@ -451,11 +456,11 @@ class WidgetModel extends Backbone.Model {
     /**
      * Send a sync message to the kernel.
      */
-    send_sync_message(state, callbacks: any = {}) {
+    send_sync_message(state: {}, callbacks: any = {}) {
         try {
             callbacks.iopub = callbacks.iopub || {};
             let statuscb = callbacks.iopub.status;
-            callbacks.iopub.status = (msg) => {
+            callbacks.iopub.status = (msg: KernelMessage.IStatusMsg) => {
                 this._handle_status(msg);
                 if (statuscb) {
                     statuscb(msg);
@@ -480,7 +485,7 @@ class WidgetModel extends Backbone.Model {
      *
      * This invokes a Backbone.Sync.
      */
-    save_changes(callbacks?) {
+    save_changes(callbacks?: {}) {
         if (this.comm_live) {
             let options: any = {patch: true};
             if (callbacks) {
@@ -498,9 +503,10 @@ class WidgetModel extends Backbone.Model {
      * the second form will result in foo being called twice
      * while the first will call foo only once.
      */
-    on_some_change(keys, callback, context) {
-        this.on('change', function() {
-            if (keys.some(this.hasChanged, this)) {
+    on_some_change(keys: string[], callback: (...args: any[]) => void, context: any) {
+        const scope = this;
+        this.on('change', function () {
+            if (keys.some(scope.hasChanged, scope)) {
                 callback.apply(context, arguments);
             }
         }, this);
@@ -510,7 +516,7 @@ class WidgetModel extends Backbone.Model {
      * Serialize the model.  See the deserialization function at the top of this file
      * and the kernel-side serializer/deserializer.
      */
-    toJSON(options) {
+    toJSON(options: any) {
         return `IPY_MODEL_${this.model_id}`;
     }
 
@@ -519,9 +525,9 @@ class WidgetModel extends Backbone.Model {
      * is an instance of widget manager, which is required for the
      * deserialization of widget models.
      */
-    static _deserialize_state(state, manager) {
+    static _deserialize_state(state: {[key: string]: any}, manager: managerBase.ManagerBase<any>) {
         let serializers = this.serializers;
-        let deserialized;
+        let deserialized: {[key: string]: any};
         if (serializers) {
             deserialized = {};
             for (let k in state) {
@@ -595,7 +601,7 @@ class WidgetView extends NativeView<WidgetModel> {
     /**
      * Initializer, called at the end of the constructor.
      */
-    initialize(parameters) {
+    initialize(parameters: WidgetView.InitializeParameters) {
         this.listenTo(this.model, 'change', () => {
             let changed = Object.keys(this.model.changedAttributes() || {});
             if (changed[0] === '_view_count' && changed.length === 1) {
@@ -631,7 +637,7 @@ class WidgetView extends NativeView<WidgetModel> {
      *
      * Update view to be consistent with this.model
      */
-    update(options?) {
+    update(options?: any) {
         return;
     }
 
@@ -647,8 +653,7 @@ class WidgetView extends NativeView<WidgetModel> {
     /**
      * Create and promise that resolves to a child view of a given model
      */
-    create_child_view(child_model, options = {}) {
-        let that = this;
+    create_child_view(child_model: WidgetModel, options = {}) {
         options = { parent: this, ...options};
         return this.model.widget_manager.create_view(child_model, options)
             .catch(utils.reject('Could not create child view', true));
@@ -664,7 +669,7 @@ class WidgetView extends NativeView<WidgetModel> {
     /**
      * Send a custom msg associated with this view.
      */
-    send(content, buffers?) {
+    send(content: {}, buffers?: ArrayBuffer[] | ArrayBufferView[]) {
         this.model.send(content, this.callbacks(), buffers);
     }
 
@@ -685,6 +690,12 @@ class WidgetView extends NativeView<WidgetModel> {
      * A promise that resolves to the parent view when a child view is displayed.
      */
     displayed: Promise<WidgetView>;
+}
+
+export namespace WidgetView {
+    export interface InitializeParameters<T extends WidgetModel = WidgetModel> extends Backbone.ViewOptions<T> {
+        options: any;
+    }
 }
 
 export
@@ -739,21 +750,21 @@ class DOMWidgetView extends WidgetView {
     /**
      * Public constructor
      */
-    initialize(parameters) {
+    initialize(parameters: WidgetView.InitializeParameters) {
         super.initialize(parameters);
 
-        this.listenTo(this.model, 'change:_dom_classes', (model, new_classes) => {
+        this.listenTo(this.model, 'change:_dom_classes', (model: WidgetModel, new_classes: string[]) => {
             let old_classes = model.previous('_dom_classes');
             this.update_classes(old_classes, new_classes);
         });
 
         this.layoutPromise = Promise.resolve();
-        this.listenTo(this.model, 'change:layout', (model, value) => {
+        this.listenTo(this.model, 'change:layout', (model: WidgetModel, value: WidgetModel) => {
             this.setLayout(value, model.previous('layout'));
         });
 
         this.stylePromise = Promise.resolve();
-        this.listenTo(this.model, 'change:style', (model, value) => {
+        this.listenTo(this.model, 'change:style', (model: WidgetModel, value: WidgetModel) => {
             this.setStyle(value, model.previous('style'));
         });
 
@@ -769,7 +780,7 @@ class DOMWidgetView extends WidgetView {
         });
     }
 
-    setLayout(layout, oldLayout?) {
+    setLayout(layout: WidgetModel, oldLayout?: WidgetModel) {
         if (layout) {
             this.layoutPromise = this.layoutPromise.then((oldLayoutView) => {
                 if (oldLayoutView) {
@@ -795,7 +806,7 @@ class DOMWidgetView extends WidgetView {
         }
     }
 
-    setStyle(style, oldStyle?) {
+    setStyle(style: WidgetModel, oldStyle?: WidgetModel) {
         if (style) {
             this.stylePromise = this.stylePromise.then((oldStyleView) => {
                 if (oldStyleView) {
@@ -820,7 +831,7 @@ class DOMWidgetView extends WidgetView {
     /**
      * Update the DOM classes applied to an element, default to this.el.
      */
-    update_classes(old_classes, new_classes, el?) {
+    update_classes(old_classes: string[], new_classes: string[], el?: HTMLElement) {
         if (el === undefined) {
             el = this.el;
         }
@@ -864,7 +875,7 @@ class DOMWidgetView extends WidgetView {
      * el: optional DOM element handle, defaults to this.el
      *  Element that the classes are applied to.
      */
-    update_mapped_classes(class_map, trait_name, el?) {
+    update_mapped_classes(class_map: {[key: string]: string[]}, trait_name: string, el?: HTMLElement) {
         let key = this.model.previous(trait_name);
         let old_classes = class_map[key] ? class_map[key] : [];
         key = this.model.get(trait_name);
@@ -873,7 +884,7 @@ class DOMWidgetView extends WidgetView {
         this.update_classes(old_classes, new_classes, el || this.el);
     }
 
-    set_mapped_classes(class_map, trait_name, el?) {
+    set_mapped_classes(class_map: {[key: string]: string[]}, trait_name: string, el?: HTMLElement) {
         let key = this.model.get(trait_name);
         let new_classes = class_map[key] ? class_map[key] : [];
         this.update_classes([], new_classes, el || this.el);
@@ -900,6 +911,7 @@ class DOMWidgetView extends WidgetView {
     }
 
     processPhosphorMessage(msg: Message) {
+        // tslint:disable-next-line:switch-default
         switch (msg.type) {
         case 'after-attach':
             this.trigger('displayed');

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -82,9 +82,9 @@ class WidgetModel extends Backbone.Model {
             _model_name: 'WidgetModel',
             _model_module_version: JUPYTER_WIDGETS_VERSION,
             _view_module: '@jupyter-widgets/base',
-            _view_name: null as string,
+            _view_name: null as string | null,
             _view_module_version: JUPYTER_WIDGETS_VERSION,
-            _view_count: null as number,
+            _view_count: null as number | null,
         };
     }
 

--- a/packages/base/src/widget_layout.ts
+++ b/packages/base/src/widget_layout.ts
@@ -13,7 +13,7 @@ import {
 /**
  * css properties exposed by the layout widget with their default values.
  */
-let css_properties = {
+let css_properties: {[key: string]: string} = {
     align_content: null,
     align_items: null,
     align_self: null,
@@ -71,7 +71,7 @@ class LayoutView extends WidgetView {
     /**
      * Public constructor
      */
-    initialize(parameters) {
+    initialize(parameters: WidgetView.InitializeParameters) {
         this._traitNames = [];
         super.initialize(parameters);
         // Register the traits that live on the Python side
@@ -88,7 +88,7 @@ class LayoutView extends WidgetView {
         this._traitNames.push(trait);
 
         // Listen to changes, and set the value on change.
-        this.listenTo(this.model, 'change:' + trait, (model, value) => {
+        this.listenTo(this.model, 'change:' + trait, (model: LayoutModel, value: any) => {
             this.handleChange(trait, value);
         });
 

--- a/packages/base/src/widget_style.ts
+++ b/packages/base/src/widget_style.ts
@@ -23,7 +23,13 @@ class StyleModel extends WidgetModel {
         }, {}));
     }
 
-    public static styleProperties = {};
+    public static styleProperties: {[s: string]: IStyleProperty} = {};
+}
+
+interface IStyleProperty {
+    attribute: string;
+    selector: string;
+    default: string;
 }
 
 export
@@ -32,7 +38,7 @@ class StyleView extends WidgetView {
     /**
      * Public constructor
      */
-    initialize(parameters) {
+    initialize(parameters: WidgetView.InitializeParameters) {
         this._traitNames = [];
         super.initialize(parameters);
         // Register the traits that live on the Python side
@@ -53,7 +59,7 @@ class StyleView extends WidgetView {
         this._traitNames.push(trait);
 
         // Listen to changes, and set the value on change.
-        this.listenTo(this.model, 'change:' + trait, (model, value) => {
+        this.listenTo(this.model, 'change:' + trait, (model: StyleModel, value: string) => {
             this.handleChange(trait, value);
         });
     }

--- a/packages/base/tslint.json
+++ b/packages/base/tslint.json
@@ -1,3 +1,8 @@
 {
-  "extends": "../../tslint.json"
+  "extends": "../../tslint.json",
+  "linterOptions": {
+    "exclude": [
+      "test/**"
+    ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,6 +1004,10 @@
     "@types/jquery" "*"
     "@types/underscore" "*"
 
+"@types/base64-js@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/@types/base64-js/-/base64-js-1.2.5.tgz#582b2476169a6cba460a214d476c744441d873d5"
+
 "@types/dom4@^2.0.0":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@types/dom4/-/dom4-2.0.1.tgz#506d5781b9bcab81bd9a878b198aec7dee2a6033"


### PR DESCRIPTION
This enables the noImplicitAny TS compiler check, with types specified to the closest approximation as I could determine. Also fixed up a handful of tslint warnings and disabled them for the test code to allow `yarn lint` to exit clean.