### PR TITLE
FIX: inconsistency between actual notebook output and Output.outputs

### DIFF
--- a/packages/jupyterlab-manager/src/output.ts
+++ b/packages/jupyterlab-manager/src/output.ts
@@ -107,7 +107,7 @@ class OutputModel extends outputBase.OutputModel {
       break;
     case 'clear_output':
       this.clear_output((msg as KernelMessage.IClearOutputMsg).content.wait);
-      this.set('outputs', [], {newMessage: true});
+      this.set('outputs', this._outputs.toJSON(), {newMessage: true});
       this.save_changes();
       break;
     default:

--- a/packages/jupyterlab-manager/src/output.ts
+++ b/packages/jupyterlab-manager/src/output.ts
@@ -102,17 +102,15 @@ class OutputModel extends outputBase.OutputModel {
       let model = msg.content as nbformat.IOutput;
       model.output_type = msgType as nbformat.OutputType;
       this._outputs.add(model);
-      this.set('outputs', this._outputs.toJSON(), {newMessage: true});
-      this.save_changes();
       break;
     case 'clear_output':
       this.clear_output((msg as KernelMessage.IClearOutputMsg).content.wait);
-      this.set('outputs', this._outputs.toJSON(), {newMessage: true});
-      this.save_changes();
       break;
     default:
       break;
     }
+    this.set('outputs', this._outputs.toJSON(), {newMessage: true});
+    this.save_changes();
   }
 
   clear_output(wait: boolean = false) {

--- a/widgetsnbextension/src/widget_output.js
+++ b/widgetsnbextension/src/widget_output.js
@@ -44,7 +44,7 @@ var OutputModel = outputBase.OutputModel.extend({
             }, that);
             that.listenTo(that, 'clear_output', function(msg) {
                 that.output_area.handle_clear_output(msg);
-                that.set('outputs', [], {newMessage: true});
+                that.set('outputs', that.output_area.toJSON(), {newMessage: true});
                 that.save_changes();
             })
             that.listenTo(that, 'change:outputs', that.setOutputs);


### PR DESCRIPTION
Fixes #2350
I think this approach of updating the outputs trait will always make the notebook's real output and the outputs trait the same.