### PR TITLE
Fix setting a selection index when having duplicate values

### DIFF
--- a/ipywidgets/widgets/tests/test_widget_selection.py
+++ b/ipywidgets/widgets/tests/test_widget_selection.py
@@ -65,3 +65,32 @@ class TestSelection(TestCase):
         assert select.value == 4
         assert select.label == '4'
         assert observations == [0]
+
+    def test_duplicate(self):
+        select = Select(options=['first', 1, 'dup', 'dup'])
+        observations = []
+        def f(change):
+            observations.append(change.new)
+        select.observe(f, 'index')
+        select.index = 3
+        assert select.index == 3
+        assert select.value == 'dup'
+        assert select.label == 'dup'
+        assert observations == [3]
+        select.index = 2
+        assert select.index == 2
+        assert select.value == 'dup'
+        assert select.label == 'dup'
+        assert observations == [3, 2]
+        select.index = 0
+        assert select.index == 0
+        assert select.value == 'first'
+        assert select.label == 'first'
+        assert observations == [3, 2, 0]
+
+        # picks the first matching value
+        select.value = 'dup'
+        assert select.index == 2
+        assert select.value == 'dup'
+        assert select.label == 'dup'
+        assert observations == [3, 2, 0, 2]

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -244,7 +244,12 @@ class _Selection(DescriptionWidget, ValueWidget, CoreWidget):
 
     @observe('value')
     def _propagate_value(self, change):
-        index = self._options_values.index(change.new) if change.new is not None else None
+        if change.new is None:
+            index = None
+        elif self.index is not None and self._options_values[self.index] == change.new:
+            index = self.index
+        else:
+            index = self._options_values.index(change.new)
         if self.index != index:
             self.index = index
 
@@ -256,7 +261,12 @@ class _Selection(DescriptionWidget, ValueWidget, CoreWidget):
 
     @observe('label')
     def _propagate_label(self, change):
-        index = self._options_labels.index(change.new) if change.new is not None else None
+        if change.new is None:
+            index = None
+        elif self.index is not None and self._options_labels[self.index] == change.new:
+            index = self.index
+        else:
+            index = self._options_labels.index(change.new)
         if self.index != index:
             self.index = index
 


### PR DESCRIPTION
Fixes #2513 

Basically, when changing a selection that had duplicate values or labels, we always ended up resetting the index to the first such value or label. Now we check to see if the current index is the correct label/value before we reset the index.

I added a test which fails before the fix and passes after the fix.