### PR TITLE
Fix: better error handling for DatePicker, removing continuous update (issue #2392)

### DIFF
--- a/packages/controls/src/widget_date.ts
+++ b/packages/controls/src/widget_date.ts
@@ -110,7 +110,6 @@ class DatePickerView extends DescriptionView {
 
     events(): {[e: string]: string} {
         return {
-            //'change [type="date"]': '_picker_change',
             'keypress input' : '_handle_keypress',
             'focusout [type="date"]': '_picker_update'
         };
@@ -126,13 +125,6 @@ class DatePickerView extends DescriptionView {
         const value = this.model.get('value');
         this._datepicker.valueAsDate = value;
     }
-
-    // private _picker_change() {
-    //     if (!this._datepicker.validity.badInput) {
-    //         this.model.set('value', this._datepicker.valueAsDate);
-    //         this.touch();
-    //     }
-    // }
 
     private _picker_update() {
         if (this._datepicker.validity.badInput) {

--- a/packages/controls/src/widget_date.ts
+++ b/packages/controls/src/widget_date.ts
@@ -110,9 +110,16 @@ class DatePickerView extends DescriptionView {
 
     events(): {[e: string]: string} {
         return {
-            'change [type="date"]': '_picker_change',
-            'focusout [type="date"]': '_picker_focusout'
+            //'change [type="date"]': '_picker_change',
+            'keypress input' : '_handle_keypress',
+            'focusout [type="date"]': '_picker_update'
         };
+    }
+
+    private _handle_keypress(e) {
+        if (e.keyCode === 13) {
+            this._picker_update();
+        }
     }
 
     private _update_value() {
@@ -120,18 +127,21 @@ class DatePickerView extends DescriptionView {
         this._datepicker.valueAsDate = value;
     }
 
-    private _picker_change() {
-        if (!this._datepicker.validity.badInput) {
-            this.model.set('value', this._datepicker.valueAsDate);
-            this.touch();
-        }
-    }
+    // private _picker_change() {
+    //     if (!this._datepicker.validity.badInput) {
+    //         this.model.set('value', this._datepicker.valueAsDate);
+    //         this.touch();
+    //     }
+    // }
 
-    private _picker_focusout() {
+    private _picker_update() {
         if (this._datepicker.validity.badInput) {
             this.model.set('value', null);
-            this.touch();
         }
+        else {
+            this.model.set('value', this._datepicker.valueAsDate)
+        }
+        this.touch();
     }
 
     private _datepicker: HTMLInputElement;


### PR DESCRIPTION
cc. @jasongrout @nickpollari

I removed the `change [type="date"]` handler as it fired the update function on any state change, causing the issue. 

The logic I implemented instead, for the purpose of determining whether a user is done updating the widget, was to use two handlers: one for focusout, and the other for the enter key code. 

