### PR TITLE
Reloading kernel state race issue

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -52,8 +52,8 @@ echo -n "ipywidgets"
 pip install -v -e .
 
 if test "$skip_jupyter_lab" != yes; then
-    jupyter labextension link ./packages/base
-    jupyter labextension link ./packages/controls
-    jupyter labextension link ./packages/output
-    jupyter labextension install ./packages/jupyterlab-manager
+    jupyter labextension link ./packages/base --no-build
+    jupyter labextension link ./packages/controls --no-build
+    jupyter labextension link ./packages/output --no-build
+    jupyter labextension install ./packages/jupyterlab-manager --minimize=False
 fi

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -55,5 +55,5 @@ if test "$skip_jupyter_lab" != yes; then
     jupyter labextension link ./packages/base --no-build
     jupyter labextension link ./packages/controls --no-build
     jupyter labextension link ./packages/output --no-build
-    jupyter labextension install ./packages/jupyterlab-manager
+    jupyter labextension install ./packages/jupyterlab-manager --minimize=False
 fi

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -55,5 +55,5 @@ if test "$skip_jupyter_lab" != yes; then
     jupyter labextension link ./packages/base --no-build
     jupyter labextension link ./packages/controls --no-build
     jupyter labextension link ./packages/output --no-build
-    jupyter labextension install ./packages/jupyterlab-manager --minimize=False
+    jupyter labextension install ./packages/jupyterlab-manager
 fi

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -267,7 +267,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
    */
   async _get_comm_info(): Promise<any> {
     const reply = await this._context.session.kernel.requestCommInfo({target: this.comm_target_name});
-    if (reply.content.status = 'ok') {
+    if (reply.content.status === 'ok') {
         return (reply.content as any).comms;
     } else {
         return {};

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -198,6 +198,9 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
       return;
     }
     await this.context.session.ready;
+    if ((this.context.session.kernel as any).handleComms === false) {
+      return;
+    }
     const comm_ids = await this._get_comm_info();
 
     // For each comm id that we do not know about, create the comm, and request the state.

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -211,7 +211,9 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
         return;
       } catch (e) {
         // If we have the widget model not found error, then we can create the
-        // widget. Otherwise, rethrow the error.
+        // widget. Otherwise, rethrow the error. We have to check the error
+        // message text explicitly because the get_model function in this
+        // class throws a generic error with this specific text.
         if (e.message !== 'widget model not found') {
           throw e;
         }

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -173,7 +173,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
   /**
    * Restore widgets from kernel and saved state.
    */
-  async restoreWidgets(notebook: INotebookModel, {loadKernel, loadNotebook}: {loadKernel: boolean, loadNotebook: boolean} = {loadKernel: true, loadNotebook: true}): Promise<void> {
+  async restoreWidgets(notebook: INotebookModel, {loadKernel, loadNotebook} = {loadKernel: true, loadNotebook: true}): Promise<void> {
     if (loadKernel) {
       await this._loadFromKernel();
     }

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -161,7 +161,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
     switch (args) {
     case 'connected':
       // Only restore if our initial restore at construction is finished
-      if (this._restoredStatus) {
+      if (this._initialRestoredStatus) {
         // We only want to restore widgets from the kernel, not ones saved in the notebook.
         this.restoreWidgets(this._context.model, {loadKernel: true, loadNotebook: false});
       }
@@ -184,6 +184,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
       await this._loadFromNotebook(notebook);
     }
     this._restoredStatus = true;
+    this._initialRestoredStatus = true;
     this._restored.emit();
   }
 
@@ -486,6 +487,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
   _commRegistration: IDisposable;
   private _restored = new Signal<this, void>(this);
   private _restoredStatus = false;
+  private _initialRestoredStatus = false;
 
   private _modelsSync = new Map<string, WidgetModel>();
   private _settings: WidgetManager.Settings;

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -217,10 +217,10 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
         }
         const comm = await this._create_comm(this.comm_target_name, comm_id);
 
-        let msgId: string;
-        let p = new PromiseDelegate<Private.ICommUpdateData>();
+        let msg_id: string;
+        let widget_info = new PromiseDelegate<Private.ICommUpdateData>();
         comm.on_msg((msg: KernelMessage.ICommMsgMsg) => {
-          if ((msg.parent_header as any).msg_id === msgId
+          if ((msg.parent_header as any).msg_id === msg_id
             && msg.header.msg_type === 'comm_msg'
             && msg.content.data.method === 'update') {
             let data = (msg.content.data as any);
@@ -234,14 +234,14 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
                 }
             });
             put_buffers(data.state, buffer_paths, buffers);
-            p.resolve({comm, msg});
+            widget_info.resolve({comm, msg});
           }
         });
-        msgId = comm.send({
+        msg_id = comm.send({
           method: 'request_state'
         }, this.callbacks(undefined));
 
-        return p.promise;
+        return widget_info.promise;
       }
     }));
 

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -202,6 +202,8 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
       return;
     }
     await this.context.session.ready;
+    // TODO: when we upgrade to @jupyterlab/services 4.1 or later, we can
+    // remove this 'any' cast.
     if ((this.context.session.kernel as any).handleComms === false) {
       return;
     }

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -218,7 +218,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
         const comm = await this._create_comm(this.comm_target_name, comm_id);
 
         let msg_id: string;
-        let widget_info = new PromiseDelegate<Private.ICommUpdateData>();
+        const widget_info = new PromiseDelegate<Private.ICommUpdateData>();
         comm.on_msg((msg: KernelMessage.ICommMsgMsg) => {
           if ((msg.parent_header as any).msg_id === msg_id
             && msg.header.msg_type === 'comm_msg'

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -226,7 +226,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
         const comm = await this._create_comm(this.comm_target_name, comm_id);
 
         let msg_id: string;
-        const widget_info = new PromiseDelegate<Private.ICommUpdateData>();
+        const info = new PromiseDelegate<Private.ICommUpdateData>();
         comm.on_msg((msg: KernelMessage.ICommMsgMsg) => {
           if ((msg.parent_header as any).msg_id === msg_id
             && msg.header.msg_type === 'comm_msg'
@@ -242,14 +242,14 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
                 }
             });
             put_buffers(data.state, buffer_paths, buffers);
-            widget_info.resolve({comm, msg});
+            info.resolve({comm, msg});
           }
         });
         msg_id = comm.send({
           method: 'request_state'
         }, this.callbacks(undefined));
 
-        return widget_info.promise;
+        return info.promise;
       }
     }));
 

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -160,8 +160,11 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
   _handleKernelStatusChange(args: Kernel.Status) {
     switch (args) {
     case 'connected':
-      // We only want to restore widgets from the kernel, not ones saved in the notebook.
-      this.restoreWidgets(this._context.model, {loadKernel: true, loadNotebook: false});
+      // Only restore if our initial restore at construction is finished
+      if (this._restoredStatus) {
+        // We only want to restore widgets from the kernel, not ones saved in the notebook.
+        this.restoreWidgets(this._context.model, {loadKernel: true, loadNotebook: false});
+      }
       break;
     case 'restarting':
       this.disconnect();

--- a/packages/jupyterlab-manager/src/manager.ts
+++ b/packages/jupyterlab-manager/src/manager.ts
@@ -220,7 +220,9 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
         let msgId: string;
         let p = new PromiseDelegate<Private.ICommUpdateData>();
         comm.on_msg((msg: KernelMessage.ICommMsgMsg) => {
-          if ((msg.parent_header as any).msg_id === msgId) {
+          if ((msg.parent_header as any).msg_id === msgId
+            && msg.header.msg_type === 'comm_msg'
+            && msg.content.data.method === 'update') {
             let data = (msg.content.data as any);
             let buffer_paths = data.buffer_paths || [];
             // Make sure the buffers are DataViews


### PR DESCRIPTION
If there is a slow kernel startup, we might have some time in between the jlab widget manager’s constructor and the kernel’s connect signal. This means we may restore from the kernel on widget manager construction, then execute some cells, then restore again when the kernel signals it is connected. We fix two problems in this situation.

1. Since we might have a cell execution before the kernel connect signal, there may be some widgets already created. In that case, we want to avoid recreating those widgets. In particular, we should not take over their comm objects and replace their on_msg handler.

2. Previously, we were sending a comm message to request state and just listening for the next message back on the comm that was an update message. However, if the comm was already active, the next message back *might* be a normal update message, rather than a full state update, which would mess up our logic. We fix this by listening for an update comm message with a parent message header matching our sent message.

Finally, we fix one more issue - at startup, we want to restore widgets from the notebook and the kernel, but on a kernel connect signal, we only want to restore widgets from the kernel.

This still does not handle the case where we disconnect from the kernel, miss some update messages, and then reconnect. In order to handle that case, it would be good to have a way to ask an existing widget to update its own state with a full refresh from the kernel.

