### PR TITLE
Added a layout widget for 'stacked' layout

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -1112,7 +1112,46 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Accordion and Tab use `selected_index`, not value\n",
+    "### Stacked\n",
+    "\n",
+    "The `Stacked` widget can have multiple children widgets as for `Tab` and `Accordion`, but only shows one at a time depending on the value of ``selected_index``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "button = widgets.Button(description='Click here')\n",
+    "slider = widgets.IntSlider()\n",
+    "stacked = widgets.Stacked([button, slider])\n",
+    "stacked  # will show only the button"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This can be used in combination with another selection-based widget to show different widgets depending on the selection:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dropdown = widgets.Dropdown(options=['button', 'slider'])\n",
+    "widgets.jslink((dropdown, 'index'), (stacked, 'selected_index'))\n",
+    "widgets.VBox([dropdown, stacked])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accordion,  Tab, and Stacked use `selected_index`, not value\n",
     "\n",
     "Unlike the rest of the widgets discussed earlier, the container widgets `Accordion` and `Tab` update their `selected_index` attribute when the user changes which accordion or tab is selected. That means that you can both see what the user is doing *and* programmatically set what the user sees by setting the value of `selected_index`.\n",
     "\n",
@@ -1194,7 +1233,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.4"
+       "value": {},
   }
  },
  "nbformat": 4,

--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -17,7 +17,7 @@ from .widget_color import ColorPicker
 from .widget_date import DatePicker
 from .widget_output import Output
 from .widget_selection import RadioButtons, ToggleButtons, ToggleButtonsStyle, Dropdown, Select, SelectionSlider, SelectMultiple, SelectionRangeSlider
-from .widget_selectioncontainer import Tab, Accordion
+from .widget_selectioncontainer import Tab, Accordion, Stacked
 from .widget_string import HTML, HTMLMath, Label, Text, Textarea, Password, Combobox
 from .widget_controller import Controller
 from .interaction import interact, interactive, fixed, interact_manual, interactive_output

--- a/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/ipywidgets/widgets/widget_selectioncontainer.py
@@ -78,3 +78,10 @@ class Tab(_SelectionContainer):
     """Displays children each on a separate accordion tab."""
     _view_name = Unicode('TabView').tag(sync=True)
     _model_name = Unicode('TabModel').tag(sync=True)
+
+
+@register
+class Stacked(_SelectionContainer):
+    """Displays only the selected child."""
+    _view_name = Unicode('StackedView').tag(sync=True)
+    _model_name = Unicode('StackedModel').tag(sync=True)

--- a/packages/controls/src/widget_selectioncontainer.ts
+++ b/packages/controls/src/widget_selectioncontainer.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    DOMWidgetView, ViewList, JupyterLuminoWidget, WidgetModel
+    DOMWidgetView, ViewList, JupyterLuminoWidget, WidgetModel, WidgetView
 } from '@jupyter-widgets/base';
 
 import {
@@ -443,7 +443,7 @@ class StackedModel extends SelectionContainerModel {
 export
 class StackedView extends BoxView {
 
-    initialize(parameters) {
+    initialize(parameters: WidgetView.InitializeParameters) {
         super.initialize(parameters);
         this.listenTo(this.model, 'change:selected_index', this.update_children);
     }

--- a/packages/controls/src/widget_selectioncontainer.ts
+++ b/packages/controls/src/widget_selectioncontainer.ts
@@ -6,7 +6,7 @@ import {
 } from '@jupyter-widgets/base';
 
 import {
-    BoxModel
+    BoxModel, BoxView
 } from './widget_box';
 
 import {
@@ -427,4 +427,35 @@ class TabView extends DOMWidgetView {
     updatingTabs: boolean = false;
     childrenViews: ViewList<DOMWidgetView>;
     pWidget: JupyterLuminoTabPanelWidget;
+}
+
+
+export
+class StackedModel extends SelectionContainerModel {
+    defaults() {
+        return _.extend(super.defaults(), {
+            _model_name: 'StackedModel',
+            _view_name: 'StackedView'
+        });
+    }
+}
+
+export
+class StackedView extends BoxView {
+
+    initialize(parameters) {
+        super.initialize(parameters);
+        this.listenTo(this.model, 'change:selected_index', this.update_children);
+    }
+
+    update_children() {
+        let selected_child = this.model.get('children')[this.model.get('selected_index')];
+        this.children_views.update([selected_child]).then((views: DOMWidgetView[]) => {
+                // Notify all children that their sizes may have changed.
+                views.forEach( (view) => {
+                    MessageLoop.postMessage(view.pWidget, Widget.ResizeMessage.UnknownSize);
+                });
+        });
+    }
+
 }

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -928,6 +928,24 @@ Attribute        | Type             | Default          | Help
 `description_width` | string           | `''`             | Width of the description to the side of the control.
 `handle_color`   | `null` or string | `null`           | Color of the slider handle.
 
+### StackedModel (@jupyter-widgets/controls, 1.5.0); StackedView (@jupyter-widgets/controls, 1.5.0)
+
+Attribute        | Type             | Default          | Help
+-----------------|------------------|------------------|----
+`_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
+`_model_module`  | string           | `'@jupyter-widgets/controls'` | 
+`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_name`    | string           | `'StackedModel'` | 
+`_titles`        | object           | `{}`             | Titles of the pages
+`_view_module`   | string           | `'@jupyter-widgets/controls'` | 
+`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_name`     | string           | `'StackedView'`  | 
+`box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
+`children`       | array of reference to Widget widget | `[]`             | List of widget children
+`layout`         | reference to Layout widget | reference to new instance | 
+`selected_index` | `null` or number (integer) | `0`              | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
+`tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
+
 ### TabModel (@jupyter-widgets/controls, 1.5.0); TabView (@jupyter-widgets/controls, 1.5.0)
 
 Attribute        | Type             | Default          | Help


### PR DESCRIPTION
This adds a new layout widget that I've called 'Stacked' for now which behaves like a ``Box`` widget where one can switch between different widgets depending on a ``selection_index``. This is very useful when used in combination with another widget that can be used to select something. Here's the example I added to the docs:

![Screen-Recording-2019-04-14-at-22 53 35](https://user-images.githubusercontent.com/314716/56099721-793e1680-5f08-11e9-9b85-5c3dce529aaf.gif)

Of course this behavior can be emulated by simply manually adding/removing widgets from a ``Box`` widget but having a dedicated widget is much more efficient.

This is inspired by [QStackedLayout](https://doc.qt.io/qt-5/qstackedlayout.html) in Qt5.

Is there any interest in including something like this? If so let me know if you think of a better name! Also, I wasn't sure what the best way to update the docs notebook - for now I just added some cells, but should I re-run it and save the widget state for the whole notebook? (which might make a large diff). Is there a script to automate this?