### PR TITLE
DOC: Avoid loading require.js twice

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,8 @@ intersphinx_mapping = {
 
 nbsphinx_allow_errors = True   # exception ipstruct.py ipython_genutils
 nbsphinx_execute = 'always'
+# Disable including require.js because it is also included by jupyter_sphinx:
+nbsphinx_requirejs_path = ''
 
 # -- General information -------
 


### PR DESCRIPTION
In the current docs, all HTML pages load `require.js` twice, because both `jupyter_sphinx` and `nbsphinx` include it by default.

Luckily, `nbsphinx` has an option to disable this ...