### PR TITLE
DOC: Use a more modern way to activate recommonmark

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ numpy
 jupyter_client
 jupyter_sphinx
 nbsphinx>=0.2.13
-recommonmark==0.4.0
+recommonmark
 sphinx>=1.4.6
 sphinx_rtd_theme
 matplotlib

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,7 +5,6 @@
 import os
 import subprocess
 import sys
-import recommonmark.parser
 
 
 # -- path -------------------------------------------------------
@@ -25,9 +24,9 @@ def bash(filename):
 
 # -- source files and parsers -----------------------------------
 
-source_suffix = ['.rst', '.md', '.ipynb']
-source_parsers = {
-    '.md': recommonmark.parser.CommonMarkParser,
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
 }
 
 
@@ -41,6 +40,7 @@ extensions = [
     'nbsphinx',
     'jupyter_sphinx.execute',
     'IPython.sphinxext.ipython_console_highlighting',
+    'recommonmark',
 ]
 
 intersphinx_mapping = {


### PR DESCRIPTION
I don't know if anybody else had those problems, but on my local installation the Markdown files were not parsed correctly.

Anyway, the recommended way to use Markdown source files has changed, see https://www.sphinx-doc.org/en/master/usage/markdown.html.

FYI: Explicitly specifying `'.ipynb'` as source suffix is not necessary, `nbsphinx` takes care of that automatically. If somebody wants to insist on mentioning it, this would be the way to do it:

```python
source_suffix = {
    '.rst': 'restructuredtext',
    '.md': 'markdown',
    '.ipynb': 'jupyter_notebook',
}
```