### PR TITLE
Add GridBox example to Widget List notebook

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -1546,6 +1546,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### GridBox\n",
+    "\n",
+    "This box uses the HTML Grid specification to lay out its children in two dimensional grid. The example below lays out the 8 items inside in 3 columns and as many rows as needed to accommodate the items."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "items = [widgets.Label(str(i)) for i in range(8)]\n",
+    "widgets.GridBox(items, layout=widgets.Layout(grid_template_columns=\"repeat(3, 100px)\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Accordion"
    ]
   },


### PR DESCRIPTION
This adds a short example to the widget list documentation.