### PR TITLE
Fix making docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 ipykernel
 ipywidgets>=7.1.0rc1
 jupyter_client
-jupyter_sphinx
+jupyter-sphinx>=0.2.0
 nbsphinx>=0.2.13
 recommonmark==0.4.0
 sphinx>=1.4.6

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'nbsphinx',
-    'jupyter_sphinx.embed_widgets',
+    'jupyter_sphinx.execute',
     'IPython.sphinxext.ipython_console_highlighting',
 ]
 


### PR DESCRIPTION
Hi @vidartf,

`jupyter-sphinx` now [requires to use](https://jupyter-sphinx.readthedocs.io/en/latest/#enabling-the-extension) `jupyter_sphinx.execute` instead of `jupyter_sphinx.embed_widgets` to enable the extension.

Regards!