### PR TITLE
Reduce count of deprecation warnings

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -8,12 +8,14 @@ in the IPython notebook front-end.
 """
 
 from contextlib import contextmanager
-import collections
-import sys
+try:
+    from collections.abc import Iterable
+except ImportError:
+    # Python 2.7
+    from collections import Iterable
 
 from IPython.core.getipython import get_ipython
 from ipykernel.comm import Comm
-from traitlets.utils.importstring import import_item
 from traitlets import (
     HasTraits, Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default, Container,
     Undefined)
@@ -21,7 +23,7 @@ from ipython_genutils.py3compat import string_types, PY3
 from IPython.display import display
 from json import loads as jsonloads, dumps as jsondumps
 
-from base64 import standard_b64decode, standard_b64encode
+from base64 import standard_b64encode
 
 from .._version import __protocol_version__, __jupyter_widgets_base_version__
 PROTOCOL_VERSION_MAJOR = __protocol_version__.split('.')[0]
@@ -505,7 +507,7 @@ class Widget(LoggingHasTraits):
             keys = self.keys
         elif isinstance(key, string_types):
             keys = [key]
-        elif isinstance(key, collections.Iterable):
+        elif isinstance(key, Iterable):
             keys = key
         else:
             raise ValueError("key must be a string, an iterable of keys, or None")

--- a/ipywidgets/widgets/widget_link.py
+++ b/ipywidgets/widgets/widget_link.py
@@ -29,7 +29,7 @@ class WidgetTraitTuple(Tuple):
         # and throw it away in a new, less informative TraitError
         if trait is None:
             raise TypeError("No such trait: %s" % trait_repr)
-        elif not trait.get_metadata('sync'):
+        elif not trait.metadata.get('sync'):
             raise TypeError("%s cannot be synced" % trait_repr)
         return value
 

--- a/ipywidgets/widgets/widget_upload.py
+++ b/ipywidgets/widgets/widget_upload.py
@@ -6,8 +6,9 @@
 Represents a file upload button.
 """
 
-import zlib
-from traitlets import observe, validate, default, Unicode, Dict, List, Int, Bool, Bytes, TraitError, CaselessStrEnum
+from traitlets import (
+    observe, default, Unicode, Dict, List, Int, Bool, Bytes, CaselessStrEnum
+)
 
 from .widget_description import DescriptionWidget
 from .valuewidget import ValueWidget
@@ -25,7 +26,7 @@ def content_from_json(value, widget):
     return output
 
 
-@register()
+@register
 class FileUpload(DescriptionWidget, ValueWidget, CoreWidget):
     """
     Upload file(s) from browser to Python kernel as bytes
@@ -42,8 +43,10 @@ class FileUpload(DescriptionWidget, ValueWidget, CoreWidget):
         values=['primary', 'success', 'info', 'warning', 'danger', ''], default_value='',
         help="""Use a predefined styling for the button.""").tag(sync=True)
     style = InstanceDict(ButtonStyle).tag(sync=True, **widget_serialization)
-    metadata = List(Dict, help='List of file metadata').tag(sync=True)
-    data = List(Bytes, help='List of file content (bytes)').tag(sync=True, from_json=content_from_json)
+    metadata = List(Dict(), help='List of file metadata').tag(sync=True)
+    data = List(Bytes(), help='List of file content (bytes)').tag(
+        sync=True, from_json=content_from_json
+    )
     error = Unicode(help='Error message').tag(sync=True)
     value = Dict(read_only=True)
 


### PR DESCRIPTION
Hello,

Hope you'll find this PR useful.

Fixed warnings:
 - Widget registration using a string name has been deprecated. Widget registration now uses a plain `@register` decorator.
 - Traits should be given as instances, not types (for example, `Int()`, not `Int`). Passing types is deprecated in traitlets 4.1.
 - Deprecated in traitlets 4.1, use the instance .metadata dictionary directly, like x.metadata[key] or x.metadata.get(key, default)
 - Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working

These changes also remove some unused imports.

Best regards!