### PR TITLE
remove class `jupyter-widgets` from jp-OutputArea-output node

### DIFF
--- a/packages/jupyterlab-manager/src/renderer.ts
+++ b/packages/jupyterlab-manager/src/renderer.ts
@@ -48,7 +48,6 @@ class WidgetRenderer extends Panel implements IRenderMime.IRenderer, IDisposable
 
     // Let's be optimistic, and hope the widget state will come later.
     this.node.textContent = 'Loading widget...';
-    this.addClass('jupyter-widgets');
 
     const manager = await this._manager.promise;
     // If there is no model id, the view was removed, so hide the node.


### PR DESCRIPTION
Fix issue #2499 