### PR TITLE
Fix building with python 3.7

### DIFF
--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -238,7 +238,7 @@ def escape_script(s):
     We only replace these three cases so that most html or other content
     involving `<` is readable.
     """
-    return script_escape_re.sub(r'\u003c\1', s)
+    return script_escape_re.sub('\\\\u003c\\1', s)
 
 @doc_subst(_doc_snippets)
 def embed_snippet(views,


### PR DESCRIPTION
Unicode characters like \u003c are not recognized in raw strings and raise an
error with python 3.7:

[    9s] ERROR: ipywidgets.tests.test_embed.TestEmbed.test_snippet
[    9s] ----------------------------------------------------------------------
[    9s] Traceback (most recent call last):
[    9s]   File "/usr/lib64/python3.7/sre_parse.py", line 1021, in parse_template
[    9s]     this = chr(ESCAPES[this][1])
[    9s] KeyError: '\\u'
[    9s]
[    9s] During handling of the above exception, another exception occurred:
[    9s]
[    9s] Traceback (most recent call last):
[    9s]   File "/usr/lib/python3.7/site-packages/nose/case.py", line 197, in runTest
[    9s]     self.test(*self.arg)
[    9s]   File "/home/abuild/rpmbuild/BUILDROOT/python-jupyter_ipywidgets-7.4.2-0.x86_64/usr/lib/python3.7/site-packages/ipywidgets/tests/test_embed.py", line 177, in test_snippet
[    9s]     snippet = embed_snippet(views=w, drop_defaults=True, state=state)
[    9s]   File "/home/abuild/rpmbuild/BUILDROOT/python-jupyter_ipywidgets-7.4.2-0.x86_64/usr/lib/python3.7/site-packages/ipywidgets/embed.py", line 268, in embed_snippet
[    9s]     for view_spec in data['view_specs']
[    9s]   File "/home/abuild/rpmbuild/BUILDROOT/python-jupyter_ipywidgets-7.4.2-0.x86_64/usr/lib/python3.7/site-packages/ipywidgets/embed.py", line 268, in <genexpr>
[    9s]     for view_spec in data['view_specs']
[    9s]   File "/home/abuild/rpmbuild/BUILDROOT/python-jupyter_ipywidgets-7.4.2-0.x86_64/usr/lib/python3.7/site-packages/ipywidgets/embed.py", line 241, in escape_script
[    9s]     return script_escape_re.sub(r'\u003c\1', s)
[    9s]   File "/usr/lib64/python3.7/re.py", line 309, in _subx
[    9s]     template = _compile_repl(template, pattern)
[    9s]   File "/usr/lib64/python3.7/re.py", line 300, in _compile_repl
[    9s]     return sre_parse.parse_template(repl, pattern)
[    9s]   File "/usr/lib64/python3.7/sre_parse.py", line 1024, in parse_template
[    9s]     raise s.error('bad escape %s' % this, len(this))
[    9s] re.error: bad escape \u at position 0

Note that https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
says that \u is only recognized in string literals, not in raw strings.