### PR TITLE
Backward-compatible-control

### DIFF
--- a/examples/web1/package.json
+++ b/examples/web1/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2.0.0-rc.2",
-    "@jupyter-widgets/controls": "^2.0.0-rc.2"
+    "@jupyter-widgets/controls": "^1.4.5"
   },
   "devDependencies": {
     "chai": "^4.0.0",

--- a/examples/web2/package.json
+++ b/examples/web2/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2.0.0-rc.2",
-    "@jupyter-widgets/controls": "^2.0.0-rc.2",
+    "@jupyter-widgets/controls": "^1.4.5",
     "codemirror": "^5.48.0",
     "font-awesome": "^4.7.0"
   },

--- a/examples/web3/package.json
+++ b/examples/web3/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2.0.0-rc.2",
-    "@jupyter-widgets/controls": "^2.0.0-rc.2",
+    "@jupyter-widgets/controls": "^1.4.5",
     "@jupyter-widgets/html-manager": "^0.18.0-rc.2",
     "@jupyterlab/services": "^4.0.0",
     "@phosphor/widgets": "^1.3.0",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyter-widgets/controls",
-  "version": "2.0.0-rc.2",
+  "version": "1.4.5",
   "description": "Jupyter interactive widgets",
   "repository": {
     "type": "git",

--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2.0.0-rc.2",
-    "@jupyter-widgets/controls": "^2.0.0-rc.2",
+    "@jupyter-widgets/controls": "^1.4.5",
     "@jupyter-widgets/output": "^2.0.0-rc.2",
     "@jupyter-widgets/schema": "^0.4.0-rc.1",
     "@jupyterlab/outputarea": "^1.0.0",

--- a/packages/jupyterlab-manager/package.json
+++ b/packages/jupyterlab-manager/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2.0.0-rc.2",
-    "@jupyter-widgets/controls": "^2.0.0-rc.2",
+    "@jupyter-widgets/controls": "^1.4.5",
     "@jupyter-widgets/output": "^2.0.0-rc.2",
     "@jupyterlab/application": "^1.0.0",
     "@jupyterlab/coreutils": "^3.0.0",

--- a/widgetsnbextension/package.json
+++ b/widgetsnbextension/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2.0.0-rc.2",
-    "@jupyter-widgets/controls": "^2.0.0-rc.2",
+    "@jupyter-widgets/controls": "^1.4.5",
     "@jupyter-widgets/html-manager": "^0.18.0-rc.2",
     "@jupyter-widgets/output": "^2.0.0-rc.2",
     "@jupyterlab/services": "^4.0.0-rc.0",


### PR DESCRIPTION
Setting the version of `@jupyter-widgets/controls` to the latest released version before running another RC.