### PR TITLE
Replace print statement with Output widget

### DIFF
--- a/docs/source/examples/Widget Asynchronous.ipynb
+++ b/docs/source/examples/Widget Asynchronous.ipynb
@@ -96,17 +96,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ipywidgets import IntSlider\n",
+    "from ipywidgets import IntSlider, Output\n",
     "slider = IntSlider()\n",
+    "out = Output()\n",
     "\n",
     "async def f():\n",
     "    for i in range(10):\n",
-    "        print('did work %s'%i)\n",
+    "        out.append_stdout('did work ' + str(i) + '\\n')\n",
     "        x = await wait_for_change(slider, 'value')\n",
-    "        print('async function continued with value %s'%x)\n",
+    "        out.append_stdout('async function continued with value ' + str(x) + '\\n')\n",
     "asyncio.ensure_future(f())\n",
     "\n",
     "slider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out"
    ]
   },
   {


### PR DESCRIPTION
Printing in callbacks does not work in JupyterLab. Better to use a `Output` widget.