### PR TITLE
Labmanager refactor

### DIFF
--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -588,7 +588,10 @@ export class WidgetManager extends LabWidgetManager {
       // Only restore if our initial restore at construction is finished
       if (this._initialRestoredStatus) {
         // We only want to restore widgets from the kernel, not ones saved in the notebook.
-        this.restoreWidgets(this._context!.model);
+        this.restoreWidgets(this._context!.model, {
+          loadKernel: true,
+          loadNotebook: false
+        });
       }
     }
   }
@@ -602,9 +605,16 @@ export class WidgetManager extends LabWidgetManager {
   /**
    * Restore widgets from kernel and saved state.
    */
-  async restoreWidgets(notebook: INotebookModel): Promise<void> {
-    await this._loadFromKernel();
-    await this._loadFromNotebook(notebook);
+  async restoreWidgets(
+    notebook: INotebookModel,
+    { loadKernel, loadNotebook } = { loadKernel: true, loadNotebook: true }
+  ): Promise<void> {
+    if (loadKernel) {
+      await this._loadFromKernel();
+    }
+    if (loadNotebook) {
+      await this._loadFromNotebook(notebook);
+    }
     this._restoredStatus = true;
     this._initialRestoredStatus = true;
     this._restored.emit();

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -138,8 +138,6 @@ export abstract class LabWidgetManager extends ManagerBase<Widget>
     if (!this.kernel) {
       return;
     }
-    // TODO: when we upgrade to @jupyterlab/services 4.1 or later, we can
-    // remove this 'any' cast.
     if (this.kernel?.handleComms === false) {
       return;
     }

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -276,7 +276,9 @@ export abstract class LabWidgetManager extends ManagerBase<Widget>
    * #### Notes
    * This is a read-only property.
    */
-  abstract get isDisposed(): boolean;
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
 
   /**
    * Dispose the resources held by the manager.
@@ -285,6 +287,7 @@ export abstract class LabWidgetManager extends ManagerBase<Widget>
     if (this.isDisposed) {
       return;
     }
+    this._isDisposed = true;
 
     if (this._commRegistration) {
       this._commRegistration.dispose();
@@ -442,6 +445,7 @@ export abstract class LabWidgetManager extends ManagerBase<Widget>
   protected _restoredStatus = false;
   protected _initialRestoredStatus = false;
 
+  private _isDisposed = false;
   private _registry: SemVerCache<ExportData> = new SemVerCache<ExportData>();
   private _rendermime: IRenderMimeRegistry;
 
@@ -507,16 +511,6 @@ export class KernelWidgetManager extends LabWidgetManager {
   }
 
   /**
-   * Get whether the manager is disposed.
-   *
-   * #### Notes
-   * This is a read-only property.
-   */
-  get isDisposed(): boolean {
-    return this._kernel === null;
-  }
-
-  /**
    * Dispose the resources held by the manager.
    */
   dispose(): void {
@@ -524,9 +518,8 @@ export class KernelWidgetManager extends LabWidgetManager {
       return;
     }
 
-    super.dispose();
-
     this._kernel = null!;
+    super.dispose();
   }
 
   get kernel(): Kernel.IKernelConnection {
@@ -629,16 +622,6 @@ export class WidgetManager extends LabWidgetManager {
   }
 
   /**
-   * Get whether the manager is disposed.
-   *
-   * #### Notes
-   * This is a read-only property.
-   */
-  get isDisposed(): boolean {
-    return this._context === null;
-  }
-
-  /**
    * Dispose the resources held by the manager.
    */
   dispose(): void {
@@ -646,8 +629,8 @@ export class WidgetManager extends LabWidgetManager {
       return;
     }
 
-    super.dispose();
     this._context = null!;
+    super.dispose();
   }
 
   /**

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -611,6 +611,7 @@ export class WidgetManager extends LabWidgetManager {
     await this._loadFromKernel();
     await this._loadFromNotebook(notebook);
     this._restoredStatus = true;
+    this._initialRestoredStatus = true;
     this._restored.emit();
   }
 

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -433,13 +433,15 @@ export abstract class LabWidgetManager extends ManagerBase<Widget>
     return serialize_state(models, options);
   }
 
-  protected async _handleCommOpen(
+  // _handleCommOpen is an attribute, not a method, so `this` is captured in a
+  // single object that can be registered and removed
+  protected _handleCommOpen = async (
     comm: Kernel.IComm,
     msg: KernelMessage.ICommOpenMsg
-  ): Promise<void> {
+  ): Promise<void> => {
     const oldComm = new shims.services.Comm(comm);
     await this.handle_comm_open(oldComm, msg);
-  }
+  };
 
   protected _restored = new Signal<this, void>(this);
   protected _restoredStatus = false;

--- a/packages/jupyterlab-manager/src/plugin.ts
+++ b/packages/jupyterlab-manager/src/plugin.ts
@@ -248,7 +248,7 @@ function activateWidgetExtension(
   }
 
   if (settingRegistry !== null) {
-    // Add a command for creating a new Markdown file.
+    // Add a command for automatically saving (jupyter-)widget state.
     commands.addCommand('@jupyter-widgets/jupyterlab-manager:saveWidgetState', {
       label: 'Save Widget State Automatically',
       execute: args => {


### PR DESCRIPTION
This PR builds on top of #2528.

**What does this do?** 
Extract parts of the widget manager into an abstract base class, and then export a new widget manager that does not rely on the document context. Instead, it takes a kernel as an argument to the constructor.

**What is the purpose?**
The goal of this PR is to make it easier for others to reuse widgets in a setting outside of Jupyterlab, (but while still using Jupyterlab components as libraries).

**Does this really belong in this package?**
Ideally, the base and kernel-based manager could live in a new, separate package, but I don't want to increase the maintenance burden of the repo/releases any more, so I think it would probably be better to later on optimize the current package for tree-shaking.