### PR TITLE
implements __copy__ for widgets

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -759,3 +759,23 @@ class Widget(LoggingHasTraits):
             for key in keys
         )
         return '%s(%s)' % (class_name, signature)
+
+
+    def __copy__(self):
+
+        cls = self.__class__
+        result = cls.__new__(cls)
+        result.__init__()
+
+        new_state = {key: value for key, value in self.get_state().items() if
+                     not key.startswith('_') and
+                     not key == 'layout' and
+                     not key == 'style'}
+
+        for key, value in new_state.items():
+            setattr(result, key, value)
+
+        result.layout = self.layout
+        result.style = self.style
+
+        return result

--- a/ipywidgets/widgets/widget_box.py
+++ b/ipywidgets/widgets/widget_box.py
@@ -68,6 +68,29 @@ class Box(DOMWidget, CoreWidget):
         for child in self.children:
             child._handle_displayed()
 
+    def __copy__(self):
+        cls = self.__class__
+        result = cls.__new__(cls)
+
+        result.__init__(children=tuple([*self.children]))
+
+        # Deep Copy
+        # from copy import copy
+        # result.__init__(children=tuple(copy(child) for child in self.children))
+
+        new_state = {key: value for key, value in self.get_state().items() if
+                     not key.startswith('_') and
+                     not key == 'layout' and
+                     not key == 'style' and
+                     not key == 'children'}
+
+        for key, value in new_state.items():
+            setattr(result, key, value)
+
+        result.layout = self.layout
+
+        return result
+
 
 @register
 @doc_subst(_doc_snippets)

--- a/ipywidgets/widgets/widget_button.py
+++ b/ipywidgets/widgets/widget_button.py
@@ -103,3 +103,27 @@ class Button(DOMWidget, CoreWidget):
         """
         if content.get('event', '') == 'click':
             self.click()
+
+        def __copy__(self):
+
+            cls = self.__class__
+            result = cls.__new__(cls)
+            result.__init__()
+
+            new_state = {key: value for key, value in self.get_state().items() if
+                         not key.startswith('_') and
+                         not key == 'layout' and
+                         not key == 'style'}
+            for key, value in new_state.items():
+                setattr(result, key, value)
+
+            result.layout = self.layout
+            result.style = self.style
+
+            for callback in self._click_handlers.callbacks:
+                result.on_click(callback, remove=False)
+
+            return result
+
+
+


### PR DESCRIPTION
implements __copy__ for widgets 

implemented on base widget - and 

Follows the following steps: 

create a new widget from the reference class. 
initialises the widget passing any required arguments. 
reads all relevant attributes and sets them on the new widget

fixes #2352  
 

