### PR TITLE
add justify-items CSS property in Layout

### DIFF
--- a/ipywidgets/widgets/widget_layout.py
+++ b/ipywidgets/widgets/widget_layout.py
@@ -45,6 +45,8 @@ class Layout(Widget):
     height = Unicode(None, allow_none=True, help="The height CSS attribute.").tag(sync=True)
     justify_content = CaselessStrEnum(['flex-start', 'flex-end', 'center',
         'space-between', 'space-around'] + CSS_PROPERTIES, allow_none=True, help="The justify-content CSS attribute.").tag(sync=True)
+    justify_items = CaselessStrEnum(['flex-start', 'flex-end', 'center'] + CSS_PROPERTIES,
+        allow_none=True, help="The justify-items CSS attribute.").tag(sync=True)
     left = Unicode(None, allow_none=True, help="The left CSS attribute.").tag(sync=True)
     margin = Unicode(None, allow_none=True, help="The margin CSS attribute.").tag(sync=True)
     max_height = Unicode(None, allow_none=True, help="The max-height CSS attribute.").tag(sync=True)

--- a/packages/base/src/widget_layout.ts
+++ b/packages/base/src/widget_layout.ts
@@ -24,6 +24,7 @@ let css_properties = {
     flex_flow: null,
     height: null,
     justify_content: null,
+    justify_items: null,
     left: null,
     margin: null,
     max_height: null,

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -39,6 +39,7 @@ Attribute        | Type             | Default          | Help
 `grid_template_rows` | `null` or string | `null`           | The grid-template-rows CSS attribute.
 `height`         | `null` or string | `null`           | The height CSS attribute.
 `justify_content` | `null` or string (one of `'flex-start'`, `'flex-end'`, `'center'`, `'space-between'`, `'space-around'`, `'inherit'`, `'initial'`, `'unset'`) | `null`           | The justify-content CSS attribute.
+`justify_items`  | `null` or string (one of `'flex-start'`, `'flex-end'`, `'center'`, `'inherit'`, `'initial'`, `'unset'`) | `null`           | The justify-items CSS attribute.
 `left`           | `null` or string | `null`           | The left CSS attribute.
 `margin`         | `null` or string | `null`           | The margin CSS attribute.
 `max_height`     | `null` or string | `null`           | The max-height CSS attribute.


### PR DESCRIPTION
closes #2340 

This PR adds `justify_items` property to Layout class:

https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items

The following snippet:

```
from ipywidgets import GridBox, Button, Layout
GridBox(children=[Button(layout=Layout(width='50px', height='30px', grid_area='A')),
                  Button(layout=Layout(width='50px', height='30px', grid_area='B')),
                  Button(layout=Layout(width='50px', height='30px', grid_area='C')),
                  ],
        layout=Layout(
            grid_template_columns='1fr 1fr',
            grid_template_rows='1fr 1fr',
            grid_gap='10px',
            grid_template_areas='"A B" "C B"',
            align_items='center',
            justify_items='center')
       )
```

Should produce:

![image](https://user-images.githubusercontent.com/41565/54034169-7daf3b00-41b6-11e9-8870-ea70a8a711cc.png)

As opposed to (on master):

![image](https://user-images.githubusercontent.com/41565/54034219-9d466380-41b6-11e9-9616-3c02ed0f2519.png)
