### PR TITLE
feat: produce embed bundle without lab theme variables

### DIFF
--- a/packages/html-manager/scripts/concat-amd-build.js
+++ b/packages/html-manager/scripts/concat-amd-build.js
@@ -27,3 +27,18 @@ var output = files
   })
   .join(';\n\n');
 fs.writeFileSync('./dist/embed-amd.js', output);
+
+
+files = [
+  'base.js',
+  'controls.js',
+  'index.js',
+  'libembed-amd.js',
+  'embed-amd-render-nolabvars.js'
+];
+var output = files
+  .map(f => {
+    return fs.readFileSync('./dist/amd/' + f).toString();
+  })
+  .join(';\n\n');
+fs.writeFileSync('./dist/embed-amd-nolabvars.js', output);

--- a/packages/html-manager/src/embed-amd-render-nolabvars.ts
+++ b/packages/html-manager/src/embed-amd-render-nolabvars.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import '@jupyter-widgets/controls/css/labvariables.css';
-
 (window as any).require(
   ['@jupyter-widgets/html-manager/dist/libembed-amd'],
   function(embed: { renderWidgets: { (): void; (): void } }) {

--- a/packages/html-manager/src/libembed.ts
+++ b/packages/html-manager/src/libembed.ts
@@ -10,7 +10,7 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 import '@fortawesome/fontawesome-free/css/v4-shims.min.css';
 
 import '@lumino/widgets/style/index.css';
-import '@jupyter-widgets/controls/css/widgets.css';
+import '@jupyter-widgets/controls/css/widgets-base.css';
 
 // Used just for the typing. We must not import the javascript because we don't
 // want to include it in the require embedding.

--- a/packages/html-manager/webpack.config.js
+++ b/packages/html-manager/webpack.config.js
@@ -83,6 +83,17 @@ module.exports = [
     mode: 'production'
   },
   {
+    // script that renders widgets using the amd embedding and can render third-party custom widgets
+    entry: './lib/embed-amd-render-nolabvars.js',
+    output: {
+      filename: 'embed-amd-render-nolabvars.js',
+      path: path.resolve(__dirname, 'dist', 'amd'),
+      publicPath: publicPath
+    },
+    module: { rules: rules },
+    mode: 'production'
+  },
+  {
     // embed library that depends on requirejs, and can load third-party widgets dynamically
     entry: './lib/libembed-amd.js',
     output: {


### PR DESCRIPTION
This PR moves the HTML manager a bit closer to voila works, making it possible to import the js module from a CDN, and have a custom way of loading the widget state etc.

On top of that, by default the `labvariables.css` were included, which would override any theming done (e.g. jupyter lab's black theme). To still support the default (light) theme (in embed.js and embed-amd.js) the css is move to those modules, while the `widget-base.css` is kept.