### PR TITLE
FIX: displaying a widget without a view should only have text/plain in the mimebundle

### DIFF
--- a/ipywidgets/widgets/tests/test_widget.py
+++ b/ipywidgets/widgets/tests/test_widget.py
@@ -8,6 +8,7 @@ from IPython.display import display
 from IPython.utils.capture import capture_output
 
 from ..widget import Widget
+from ..widget_button import Button
 
 
 def test_no_widget_view():
@@ -19,6 +20,26 @@ def test_no_widget_view():
         w = Widget()
         display(w)
 
-    assert cap.outputs == [], repr(cap.outputs)
+    assert len(cap.outputs) == 1, "expect 1 output"
+    mime_bundle = cap.outputs[0].data
+    assert mime_bundle['text/plain'] == repr(w), "expected plain text output"
+    assert 'application/vnd.jupyter.widget-view+json' not in mime_bundle, "widget has no view"
+    assert cap.stdout == '', repr(cap.stdout)
+    assert cap.stderr == '', repr(cap.stderr)
+
+
+def test_widget_view():
+    # ensure IPython shell is instantiated
+    # otherwise display() just calls print
+    shell = InteractiveShell.instance()
+
+    with capture_output() as cap:
+        w = Button()
+        display(w)
+
+    assert len(cap.outputs) == 1, "expect 1 output"
+    mime_bundle = cap.outputs[0].data
+    assert mime_bundle['text/plain'] == repr(w), "expected plain text output"
+    assert 'application/vnd.jupyter.widget-view+json' in mime_bundle, "widget should have have a view"
     assert cap.stdout == '', repr(cap.stdout)
     assert cap.stderr == '', repr(cap.stderr)

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -706,26 +706,27 @@ class Widget(LoggingHasTraits):
 
     def _ipython_display_(self, **kwargs):
         """Called when `IPython.display.display` is called on the widget."""
-        if self._view_name is not None:
 
-            plaintext = repr(self)
-            if len(plaintext) > 110:
-                plaintext = plaintext[:110] + '…'
+        plaintext = repr(self)
+        if len(plaintext) > 110:
+            plaintext = plaintext[:110] + '…'
+        data = {
+            'text/plain': plaintext,
+        }
+        if self._view_name is not None:
             # The 'application/vnd.jupyter.widget-view+json' mimetype has not been registered yet.
             # See the registration process and naming convention at
             # http://tools.ietf.org/html/rfc6838
             # and the currently registered mimetypes at
             # http://www.iana.org/assignments/media-types/media-types.xhtml.
-            data = {
-                'text/plain': plaintext,
-                'application/vnd.jupyter.widget-view+json': {
-                    'version_major': 2,
-                    'version_minor': 0,
-                    'model_id': self._model_id
-                }
+            data['application/vnd.jupyter.widget-view+json'] = {
+                'version_major': 2,
+                'version_minor': 0,
+                'model_id': self._model_id
             }
-            display(data, raw=True)
+        display(data, raw=True)
 
+        if self._view_name is not None:
             self._handle_displayed(**kwargs)
 
     def _send(self, msg, buffers=None):


### PR DESCRIPTION
The current _ipython_display_ always adds the `'application/vnd.jupyter.widget-view+json'` mimetype to the mimebundle, that causes nothing to show for non-dom/view widgets:
![image](https://user-images.githubusercontent.com/1765949/53888316-7b1cdc00-4024-11e9-9a63-0c5a61ff0e28.png)

The expected output is:

![image](https://user-images.githubusercontent.com/1765949/53888346-8a038e80-4024-11e9-98d9-ae449a34a6fd.png)

Related PR #2021 
Reported in https://github.com/QuantStack/ipysheet/issues/7