### PR TITLE
Add _user_data attribute to the Widget class

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -388,6 +388,8 @@ class Widget(LoggingHasTraits):
 
     _view_count = Int(None, allow_none=True,
         help="EXPERIMENTAL: The number of views of the model displayed in the frontend. This attribute is experimental and may change or be removed in the future. None signifies that views will not be tracked. Set this to 0 to start tracking view creation/deletion.").tag(sync=True)
+    _user_data = Dict({}, help="User defined data.").tag(sync=True)
+
     comm = Instance('ipykernel.comm.Comm', allow_none=True)
 
     keys = List(help="The traits which are synced.")


### PR DESCRIPTION
cc. @maartenbreddels @rmorshea 

Add `_user_data` attribute to the Widget class. This allows us, in `voila`, to provide metadata to the widget instance like `mount_id` for putting a given widget to a specific place in the `voila` template.

Multiple things to discuss here:
- the name: is `_user_data` fine or should we use `_metadata` ?
- the serialization: what should we use for the serialization? Do we only allow JSON types in this dict (numbers, strings, lists, dicts..)?
- a util method: should we provide a `tag` method to the `Widget` class? Similar to the `tag` method of `Trait` classes?