### PR TITLE
Use JupyterLab notebook tracker rather than the document widget extension mechanism

### DIFF
--- a/packages/jupyterlab-manager/package.json
+++ b/packages/jupyterlab-manager/package.json
@@ -45,14 +45,18 @@
     "@jupyterlab/rendermime": "^1.0.0-alpha.3",
     "@jupyterlab/rendermime-interfaces": "^1.3.0-alpha.3",
     "@jupyterlab/services": "^4.0.0-alpha.3",
+    "@phosphor/algorithm": "^1.1.0",
+    "@phosphor/coreutils": "^1.3.0",
     "@phosphor/disposable": "^1.1.1",
     "@phosphor/messaging": "^1.2.1",
+    "@phosphor/properties": "^1.1.0",
     "@phosphor/widgets": "^1.3.0",
     "@types/backbone": "^1.3.33",
     "jquery": "^3.1.1",
     "semver": "^5.1.0"
   },
   "devDependencies": {
+    "@jupyterlab/cells": "^1.0.0-alpha.3",
     "@types/semver": "^5.4.0",
     "rimraf": "^2.6.1",
     "tslint": "^5.8.0",

--- a/packages/jupyterlab-manager/src/index.ts
+++ b/packages/jupyterlab-manager/src/index.ts
@@ -7,7 +7,7 @@ import * as output from './output';
 export default WidgetManagerProvider;
 
 export {
-  INBWidgetExtension
+  registerWidgetManager
 } from './plugin';
 
 export {

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -123,12 +123,11 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
    * Create a comm.
    */
   async _create_comm(target_name: string, model_id: string, data?: any, metadata?: any, buffers?: ArrayBuffer[] | ArrayBufferView[]): Promise<IClassicComm> {
-    // We await connectToComm because we still support using @jupyterlab/services<4
-    let comm = await this._context.session.kernel.connectToComm(target_name, model_id);
+    let comm = this._context.session.kernel.connectToComm(target_name, model_id);
     if (data || metadata) {
       comm.open(data, metadata, buffers);
     }
-    return Promise.resolve(new shims.services.Comm(comm));
+    return new shims.services.Comm(comm);
   }
 
   /**

--- a/packages/jupyterlab-manager/src/plugin.ts
+++ b/packages/jupyterlab-manager/src/plugin.ts
@@ -18,6 +18,10 @@ import {
 } from '@phosphor/disposable';
 
 import {
+  AttachedProperty
+} from '@phosphor/properties';
+
+import {
   WidgetRenderer
 } from './renderer';
 
@@ -43,8 +47,12 @@ const WIDGET_REGISTRY: base.IWidgetRegistryData[] = [];
 
 export
 function registerWidgetManager(context: DocumentRegistry.IContext<INotebookModel>, rendermime: RenderMimeRegistry) {
-  const wManager = new WidgetManager(context, rendermime);
-  WIDGET_REGISTRY.forEach(data => wManager.register(data));
+  let wManager = Private.widgetManagerProperty.get(context);
+  if (!wManager) {
+    wManager = new WidgetManager(context, rendermime);
+    WIDGET_REGISTRY.forEach(data => wManager.register(data));
+    Private.widgetManagerProperty.set(context, wManager);
+  }
   rendermime.addFactory({
     safe: false,
     mimeTypes: [WIDGET_MIMETYPE],
@@ -125,4 +133,17 @@ function activateWidgetExtension(app: JupyterFrontEnd, tracker: INotebookTracker
       WIDGET_REGISTRY.push(data);
     }
   };
+}
+
+namespace Private {
+  /**
+   * A private attached property for a widget manager.
+   */
+  export const widgetManagerProperty = new AttachedProperty<
+    DocumentRegistry.Context,
+    WidgetManager | undefined
+  >({
+    name: 'widgetManager',
+    create: () => undefined
+  });
 }


### PR DESCRIPTION
This explores using the tracker mechanism in JLab instead of the document widget extensions, as explained in https://github.com/jupyterlab/jupyterlab/issues/3974.

It seems to work pretty well!