### PR TITLE
FIX: TypeError: NoneType in xeus-python

### DIFF
--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -733,6 +733,7 @@ class Widget(LoggingHasTraits):
 
     def _send(self, msg, buffers=None):
         """Sends a message to the model in the front-end."""
+        buffers = buffers or []
         if self.comm is not None and self.comm.kernel is not None:
             self.comm.send(data=msg, buffers=buffers)
 


### PR DESCRIPTION
Please see below error:

![image](https://user-images.githubusercontent.com/4451957/63455844-97b6a000-c41b-11e9-9302-c9004aea3a72.png)

Original issue is here: https://github.com/QuantStack/xeus-python/issues/124#issuecomment-523533272