### PR TITLE
FloatRangeSlider `value` logic

### DIFF
--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -288,7 +288,7 @@ class _BoundedFloatRange(_FloatRange):
 
     def __init__(self, *args, **kwargs):
         min, max = kwargs.get('min', 0.0), kwargs.get('max', 100.0)
-        if not kwargs.get('value', None):
+        if kwargs.get('value', None) is None:
             kwargs['value'] = (0.75 * min + 0.25 * max,
                                0.25 * min + 0.75 * max)
         super(_BoundedFloatRange, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Update logic in setting of default `value` field of the FloatRangeSlider so that numpy arrays can be passed as inputs (see #2434). Note that this will still currently error in traitlets as a `tuple` is expected, but at least the error at this point is very clear: A trait error is raised:
```
TraitError: The 'value' trait of a FloatRangeSlider instance must be a tuple, but a value of class 'numpy.ndarray' (i.e. array([-5,  5])) was specified.
```

I would appreciate the ability to simply provide a 2-entry long numpy array in the `value` field. What do folks think of adding something like: 
```python
try:
    proposal_tuple = tuple(proposal['value'])
    proposal['value'] = proposal_tuple
except:
    raise TraitError
```
to the validation of the `FloatRange` value 
https://github.com/jupyter-widgets/ipywidgets/blob/825dc5837df6938bfc57abedabd7d617ce1da920/ipywidgets/widgets/widget_float.py#L276-L281

or would it make more sense to do something at the traitlets level? 