### PR TITLE
Fix documentation and add more helpful error message for interact usage

### DIFF
--- a/docs/source/examples/Using Interact.ipynb
+++ b/docs/source/examples/Using Interact.ipynb
@@ -197,12 +197,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example clarifies how `interact` processes its keyword arguments:\n",
-    "\n",
-    "1. If the keyword argument is a `ValueWidget` instance, that widget is used. A `ValueWidget` is a widget intended for use with `interact`. For more information, see [this section](Widget%20Custom.ipynb#DOMWidget,-ValueWidget-and-Widget) on widget types.\n",
-    "2. Otherwise, the value is treated as a *widget abbreviation* that is converted to a widget before it is used.\n",
-    "\n",
-    "The following table gives an overview of different widget abbreviations:\n",
+    "The following table gives an overview of different argument types, and how they map to interactive controls:\n",
     "\n",
     "<table class=\"table table-condensed table-bordered\">\n",
     "  <tr><td><strong>Keyword argument</strong></td><td><strong>Widget</strong></td></tr>  \n",
@@ -329,6 +324,22 @@
    "outputs": [],
    "source": [
     "interact(f, x=[('one', 10), ('two', 20)]);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, if you need more granular control than that afforded by the abbreviation, you can pass a `ValueWidget` instance as the argument. A `ValueWidget` is a widget that aims to control a single value. Most of the widgets [bundled with ipywidgets](Widget%20List) inherit from `ValueWidget`. For more information, see [this section](Widget%20Custom.ipynb#DOMWidget,-ValueWidget-and-Widget) on widget types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interact(f, x=widgets.Combobox(options=[\"Chicago\", \"New York\", \"Washington\"], value=\"Chicago\"));"
    ]
   },
   {

--- a/docs/source/examples/Using Interact.ipynb
+++ b/docs/source/examples/Using Interact.ipynb
@@ -197,9 +197,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This examples clarifies how `interact` processes its keyword arguments:\n",
+    "This example clarifies how `interact` processes its keyword arguments:\n",
     "\n",
-    "1. If the keyword argument is a `Widget` instance with a `value` attribute, that widget is used. Any widget with a `value` attribute can be used, even custom ones.\n",
+    "1. If the keyword argument is a `ValueWidget` instance, that widget is used. A `ValueWidget` is a widget intended for use with `interact`. For more information, see [this section](Widget%20Custom.ipynb#DOMWidget,-ValueWidget-and-Widget) on widget types.\n",
     "2. Otherwise, the value is treated as a *widget abbreviation* that is converted to a widget before it is used.\n",
     "\n",
     "The following table gives an overview of different widget abbreviations:\n",

--- a/docs/source/examples/Widget Custom.ipynb
+++ b/docs/source/examples/Widget Custom.ipynb
@@ -80,10 +80,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To define a widget, you must inherit from the `DOMWidget`, `ValueWidget`, or `Widget` base class.  If you intend for your widget to be displayed in the Jupyter notebook, you'll want to inherit from the `DOMWidget`.  If you intend for your widget to be used with [interact](./Using%20Interact.ipynb), you'll want to inherit from `ValueWidget`. Both the `DOMWidget` and `ValueWidget` classes inherit from the `Widget` class. The `Widget` class is useful for cases in which the widget is not meant to be displayed directly in the notebook, but instead as a child of another rendering environment.  Here are some examples:\n",
+    "To define a widget, you must inherit from the `DOMWidget`, `ValueWidget`, or `Widget` base class.  If you intend for your widget to be displayed, you'll want to inherit from `DOMWidget`.  If you intend for your widget to be used as an input for [interact](./Using%20Interact.ipynb), you'll want to inherit from `ValueWidget`. Your widget should inherit from `ValueWidget` if it has a single ovious output (for example, the output of an `IntSlider` is clearly the current value of the slider).\n",
     "\n",
-    "- If you wanted to create a three.js widget (a popular WebGL library), you would implement the rendering window as a `DOMWidget` and any 3D objects or lights meant to be rendered in that window as `Widget`\n",
-    "- If you wanted to create a widget that displays directly in the notebook for usage with `interact` (like IntSlider), you should multiple inherit from both `DOMWidget` and `ValueWidget`\n",
+    "Both the `DOMWidget` and `ValueWidget` classes inherit from the `Widget` class. The `Widget` class is useful for cases in which the widget is not meant to be displayed directly in the notebook, but instead as a child of another rendering environment.  Here are some examples:\n",
+    "\n",
+    "- If you wanted to create a [three.js](https://threejs.org/) widget (three.js is a popular WebGL library), you would implement the rendering window as a `DOMWidget` and any 3D objects or lights meant to be rendered in that window as `Widget`\n",
+    "- If you wanted to create a widget that displays directly in the notebook for usage with `interact` (like `IntSlider`), you should multiple inherit from both `DOMWidget` and `ValueWidget`. \n",
     "- If you wanted to create a widget that provides a value to `interact` but is controlled and viewed by another widget or an external source, you should inherit from only `ValueWidget`"
    ]
   },

--- a/docs/source/examples/Widget Custom.ipynb
+++ b/docs/source/examples/Widget Custom.ipynb
@@ -73,14 +73,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### DOMWidget and Widget"
+    "## DOMWidget, ValueWidget and Widget\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To define a widget, you must inherit from the Widget or DOMWidget base class.  If you intend for your widget to be displayed in the Jupyter notebook, you'll want to inherit from the DOMWidget.  The DOMWidget class itself inherits from the Widget class.  The Widget class is useful for cases in which the Widget is not meant to be displayed directly in the notebook, but instead as a child of another rendering environment.  For example, if you wanted to create a three.js widget (a popular WebGL library), you would implement the rendering window as a DOMWidget and any 3D objects or lights meant to be rendered in that window as Widgets."
+    "To define a widget, you must inherit from the `DOMWidget`, `ValueWidget`, or `Widget` base class.  If you intend for your widget to be displayed in the Jupyter notebook, you'll want to inherit from the `DOMWidget`.  If you intend for your widget to be used with [interact](./Using%20Interact.ipynb), you'll want to inherit from `ValueWidget`. Both the `DOMWidget` and `ValueWidget` classes inherit from the `Widget` class. The `Widget` class is useful for cases in which the widget is not meant to be displayed directly in the notebook, but instead as a child of another rendering environment.  Here are some examples:\n",
+    "\n",
+    "- If you wanted to create a three.js widget (a popular WebGL library), you would implement the rendering window as a `DOMWidget` and any 3D objects or lights meant to be rendered in that window as `Widget`\n",
+    "- If you wanted to create a widget that displays directly in the notebook for usage with `interact` (like IntSlider), you should multiple inherit from both `DOMWidget` and `ValueWidget`\n",
+    "- If you wanted to create a widget that provides a value to `interact` but is controlled and viewed by another widget or an external source, you should inherit from only `ValueWidget`"
    ]
   },
   {
@@ -110,11 +114,11 @@
    "outputs": [],
    "source": [
     "from traitlets import Unicode, Bool, validate, TraitError\n",
-    "from ipywidgets import DOMWidget, register\n",
+    "from ipywidgets import DOMWidget, ValueWidget, register\n",
     "\n",
     "\n",
     "@register\n",
-    "class Email(DOMWidget):\n",
+    "class Email(DOMWidget, ValueWidget):\n",
     "    _view_name = Unicode('EmailView').tag(sync=True)\n",
     "    _view_module = Unicode('email_widget').tag(sync=True)\n",
     "    _view_module_version = Unicode('0.1.0').tag(sync=True)"
@@ -391,11 +395,11 @@
    "outputs": [],
    "source": [
     "from traitlets import Unicode, Bool, validate, TraitError\n",
-    "from ipywidgets import DOMWidget, register\n",
+    "from ipywidgets import DOMWidget, ValueWidget, register\n",
     "\n",
     "\n",
     "@register\n",
-    "class Email(DOMWidget):\n",
+    "class Email(DOMWidget, ValueWidget):\n",
     "    _view_name = Unicode('EmailView').tag(sync=True)\n",
     "    _view_module = Unicode('email_widget').tag(sync=True)\n",
     "    _view_module_version = Unicode('0.1.0').tag(sync=True)\n",

--- a/docs/source/examples/Widget Custom.ipynb
+++ b/docs/source/examples/Widget Custom.ipynb
@@ -73,7 +73,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## DOMWidget, ValueWidget and Widget\n"
+    "### DOMWidget, ValueWidget and Widget\n"
    ]
   },
   {

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -10,7 +10,7 @@ from inspect import getfullargspec as check_argspec
 import sys
 
 from IPython import get_ipython
-from . import (ValueWidget, Text,
+from . import (Widget, ValueWidget, Text,
     FloatSlider, IntSlider, Checkbox, Dropdown,
     VBox, Button, DOMWidget, Output)
 from IPython.display import display, clear_output
@@ -275,13 +275,12 @@ class interactive(VBox):
         """Given a sequence of (name, abbrev, default) tuples, return a sequence of Widgets."""
         result = []
         for name, abbrev, default in seq:
+            if isinstance(abbrev, Widget) and (not isinstance(abbrev, ValueWidget)):
+                raise TypeError("{!r} is not a ValueWidget".format(abbrev))
             widget = self.widget_from_abbrev(abbrev, default)
-            if not (isinstance(widget, ValueWidget) or isinstance(widget, fixed)):
-                if widget is None:
-                    raise ValueError("{!r} cannot be transformed to a widget".format(abbrev))
-                else:
-                    raise TypeError("{!r} is not a ValueWidget".format(widget))
-            if not widget.description:
+            if widget is None:
+                raise ValueError("{!r} cannot be transformed to a widget".format(abbrev))
+            if not hasattr(widget,"description") or not widget.description:
                 widget.description = name
             widget._kwarg = name
             result.append(widget)

--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -280,7 +280,7 @@ class interactive(VBox):
             widget = self.widget_from_abbrev(abbrev, default)
             if widget is None:
                 raise ValueError("{!r} cannot be transformed to a widget".format(abbrev))
-            if not hasattr(widget,"description") or not widget.description:
+            if not hasattr(widget, "description") or not widget.description:
                 widget.description = name
             widget._kwarg = name
             result.append(widget)

--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -11,9 +11,9 @@ import pytest
 
 import ipywidgets as widgets
 
-from traitlets import TraitError
+from traitlets import TraitError, Float
 from ipywidgets import (interact, interact_manual, interactive,
-    interaction, Output)
+                        interaction, Output, Widget)
 
 #-----------------------------------------------------------------------------
 # Utility stuff
@@ -443,6 +443,16 @@ def test_custom_description():
     )
     w.value = 'different text'
     assert d == {'b': 'different text'}
+
+def test_raises_on_non_value_widget():
+    """ Test that passing in a non-value widget raises an error """
+
+    class BadWidget(Widget):
+        """ A widget that contains a `value` traitlet """
+        value = Float()
+
+    with pytest.raises(TypeError, match=".* not a ValueWidget.*"):
+        interactive(f, b=BadWidget())
 
 def test_interact_manual_button():
     c = interact.options(manual=True).widget(f)


### PR DESCRIPTION
@SylvainCorlay suggested in #2511 that the current design for `interact` should be that only ValueWidgets can be passed as keyword arguments. This PR edits the documentation to reflect this and changes the error message that displays when a non-ValueWidget Widget is passed to let the user know that a ValueWidget is expected. ValueWidgets are currently not mentioned in the documentation nor any accessible error messages which gave me a big headache when trying to start a custom widget project.