### PR TITLE
Drop notebook dependency from widgetsnbextension

### DIFF
--- a/widgetsnbextension/setup.py
+++ b/widgetsnbextension/setup.py
@@ -214,13 +214,5 @@ if 'setuptools' in sys.modules:
     from setuptools.command.develop import develop
     setup_args['cmdclass']['develop'] = js_prerelease(develop, strict=True)
 
-setuptools_args = {}
-install_requires = setuptools_args['install_requires'] = [
-    'notebook>=4.4.1',
-]
-
-if 'setuptools' in sys.modules:
-    setup_args.update(setuptools_args)
-
 if __name__ == '__main__':
     setup(**setup_args)


### PR DESCRIPTION
While we may not drop the `ipywidgets -> widgetsnbextension` dependency in a backward-compatible fashion, a good way to enable the installation of ipykernel in an environment without pulling the notebook server is to drop the `widgetsnbextension -> notebook` dependency.

Could that land in a 7.x release?