### PR TITLE
Ignore some characters on WidgetInt

### DIFF
--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -548,6 +548,7 @@ class IntTextView extends DescriptionView {
         return {
             'keydown input'  : 'handleKeyDown',
             'keypress input' : 'handleKeypress',
+            'keyup input': 'handleKeyUp',
             'input input'  : 'handleChanging',
             'change input' : 'handleChanged'
         };
@@ -569,6 +570,26 @@ class IntTextView extends DescriptionView {
      */
     handleKeypress(e) {
         e.stopPropagation();
+    }
+
+    /**
+     * Handle key up
+     */
+    handleKeyUp(e) {
+        /* remove invalid characters */
+        let value = e.target.value;
+
+        value = value.replace(/[e,.\s]/g, "");
+
+        if (value.length >= 1) {
+            var subvalue = value.substr(1);
+            value = value[0] + subvalue.replace(/[+-]/g, "");
+        }
+
+        if (e.target.value != value) {
+            e.preventDefault();
+            e.target.value = value;
+        }
     }
 
     /**

--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -565,17 +565,20 @@ class IntTextView extends DescriptionView {
 
     /**
      * Handles key press
-     *
-     * Stop propagation so the event isn't sent to the application.
      */
     handleKeypress(e) {
-        e.stopPropagation();
+        if (/[e,.\s]/.test(String.fromCharCode(e.keyCode))) {
+            e.preventDefault();
+        }
     }
 
     /**
      * Handle key up
      */
     handleKeyUp(e) {
+        if (e.altKey || e.ctrlKey) {
+            return;
+        }
         /* remove invalid characters */
         let value = e.target.value;
 


### PR DESCRIPTION
Resolves #1999 

In this PR:

- added a check on keypress for `e`, `.`, `,`, `\s`
- added a check on keyup* for `e`, `.`, `,`, `\s` and also for `+` and `-` in some conditions.

NOT in this PR:

- cannot remove undesired characters added by CTRL+V


* for some reason when pressed keys like `+` on keyup `e.target.value` is empty