### PR TITLE
Add combobox widget

### DIFF
--- a/ipywidgets/widgets/__init__.py
+++ b/ipywidgets/widgets/__init__.py
@@ -18,7 +18,7 @@ from .widget_date import DatePicker
 from .widget_output import Output
 from .widget_selection import RadioButtons, ToggleButtons, ToggleButtonsStyle, Dropdown, Select, SelectionSlider, SelectMultiple, SelectionRangeSlider
 from .widget_selectioncontainer import Tab, Accordion
-from .widget_string import HTML, HTMLMath, Label, Text, Textarea, Password
+from .widget_string import HTML, HTMLMath, Label, Text, Textarea, Password, Combobox
 from .widget_controller import Controller
 from .interaction import interact, interactive, fixed, interact_manual, interactive_output
 from .widget_link import jslink, jsdlink

--- a/ipywidgets/widgets/tests/test_widget_string.py
+++ b/ipywidgets/widgets/tests/test_widget_string.py
@@ -1,0 +1,34 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from ..widget_string import Combobox
+
+
+def test_combobox_creation_blank():
+    w = Combobox()
+    assert w.value == ''
+    assert w.options == ()
+    assert w.ensure_option == False
+
+
+def test_combobox_creation_kwargs():
+    w = Combobox(
+        value='Chocolate',
+        options=[
+            "Chocolate"
+            "Coconut"
+            "Mint"
+            "Strawberry"
+            "Vanilla"
+        ],
+        ensure_option=True
+    )
+    assert w.value == 'Chocolate'
+    assert w.options == (
+            "Chocolate"
+            "Coconut"
+            "Mint"
+            "Strawberry"
+            "Vanilla"
+        )
+    assert w.ensure_option == True

--- a/ipywidgets/widgets/tests/test_widget_string.py
+++ b/ipywidgets/widgets/tests/test_widget_string.py
@@ -15,20 +15,20 @@ def test_combobox_creation_kwargs():
     w = Combobox(
         value='Chocolate',
         options=[
-            "Chocolate"
-            "Coconut"
-            "Mint"
-            "Strawberry"
-            "Vanilla"
+            "Chocolate",
+            "Coconut",
+            "Mint",
+            "Strawberry",
+            "Vanilla",
         ],
         ensure_option=True
     )
     assert w.value == 'Chocolate'
     assert w.options == (
-            "Chocolate"
-            "Coconut"
-            "Mint"
-            "Strawberry"
-            "Vanilla"
+            "Chocolate",
+            "Coconut",
+            "Mint",
+            "Strawberry",
+            "Vanilla",
         )
     assert w.ensure_option == True

--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -125,7 +125,7 @@ class Password(Text):
 
 @register
 class Combobox(Text):
-    """TODO: Add docstring here
+    """Single line textbox widget with a dropdown and autocompletion.
     """
     _model_name = Unicode('ComboboxModel').tag(sync=True)
     _view_name = Unicode('ComboboxView').tag(sync=True)

--- a/ipywidgets/widgets/widget_string.py
+++ b/ipywidgets/widgets/widget_string.py
@@ -10,6 +10,7 @@ from .widget_description import DescriptionWidget
 from .valuewidget import ValueWidget
 from .widget import CallbackDispatcher, register
 from .widget_core import CoreWidget
+from .trait_types import TypedTuple
 from traitlets import Unicode, Bool, Int
 from warnings import warn
 
@@ -120,3 +121,21 @@ class Password(Text):
         for key in super_keys:
             if key != 'value':
                 yield key
+
+
+@register
+class Combobox(Text):
+    """TODO: Add docstring here
+    """
+    _model_name = Unicode('ComboboxModel').tag(sync=True)
+    _view_name = Unicode('ComboboxView').tag(sync=True)
+
+    options = TypedTuple(
+        trait=Unicode(),
+        help="Dropdown options for the combobox"
+    ).tag(sync=True)
+
+    ensure_option = Bool(
+        False,
+        help='If set, ensure value is in options. Implies continuous_update=False.'
+    ).tag(sync=True)

--- a/packages/controls/src/widget_string.ts
+++ b/packages/controls/src/widget_string.ts
@@ -211,10 +211,10 @@ class TextareaView extends DescriptionView {
 
     events() {
         return {
-            'keydown input'  : 'handleKeyDown',
-            'keypress input' : 'handleKeypress',
-            'input textarea'  : 'handleChanging',
-            'change textarea' : 'handleChanged'
+            'keydown input': 'handleKeyDown',
+            'keypress input': 'handleKeypress',
+            'input textarea': 'handleChanging',
+            'change textarea': 'handleChanged'
         };
     }
 
@@ -286,7 +286,7 @@ class TextView extends DescriptionView {
         this.el.appendChild(this.textbox);
 
         this.update(); // Set defaults.
-        this.listenTo(this.model, 'change:placeholder', function(model, value, options) {
+        this.listenTo(this.model, 'change:placeholder', (model, value, options) => {
             this.update_placeholder(value);
         });
         this.listenTo(this.model, 'change:description_tooltip', this.update_title);
@@ -303,7 +303,7 @@ class TextView extends DescriptionView {
     update_title() {
         let title = this.model.get('description_tooltip');
         if (!title) {
-           this.textbox.removeAttribute('title');
+            this.textbox.removeAttribute('title');
         } else if (this.model.get('description').length === 0) {
             this.textbox.setAttribute('title', title);
         }
@@ -316,9 +316,9 @@ class TextView extends DescriptionView {
          * Called when the model is changed.  The model may have been
          * changed by another view or by a state update from the back-end.
          */
-        if (options === undefined || options.updated_view != this) {
-            if (this.textbox.value != this.model.get('value')) {
-              this.textbox.value = this.model.get('value');
+        if (options === undefined || options.updated_view !== this) {
+            if (this.textbox.value !== this.model.get('value')) {
+                this.textbox.value = this.model.get('value');
             }
 
             this.textbox.disabled = this.model.get('disabled');
@@ -328,10 +328,10 @@ class TextView extends DescriptionView {
 
     events() {
         return {
-            'keydown input'  : 'handleKeyDown',
-            'keypress input' : 'handleKeypress',
-            'input input'  : 'handleChanging',
-            'change input' : 'handleChanged'
+            'keydown input': 'handleKeyDown',
+            'keypress input': 'handleKeypress',
+            'input input': 'handleChanging',
+            'change input': 'handleChanged'
         };
     }
 
@@ -350,8 +350,8 @@ class TextView extends DescriptionView {
     handleKeypress(e: KeyboardEvent) {
         e.stopPropagation();
         // The submit message is deprecated in widgets 7
-        if (e.keyCode == 13) { // Return key
             this.send({event: 'submit'});
+        if (e.keyCode === 13) { // Return key
         }
     }
 

--- a/packages/controls/src/widget_string.ts
+++ b/packages/controls/src/widget_string.ts
@@ -15,6 +15,13 @@ import {
 
 import * as _ from 'underscore';
 
+
+/**
+ * Class name for a combobox with an invlid value.
+ */
+const INVALID_VALUE_CLASS = 'jpwidgets-invalidComboValue';
+
+
 export
 class StringModel extends CoreDescriptionModel {
     defaults() {
@@ -388,7 +395,98 @@ class PasswordModel extends TextModel {
 }
 
 export
-class PasswordView extends TextView
-{
+class PasswordView extends TextView {
     protected readonly inputType: string = 'password';
+}
+
+
+/**
+ * Combobox widget model class.
+ */
+export
+class ComboboxModel extends TextModel {
+    defaults() {
+        return {...super.defaults(),
+            _model_name: 'ComboboxModel',
+            _view_name: 'ComboboxView',
+            options: [],
+            ensure_options: false,
+        };
+    }
+}
+
+
+/**
+ * Combobox widget view class.
+ */
+export
+class ComboboxView extends TextView {
+    render() {
+        this.datalist = document.createElement('datalist');
+        this.datalist.id = uuid();
+
+        super.render();
+
+        this.textbox.setAttribute('list', this.datalist.id);
+        this.el.appendChild(this.datalist);
+    }
+
+    update(options?: any) {
+        super.update(options);
+        if (!this.datalist) {
+        return;
+        }
+
+        const valid = this.isValid(this.model.get('value'));
+        this.highlightValidState(valid);
+
+        // Check if we need to update options
+        if (options !== undefined && options.updated_view) {
+        // Value update only, keep current options
+        return;
+        }
+
+        this.datalist.innerHTML = '';
+        for (let opt of this.model.get('options') as string[]) {
+        let el = document.createElement('option');
+        el.value = opt;
+        this.datalist.appendChild(el);
+        }
+    }
+
+    isValid(value: string): boolean {
+        if (true === this.model.get('ensure_option')) {
+        const options = this.model.get('options') as string[];
+        if (options.indexOf(value) === -1) {
+            return false;
+        }
+        }
+        return true;
+    }
+
+    handleChanging(e: KeyboardEvent) {
+        // Override to validate value
+        const target = e.target as HTMLInputElement;
+        const valid = this.isValid(target.value);
+        this.highlightValidState(valid);
+        if (valid) {
+        super.handleChanging(e);
+        }
+    }
+
+    handleChanged(e: KeyboardEvent) {
+        // Override to validate value
+        const target = e.target as HTMLInputElement;
+        const valid = this.isValid(target.value);
+        this.highlightValidState(valid);
+        if (valid) {
+        super.handleChanged(e);
+        }
+    }
+
+    highlightValidState(valid: boolean): void {
+        this.textbox.classList.toggle(INVALID_VALUE_CLASS, !valid);
+    }
+
+    datalist: HTMLDataListElement | undefined;
 }

--- a/packages/controls/src/widget_string.ts
+++ b/packages/controls/src/widget_string.ts
@@ -350,8 +350,8 @@ class TextView extends DescriptionView {
     handleKeypress(e: KeyboardEvent) {
         e.stopPropagation();
         // The submit message is deprecated in widgets 7
-            this.send({event: 'submit'});
         if (e.keyCode === 13) { // Return key
+            this.send({event: 'submit'});
         }
     }
 

--- a/packages/controls/src/widget_string.ts
+++ b/packages/controls/src/widget_string.ts
@@ -434,32 +434,36 @@ class ComboboxView extends TextView {
     update(options?: any) {
         super.update(options);
         if (!this.datalist) {
-        return;
+            return;
         }
 
         const valid = this.isValid(this.model.get('value'));
         this.highlightValidState(valid);
 
         // Check if we need to update options
-        if (options !== undefined && options.updated_view) {
-        // Value update only, keep current options
-        return;
+        if ((options !== undefined && options.updated_view) || (
+            !this.model.hasChanged('options') &&
+            !this.isInitialRender
+        )) {
+            // Value update only, keep current options
+            return;
         }
 
-        this.datalist.innerHTML = '';
-        for (let opt of this.model.get('options') as string[]) {
-        let el = document.createElement('option');
-        el.value = opt;
-        this.datalist.appendChild(el);
-        }
+        this.isInitialRender = false;
+
+        const opts = this.model.get('options') as string[];
+        const optLines = opts.map(o => {
+            return `<option value="${o}"></option>`;
+        });
+        this.datalist.innerHTML = optLines.join('\n');
     }
 
     isValid(value: string): boolean {
         if (true === this.model.get('ensure_option')) {
-        const options = this.model.get('options') as string[];
-        if (options.indexOf(value) === -1) {
-            return false;
-        }
+            const options = this.model.get('options') as string[];
+            if (options.indexOf(value) === -1) {
+                return false;
+            }
         }
         return true;
     }
@@ -470,7 +474,7 @@ class ComboboxView extends TextView {
         const valid = this.isValid(target.value);
         this.highlightValidState(valid);
         if (valid) {
-        super.handleChanging(e);
+            super.handleChanging(e);
         }
     }
 
@@ -480,7 +484,7 @@ class ComboboxView extends TextView {
         const valid = this.isValid(target.value);
         this.highlightValidState(valid);
         if (valid) {
-        super.handleChanged(e);
+            super.handleChanged(e);
         }
     }
 
@@ -489,4 +493,6 @@ class ComboboxView extends TextView {
     }
 
     datalist: HTMLDataListElement | undefined;
+
+    isInitialRender = true;
 }

--- a/packages/controls/test/src/index.ts
+++ b/packages/controls/test/src/index.ts
@@ -2,4 +2,5 @@
 // Distributed under the terms of the Modified BSD License.
 
 import './widget_date_test';
+import './widget_string_test';
 import './phosphor/currentselection_test';

--- a/packages/controls/test/src/widget_string_test.ts
+++ b/packages/controls/test/src/widget_string_test.ts
@@ -1,0 +1,71 @@
+import {
+    DummyManager
+} from './dummy-manager';
+
+import {
+    expect
+} from 'chai';
+
+import * as sinon from 'sinon';
+
+import * as widgets from '../../lib';
+
+
+describe('ComboboxView', function() {
+    beforeEach(async function() {
+        this.manager = new DummyManager();
+        const modelId = 'u-u-i-d';
+        this.model = await this.manager.new_model({
+            model_name: 'ComboboxModel',
+            model_module: '@jupyter-widgets/controls',
+            model_module_version: '1.0.0',
+            model_id: modelId,
+        }, { description: 'test-combo-model'} );
+    });
+
+    it('construction', function() {
+        const options = { model: this.model };
+        const view = new widgets.ComboboxView(options);
+        expect(view).to.not.be.undefined;
+    });
+
+    it('no invalid flag when not checking', function() {
+        this.model.set({
+            value: 'ABC',
+            options: ['ABCDEF', '123', 'foobar'],
+            ensure_option: false,
+        });
+        const options = { model: this.model };
+        const view = new widgets.ComboboxView(options);
+        view.render();
+        expect(view.textbox.classList.contains(
+            'jpwidgets-invalidComboValue')).to.equal(false);
+    });
+
+    it('no invalid flag with valid value', function() {
+        this.model.set({
+            value: 'ABCDEF',
+            options: ['ABCDEF', '123', 'foobar'],
+            ensure_option: true,
+        });
+        const options = { model: this.model };
+        const view = new widgets.ComboboxView(options);
+        view.render();
+        expect(view.textbox.classList.contains(
+            'jpwidgets-invalidComboValue')).to.equal(false);
+    });
+
+    it('sets invalid flag when it should', function() {
+        this.model.set({
+            value: 'ABC',
+            options: ['ABCDEF', '123', 'foobar'],
+            ensure_option: true,
+        });
+        const options = { model: this.model };
+        const view = new widgets.ComboboxView(options);
+        view.render();
+        expect(view.textbox.classList.contains(
+            'jpwidgets-invalidComboValue')).to.equal(true);
+    });
+
+});

--- a/packages/controls/test/src/widget_string_test.ts
+++ b/packages/controls/test/src/widget_string_test.ts
@@ -6,10 +6,7 @@ import {
     expect
 } from 'chai';
 
-import * as sinon from 'sinon';
-
 import * as widgets from '../../lib';
-
 
 describe('ComboboxView', function() {
     beforeEach(async function() {

--- a/packages/schema/jupyterwidgetmodels.v8.md
+++ b/packages/schema/jupyterwidgetmodels.v8.md
@@ -9,15 +9,15 @@ This model specification is for ipywidgets 7.4.*, @jupyter-widgets/base 1.1.*, a
 Each widget in the Jupyter core widgets is represented below. The heading represents the model name, module, and version, view name, module, and version that the widget is registered with.
 
 
-### LayoutModel (@jupyter-widgets/base, 1.2.0); LayoutView (@jupyter-widgets/base, 1.2.0)
+### LayoutModel (@jupyter-widgets/base, 1.1.0); LayoutView (@jupyter-widgets/base, 1.1.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_model_module`  | string           | `'@jupyter-widgets/base'` | The namespace for the model.
-`_model_module_version` | string           | `'1.2.0'`        | A semver requirement for namespace version containing the model.
+`_model_module_version` | string           | `'1.1.0'`        | A semver requirement for namespace version containing the model.
 `_model_name`    | string           | `'LayoutModel'`  | 
 `_view_module`   | string           | `'@jupyter-widgets/base'` | 
-`_view_module_version` | string           | `'1.2.0'`        | 
+`_view_module_version` | string           | `'1.1.0'`        | 
 `_view_name`     | string           | `'LayoutView'`   | 
 `align_content`  | `null` or string (one of `'flex-start'`, `'flex-end'`, `'center'`, `'space-between'`, `'space-around'`, `'space-evenly'`, `'stretch'`, `'inherit'`, `'initial'`, `'unset'`) | `null`           | The align-content CSS attribute.
 `align_items`    | `null` or string (one of `'flex-start'`, `'flex-end'`, `'center'`, `'baseline'`, `'stretch'`, `'inherit'`, `'initial'`, `'unset'`) | `null`           | The align-items CSS attribute.
@@ -46,45 +46,43 @@ Attribute        | Type             | Default          | Help
 `max_width`      | `null` or string | `null`           | The max-width CSS attribute.
 `min_height`     | `null` or string | `null`           | The min-height CSS attribute.
 `min_width`      | `null` or string | `null`           | The min-width CSS attribute.
-`object_fit`     | `null` or string (one of `'contain'`, `'cover'`, `'fill'`, `'scale-down'`, `'none'`) | `null`           | The object-fit CSS attribute.
-`object_position` | `null` or string | `null`           | The object-position CSS attribute.
 `order`          | `null` or string | `null`           | The order CSS attribute.
-`overflow`       | `null` or string | `null`           | The overflow CSS attribute.
-`overflow_x`     | `null` or string (one of `'visible'`, `'hidden'`, `'scroll'`, `'auto'`, `'inherit'`, `'initial'`, `'unset'`) | `null`           | The overflow-x CSS attribute (deprecated).
-`overflow_y`     | `null` or string (one of `'visible'`, `'hidden'`, `'scroll'`, `'auto'`, `'inherit'`, `'initial'`, `'unset'`) | `null`           | The overflow-y CSS attribute (deprecated).
+`overflow`       | `null` or string (one of `'visible'`, `'hidden'`, `'scroll'`, `'auto'`, `'inherit'`, `'initial'`, `'unset'`) | `null`           | The overflow CSS attribute.
+`overflow_x`     | `null` or string (one of `'visible'`, `'hidden'`, `'scroll'`, `'auto'`, `'inherit'`, `'initial'`, `'unset'`) | `null`           | The overflow-x CSS attribute.
+`overflow_y`     | `null` or string (one of `'visible'`, `'hidden'`, `'scroll'`, `'auto'`, `'inherit'`, `'initial'`, `'unset'`) | `null`           | The overflow-y CSS attribute.
 `padding`        | `null` or string | `null`           | The padding CSS attribute.
 `right`          | `null` or string | `null`           | The right CSS attribute.
 `top`            | `null` or string | `null`           | The top CSS attribute.
 `visibility`     | `null` or string (one of `'visible'`, `'hidden'`, `'inherit'`, `'initial'`, `'unset'`) | `null`           | The visibility CSS attribute.
 `width`          | `null` or string | `null`           | The width CSS attribute.
 
-### AccordionModel (@jupyter-widgets/controls, 1.5.0); AccordionView (@jupyter-widgets/controls, 1.5.0)
+### AccordionModel (@jupyter-widgets/controls, 1.4.0); AccordionView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'AccordionModel'` | 
 `_titles`        | object           | `{}`             | Titles of the pages
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'AccordionView'` | 
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
 `selected_index` | `null` or number (integer) | `0`              | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
 
-### AudioModel (@jupyter-widgets/controls, 1.5.0); AudioView (@jupyter-widgets/controls, 1.5.0)
+### AudioModel (@jupyter-widgets/controls, 1.4.0); AudioView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'AudioModel'`   | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'AudioView'`    | 
 `autoplay`       | boolean          | `true`           | When true, the audio starts when it's displayed
 `controls`       | boolean          | `true`           | Specifies that audio controls should be displayed (such as a play/pause button etc)
@@ -93,16 +91,16 @@ Attribute        | Type             | Default          | Help
 `loop`           | boolean          | `true`           | When true, the audio will start from the beginning after finishing
 `value`          | Bytes            | `b''`            | The media data as a byte string.
 
-### BoundedFloatTextModel (@jupyter-widgets/controls, 1.5.0); FloatTextView (@jupyter-widgets/controls, 1.5.0)
+### BoundedFloatTextModel (@jupyter-widgets/controls, 1.4.0); FloatTextView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'BoundedFloatTextModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'FloatTextView'` | 
 `continuous_update` | boolean          | `false`          | Update the value as the user types. If False, update on submission, e.g., pressing Enter or navigating away.
 `description`    | string           | `''`             | Description of the control.
@@ -115,16 +113,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | number (float)   | `0.0`            | Float value
 
-### BoundedIntTextModel (@jupyter-widgets/controls, 1.5.0); IntTextView (@jupyter-widgets/controls, 1.5.0)
+### BoundedIntTextModel (@jupyter-widgets/controls, 1.4.0); IntTextView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'BoundedIntTextModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'IntTextView'`  | 
 `continuous_update` | boolean          | `false`          | Update the value as the user types. If False, update on submission, e.g., pressing Enter or navigating away.
 `description`    | string           | `''`             | Description of the control.
@@ -137,31 +135,31 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | number (integer) | `0`              | Int value
 
-### BoxModel (@jupyter-widgets/controls, 1.5.0); BoxView (@jupyter-widgets/controls, 1.5.0)
+### BoxModel (@jupyter-widgets/controls, 1.4.0); BoxView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'BoxModel'`     | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'BoxView'`      | 
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
 
-### ButtonModel (@jupyter-widgets/controls, 1.5.0); ButtonView (@jupyter-widgets/controls, 1.5.0)
+### ButtonModel (@jupyter-widgets/controls, 1.4.0); ButtonView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ButtonModel'`  | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ButtonView'`   | 
 `button_style`   | string (one of `'primary'`, `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the button.
 `description`    | string           | `''`             | Button label.
@@ -171,29 +169,29 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to ButtonStyle widget | reference to new instance | 
 `tooltip`        | string           | `''`             | Tooltip caption of the button.
 
-### ButtonStyleModel (@jupyter-widgets/controls, 1.5.0); StyleView (@jupyter-widgets/base, 1.2.0)
+### ButtonStyleModel (@jupyter-widgets/controls, 1.4.0); StyleView (@jupyter-widgets/base, 1.1.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ButtonStyleModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/base'` | 
-`_view_module_version` | string           | `'1.2.0'`        | 
+`_view_module_version` | string           | `'1.1.0'`        | 
 `_view_name`     | string           | `'StyleView'`    | 
 `button_color`   | `null` or string | `null`           | Color of the button
 `font_weight`    | string           | `''`             | Button text font weight.
 
-### CheckboxModel (@jupyter-widgets/controls, 1.5.0); CheckboxView (@jupyter-widgets/controls, 1.5.0)
+### CheckboxModel (@jupyter-widgets/controls, 1.4.0); CheckboxView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'CheckboxModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'CheckboxView'` | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -203,16 +201,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | boolean          | `false`          | Bool value
 
-### ColorPickerModel (@jupyter-widgets/controls, 1.5.0); ColorPickerView (@jupyter-widgets/controls, 1.5.0)
+### ColorPickerModel (@jupyter-widgets/controls, 1.4.0); ColorPickerView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ColorPickerModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ColorPickerView'` | 
 `concise`        | boolean          | `false`          | Display short version with just a color selector.
 `description`    | string           | `''`             | Description of the control.
@@ -222,16 +220,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | string           | `'black'`        | The color value.
 
-### ComboboxModel (@jupyter-widgets/controls, 1.5.0); ComboboxView (@jupyter-widgets/controls, 1.5.0)
+### ComboboxModel (@jupyter-widgets/controls, 1.4.0); ComboboxView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ComboboxModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ComboboxView'` | 
 `continuous_update` | boolean          | `true`           | Update the value as the user types. If False, update on submission, e.g., pressing Enter or navigating away.
 `description`    | string           | `''`             | Description of the control.
@@ -244,45 +242,45 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | string           | `''`             | String value
 
-### ControllerAxisModel (@jupyter-widgets/controls, 1.5.0); ControllerAxisView (@jupyter-widgets/controls, 1.5.0)
+### ControllerAxisModel (@jupyter-widgets/controls, 1.4.0); ControllerAxisView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ControllerAxisModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ControllerAxisView'` | 
 `layout`         | reference to Layout widget | reference to new instance | 
 `value`          | number (float)   | `0.0`            | The value of the axis.
 
-### ControllerButtonModel (@jupyter-widgets/controls, 1.5.0); ControllerButtonView (@jupyter-widgets/controls, 1.5.0)
+### ControllerButtonModel (@jupyter-widgets/controls, 1.4.0); ControllerButtonView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ControllerButtonModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ControllerButtonView'` | 
 `layout`         | reference to Layout widget | reference to new instance | 
 `pressed`        | boolean          | `false`          | Whether the button is pressed.
 `value`          | number (float)   | `0.0`            | The value of the button.
 
-### ControllerModel (@jupyter-widgets/controls, 1.5.0); ControllerView (@jupyter-widgets/controls, 1.5.0)
+### ControllerModel (@jupyter-widgets/controls, 1.4.0); ControllerView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ControllerModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ControllerView'` | 
 `axes`           | array of reference to Axis widget | `[]`             | The axes on the gamepad.
 `buttons`        | array of reference to Button widget | `[]`             | The buttons on the gamepad.
@@ -293,30 +291,30 @@ Attribute        | Type             | Default          | Help
 `name`           | string           | `''`             | The name of the controller.
 `timestamp`      | number (float)   | `0.0`            | The last time the data from this gamepad was updated.
 
-### DOMWidgetModel (@jupyter-widgets/controls, 1.5.0); None (@jupyter-widgets/controls, 1.5.0)
+### DOMWidgetModel (@jupyter-widgets/controls, 1.4.0); None (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'DOMWidgetModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | `null` or string | `null`           | Name of the view.
 `layout`         | reference to Layout widget | reference to new instance | 
 `value`          | Bytes            | `b''`            | The media data as a byte string.
 
-### DatePickerModel (@jupyter-widgets/controls, 1.5.0); DatePickerView (@jupyter-widgets/controls, 1.5.0)
+### DatePickerModel (@jupyter-widgets/controls, 1.4.0); DatePickerView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'DatePickerModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'DatePickerView'` | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -325,42 +323,42 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | `null` or Date   | `null`           | 
 
-### DescriptionStyleModel (@jupyter-widgets/controls, 1.5.0); StyleView (@jupyter-widgets/base, 1.2.0)
+### DescriptionStyleModel (@jupyter-widgets/controls, 1.4.0); StyleView (@jupyter-widgets/base, 1.1.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'DescriptionStyleModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/base'` | 
-`_view_module_version` | string           | `'1.2.0'`        | 
+`_view_module_version` | string           | `'1.1.0'`        | 
 `_view_name`     | string           | `'StyleView'`    | 
 `description_width` | string           | `''`             | Width of the description to the side of the control.
 
-### DirectionalLinkModel (@jupyter-widgets/controls, 1.5.0); None (@jupyter-widgets/controls, 1.5.0)
+### DirectionalLinkModel (@jupyter-widgets/controls, 1.4.0); None (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'DirectionalLinkModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | `null` or string | `null`           | Name of the view.
 `source`         | array            | `[]`             | The source (widget, 'trait_name') pair
 `target`         | array            | `[]`             | The target (widget, 'trait_name') pair
 
-### DropdownModel (@jupyter-widgets/controls, 1.5.0); DropdownView (@jupyter-widgets/controls, 1.5.0)
+### DropdownModel (@jupyter-widgets/controls, 1.4.0); DropdownView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'DropdownModel'` | 
 `_options_labels` | array of string  | `[]`             | The labels for the options.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'DropdownView'` | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -369,41 +367,16 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 
-### FileUploadModel (@jupyter-widgets/controls, 1.5.0); FileUploadView (@jupyter-widgets/controls, 1.5.0)
-
-Attribute        | Type             | Default          | Help
------------------|------------------|------------------|----
-`_counter`       | number (integer) | `0`              | 
-`_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
-`_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
-`_model_name`    | string           | `'FileUploadModel'` | 
-`_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
-`_view_name`     | string           | `'FileUploadView'` | 
-`accept`         | string           | `''`             | File types to accept, empty string for all
-`button_style`   | string (one of `'primary'`, `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the button.
-`data`           | array            | `[]`             | List of file content (bytes)
-`description`    | string           | `''`             | Description of the control.
-`description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
-`disabled`       | boolean          | `false`          | Enable or disable button
-`error`          | string           | `''`             | Error message
-`icon`           | string           | `'upload'`       | Font-awesome icon name, without the 'fa-' prefix.
-`layout`         | reference to Layout widget | reference to new instance | 
-`metadata`       | array            | `[]`             | List of file metadata
-`multiple`       | boolean          | `false`          | If True, allow for multiple files upload
-`style`          | reference to ButtonStyle widget | reference to new instance | 
-
-### FloatLogSliderModel (@jupyter-widgets/controls, 1.5.0); FloatLogSliderView (@jupyter-widgets/controls, 1.5.0)
+### FloatLogSliderModel (@jupyter-widgets/controls, 1.4.0); FloatLogSliderView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'FloatLogSliderModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'FloatLogSliderView'` | 
 `base`           | number (float)   | `10.0`           | Base for the logarithm
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
@@ -420,16 +393,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to SliderStyle widget | reference to new instance | 
 `value`          | number (float)   | `1.0`            | Float value
 
-### FloatProgressModel (@jupyter-widgets/controls, 1.5.0); ProgressView (@jupyter-widgets/controls, 1.5.0)
+### FloatProgressModel (@jupyter-widgets/controls, 1.4.0); ProgressView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'FloatProgressModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ProgressView'` | 
 `bar_style`      | `null` or string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the progess bar.
 `description`    | string           | `''`             | Description of the control.
@@ -441,16 +414,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to ProgressStyle widget | reference to new instance | 
 `value`          | number (float)   | `0.0`            | Float value
 
-### FloatRangeSliderModel (@jupyter-widgets/controls, 1.5.0); FloatRangeSliderView (@jupyter-widgets/controls, 1.5.0)
+### FloatRangeSliderModel (@jupyter-widgets/controls, 1.4.0); FloatRangeSliderView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'FloatRangeSliderModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'FloatRangeSliderView'` | 
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is sliding the slider.
 `description`    | string           | `''`             | Description of the control.
@@ -466,16 +439,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to SliderStyle widget | reference to new instance | 
 `value`          | array            | `[0.0, 1.0]`     | Tuple of (lower, upper) bounds
 
-### FloatSliderModel (@jupyter-widgets/controls, 1.5.0); FloatSliderView (@jupyter-widgets/controls, 1.5.0)
+### FloatSliderModel (@jupyter-widgets/controls, 1.4.0); FloatSliderView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'FloatSliderModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'FloatSliderView'` | 
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
@@ -491,16 +464,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to SliderStyle widget | reference to new instance | 
 `value`          | number (float)   | `0.0`            | Float value
 
-### FloatTextModel (@jupyter-widgets/controls, 1.5.0); FloatTextView (@jupyter-widgets/controls, 1.5.0)
+### FloatTextModel (@jupyter-widgets/controls, 1.4.0); FloatTextView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'FloatTextModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'FloatTextView'` | 
 `continuous_update` | boolean          | `false`          | Update the value as the user types. If False, update on submission, e.g., pressing Enter or navigating away.
 `description`    | string           | `''`             | Description of the control.
@@ -511,46 +484,46 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | number (float)   | `0.0`            | Float value
 
-### GridBoxModel (@jupyter-widgets/controls, 1.5.0); GridBoxView (@jupyter-widgets/controls, 1.5.0)
+### GridBoxModel (@jupyter-widgets/controls, 1.4.0); GridBoxView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'GridBoxModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'GridBoxView'`  | 
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
 
-### HBoxModel (@jupyter-widgets/controls, 1.5.0); HBoxView (@jupyter-widgets/controls, 1.5.0)
+### HBoxModel (@jupyter-widgets/controls, 1.4.0); HBoxView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'HBoxModel'`    | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'HBoxView'`     | 
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
 
-### HTMLMathModel (@jupyter-widgets/controls, 1.5.0); HTMLMathView (@jupyter-widgets/controls, 1.5.0)
+### HTMLMathModel (@jupyter-widgets/controls, 1.4.0); HTMLMathView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'HTMLMathModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'HTMLMathView'` | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -559,16 +532,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | string           | `''`             | String value
 
-### HTMLModel (@jupyter-widgets/controls, 1.5.0); HTMLView (@jupyter-widgets/controls, 1.5.0)
+### HTMLModel (@jupyter-widgets/controls, 1.4.0); HTMLView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'HTMLModel'`    | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'HTMLView'`     | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -577,33 +550,33 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | string           | `''`             | String value
 
-### ImageModel (@jupyter-widgets/controls, 1.5.0); ImageView (@jupyter-widgets/controls, 1.5.0)
+### ImageModel (@jupyter-widgets/controls, 1.4.0); ImageView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ImageModel'`   | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ImageView'`    | 
 `format`         | string           | `'png'`          | The format of the image.
-`height`         | string           | `''`             | Height of the image in pixels. Use layout.height for styling the widget.
+`height`         | string           | `''`             | Height of the image in pixels.
 `layout`         | reference to Layout widget | reference to new instance | 
 `value`          | Bytes            | `b''`            | The media data as a byte string.
-`width`          | string           | `''`             | Width of the image in pixels. Use layout.width for styling the widget.
+`width`          | string           | `''`             | Width of the image in pixels.
 
-### IntProgressModel (@jupyter-widgets/controls, 1.5.0); ProgressView (@jupyter-widgets/controls, 1.5.0)
+### IntProgressModel (@jupyter-widgets/controls, 1.4.0); ProgressView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'IntProgressModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ProgressView'` | 
 `bar_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the progess bar.
 `description`    | string           | `''`             | Description of the control.
@@ -615,16 +588,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to ProgressStyle widget | reference to new instance | 
 `value`          | number (integer) | `0`              | Int value
 
-### IntRangeSliderModel (@jupyter-widgets/controls, 1.5.0); IntRangeSliderView (@jupyter-widgets/controls, 1.5.0)
+### IntRangeSliderModel (@jupyter-widgets/controls, 1.4.0); IntRangeSliderView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'IntRangeSliderModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'IntRangeSliderView'` | 
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is sliding the slider.
 `description`    | string           | `''`             | Description of the control.
@@ -640,16 +613,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to SliderStyle widget | reference to new instance | Slider style customizations.
 `value`          | array            | `[0, 1]`         | Tuple of (lower, upper) bounds
 
-### IntSliderModel (@jupyter-widgets/controls, 1.5.0); IntSliderView (@jupyter-widgets/controls, 1.5.0)
+### IntSliderModel (@jupyter-widgets/controls, 1.4.0); IntSliderView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'IntSliderModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'IntSliderView'` | 
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
@@ -665,16 +638,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to SliderStyle widget | reference to new instance | 
 `value`          | number (integer) | `0`              | Int value
 
-### IntTextModel (@jupyter-widgets/controls, 1.5.0); IntTextView (@jupyter-widgets/controls, 1.5.0)
+### IntTextModel (@jupyter-widgets/controls, 1.4.0); IntTextView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'IntTextModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'IntTextView'`  | 
 `continuous_update` | boolean          | `false`          | Update the value as the user types. If False, update on submission, e.g., pressing Enter or navigating away.
 `description`    | string           | `''`             | Description of the control.
@@ -685,16 +658,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | number (integer) | `0`              | Int value
 
-### LabelModel (@jupyter-widgets/controls, 1.5.0); LabelView (@jupyter-widgets/controls, 1.5.0)
+### LabelModel (@jupyter-widgets/controls, 1.4.0); LabelView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'LabelModel'`   | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'LabelView'`    | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -703,29 +676,29 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | string           | `''`             | String value
 
-### LinkModel (@jupyter-widgets/controls, 1.5.0); None (@jupyter-widgets/controls, 1.5.0)
+### LinkModel (@jupyter-widgets/controls, 1.4.0); None (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'LinkModel'`    | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | `null` or string | `null`           | Name of the view.
 `source`         | array            | `[]`             | The source (widget, 'trait_name') pair
 `target`         | array            | `[]`             | The target (widget, 'trait_name') pair
 
-### PasswordModel (@jupyter-widgets/controls, 1.5.0); PasswordView (@jupyter-widgets/controls, 1.5.0)
+### PasswordModel (@jupyter-widgets/controls, 1.4.0); PasswordView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'PasswordModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'PasswordView'` | 
 `continuous_update` | boolean          | `true`           | Update the value as the user types. If False, update on submission, e.g., pressing Enter or navigating away.
 `description`    | string           | `''`             | Description of the control.
@@ -736,18 +709,18 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | string           | `''`             | String value
 
-### PlayModel (@jupyter-widgets/controls, 1.5.0); PlayView (@jupyter-widgets/controls, 1.5.0)
+### PlayModel (@jupyter-widgets/controls, 1.4.0); PlayView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'PlayModel'`    | 
 `_playing`       | boolean          | `false`          | Whether the control is currently playing.
 `_repeat`        | boolean          | `false`          | Whether the control will repeat in a continous loop.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'PlayView'`     | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -761,30 +734,30 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | number (integer) | `0`              | Int value
 
-### ProgressStyleModel (@jupyter-widgets/controls, 1.5.0); StyleView (@jupyter-widgets/base, 1.2.0)
+### ProgressStyleModel (@jupyter-widgets/controls, 1.4.0); StyleView (@jupyter-widgets/base, 1.1.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ProgressStyleModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/base'` | 
-`_view_module_version` | string           | `'1.2.0'`        | 
+`_view_module_version` | string           | `'1.1.0'`        | 
 `_view_name`     | string           | `'StyleView'`    | 
 `bar_color`      | `null` or string | `null`           | Color of the progress bar.
 `description_width` | string           | `''`             | Width of the description to the side of the control.
 
-### RadioButtonsModel (@jupyter-widgets/controls, 1.5.0); RadioButtonsView (@jupyter-widgets/controls, 1.5.0)
+### RadioButtonsModel (@jupyter-widgets/controls, 1.4.0); RadioButtonsView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'RadioButtonsModel'` | 
 `_options_labels` | array of string  | `[]`             | The labels for the options.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'RadioButtonsView'` | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -793,17 +766,17 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 
-### SelectModel (@jupyter-widgets/controls, 1.5.0); SelectView (@jupyter-widgets/controls, 1.5.0)
+### SelectModel (@jupyter-widgets/controls, 1.4.0); SelectView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'SelectModel'`  | 
 `_options_labels` | array of string  | `[]`             | The labels for the options.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'SelectView'`   | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -813,17 +786,17 @@ Attribute        | Type             | Default          | Help
 `rows`           | number (integer) | `5`              | The number of rows to display.
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 
-### SelectMultipleModel (@jupyter-widgets/controls, 1.5.0); SelectMultipleView (@jupyter-widgets/controls, 1.5.0)
+### SelectMultipleModel (@jupyter-widgets/controls, 1.4.0); SelectMultipleView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'SelectMultipleModel'` | 
 `_options_labels` | array of string  | `[]`             | The labels for the options.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'SelectMultipleView'` | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -833,17 +806,17 @@ Attribute        | Type             | Default          | Help
 `rows`           | number (integer) | `5`              | The number of rows to display.
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 
-### SelectionRangeSliderModel (@jupyter-widgets/controls, 1.5.0); SelectionRangeSliderView (@jupyter-widgets/controls, 1.5.0)
+### SelectionRangeSliderModel (@jupyter-widgets/controls, 1.4.0); SelectionRangeSliderView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'SelectionRangeSliderModel'` | 
 `_options_labels` | array of string  | `[]`             | The labels for the options.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'SelectionRangeSliderView'` | 
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
@@ -855,17 +828,17 @@ Attribute        | Type             | Default          | Help
 `readout`        | boolean          | `true`           | Display the current selected label next to the slider
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 
-### SelectionSliderModel (@jupyter-widgets/controls, 1.5.0); SelectionSliderView (@jupyter-widgets/controls, 1.5.0)
+### SelectionSliderModel (@jupyter-widgets/controls, 1.4.0); SelectionSliderView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'SelectionSliderModel'` | 
 `_options_labels` | array of string  | `[]`             | The labels for the options.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'SelectionSliderView'` | 
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
@@ -877,46 +850,46 @@ Attribute        | Type             | Default          | Help
 `readout`        | boolean          | `true`           | Display the current selected label next to the slider
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 
-### SliderStyleModel (@jupyter-widgets/controls, 1.5.0); StyleView (@jupyter-widgets/base, 1.2.0)
+### SliderStyleModel (@jupyter-widgets/controls, 1.4.0); StyleView (@jupyter-widgets/base, 1.1.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'SliderStyleModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/base'` | 
-`_view_module_version` | string           | `'1.2.0'`        | 
+`_view_module_version` | string           | `'1.1.0'`        | 
 `_view_name`     | string           | `'StyleView'`    | 
 `description_width` | string           | `''`             | Width of the description to the side of the control.
 `handle_color`   | `null` or string | `null`           | Color of the slider handle.
 
-### TabModel (@jupyter-widgets/controls, 1.5.0); TabView (@jupyter-widgets/controls, 1.5.0)
+### TabModel (@jupyter-widgets/controls, 1.4.0); TabView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'TabModel'`     | 
 `_titles`        | object           | `{}`             | Titles of the pages
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'TabView'`      | 
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
 `selected_index` | `null` or number (integer) | `0`              | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
 
-### TextModel (@jupyter-widgets/controls, 1.5.0); TextView (@jupyter-widgets/controls, 1.5.0)
+### TextModel (@jupyter-widgets/controls, 1.4.0); TextView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'TextModel'`    | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'TextView'`     | 
 `continuous_update` | boolean          | `true`           | Update the value as the user types. If False, update on submission, e.g., pressing Enter or navigating away.
 `description`    | string           | `''`             | Description of the control.
@@ -927,16 +900,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | string           | `''`             | String value
 
-### TextareaModel (@jupyter-widgets/controls, 1.5.0); TextareaView (@jupyter-widgets/controls, 1.5.0)
+### TextareaModel (@jupyter-widgets/controls, 1.4.0); TextareaView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'TextareaModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'TextareaView'` | 
 `continuous_update` | boolean          | `true`           | Update the value as the user types. If False, update on submission, e.g., pressing Enter or navigating away.
 `description`    | string           | `''`             | Description of the control.
@@ -948,16 +921,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | string           | `''`             | String value
 
-### ToggleButtonModel (@jupyter-widgets/controls, 1.5.0); ToggleButtonView (@jupyter-widgets/controls, 1.5.0)
+### ToggleButtonModel (@jupyter-widgets/controls, 1.4.0); ToggleButtonView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ToggleButtonModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ToggleButtonView'` | 
 `button_style`   | string (one of `'primary'`, `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the button.
 `description`    | string           | `''`             | Description of the control.
@@ -969,17 +942,17 @@ Attribute        | Type             | Default          | Help
 `tooltip`        | string           | `''`             | Tooltip caption of the toggle button.
 `value`          | boolean          | `false`          | Bool value
 
-### ToggleButtonsModel (@jupyter-widgets/controls, 1.5.0); ToggleButtonsView (@jupyter-widgets/controls, 1.5.0)
+### ToggleButtonsModel (@jupyter-widgets/controls, 1.4.0); ToggleButtonsView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ToggleButtonsModel'` | 
 `_options_labels` | array of string  | `[]`             | The labels for the options.
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ToggleButtonsView'` | 
 `button_style`   | `null` or string (one of `'primary'`, `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the buttons.
 `description`    | string           | `''`             | Description of the control.
@@ -991,45 +964,45 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to ToggleButtonsStyle widget | reference to new instance | 
 `tooltips`       | array of string  | `[]`             | Tooltips for each button.
 
-### ToggleButtonsStyleModel (@jupyter-widgets/controls, 1.5.0); StyleView (@jupyter-widgets/base, 1.2.0)
+### ToggleButtonsStyleModel (@jupyter-widgets/controls, 1.4.0); StyleView (@jupyter-widgets/base, 1.1.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ToggleButtonsStyleModel'` | 
 `_view_module`   | string           | `'@jupyter-widgets/base'` | 
-`_view_module_version` | string           | `'1.2.0'`        | 
+`_view_module_version` | string           | `'1.1.0'`        | 
 `_view_name`     | string           | `'StyleView'`    | 
 `button_width`   | string           | `''`             | The width of each button.
 `description_width` | string           | `''`             | Width of the description to the side of the control.
 `font_weight`    | string           | `''`             | Text font weight of each button.
 
-### VBoxModel (@jupyter-widgets/controls, 1.5.0); VBoxView (@jupyter-widgets/controls, 1.5.0)
+### VBoxModel (@jupyter-widgets/controls, 1.4.0); VBoxView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'VBoxModel'`    | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'VBoxView'`     | 
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
 
-### ValidModel (@jupyter-widgets/controls, 1.5.0); ValidView (@jupyter-widgets/controls, 1.5.0)
+### ValidModel (@jupyter-widgets/controls, 1.4.0); ValidView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'ValidModel'`   | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'ValidView'`    | 
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
@@ -1039,16 +1012,16 @@ Attribute        | Type             | Default          | Help
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
 `value`          | boolean          | `false`          | Bool value
 
-### VideoModel (@jupyter-widgets/controls, 1.5.0); VideoView (@jupyter-widgets/controls, 1.5.0)
+### VideoModel (@jupyter-widgets/controls, 1.4.0); VideoView (@jupyter-widgets/controls, 1.4.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
-`_model_module_version` | string           | `'1.5.0'`        | 
+`_model_module_version` | string           | `'1.4.0'`        | 
 `_model_name`    | string           | `'VideoModel'`   | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
-`_view_module_version` | string           | `'1.5.0'`        | 
+`_view_module_version` | string           | `'1.4.0'`        | 
 `_view_name`     | string           | `'VideoView'`    | 
 `autoplay`       | boolean          | `true`           | When true, the video starts when it's displayed
 `controls`       | boolean          | `true`           | Specifies that video controls should be displayed (such as a play/pause button etc)


### PR DESCRIPTION
Based on adding a `<datalist>` tag to the `<input>` of the Text widget.

Fixes #1871.
Fixes #692.