### PR TITLE
Make unpack_models compatible with ISerializers

### DIFF
--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -36,7 +36,7 @@ import {
  * Replace model ids with models recursively.
  */
 export
-function unpack_models(value: any, manager: managerBase.ManagerBase<any>): Promise<any> {
+function unpack_models(value?: any, manager?: managerBase.ManagerBase<any>): Promise<any> {
     if (Array.isArray(value)) {
         const unpacked: any[] = [];
         value.forEach((sub_value, key) => {


### PR DESCRIPTION
Previously, `unpack_models` could not be typed it as `ISerializers['deserialize']` when strict null checks are on.