### PR TITLE
Add scope description to developer docs

### DIFF
--- a/docs/source/developer_docs.rst
+++ b/docs/source/developer_docs.rst
@@ -1,7 +1,22 @@
 Developer Docs
 ===============
 
-The Jupyter widgets packages are developed in the `https://github.com/jupyter-widgets/ipywidgets <https://github.com/jupyter-widgets/ipywidgets>`_ git repository.
+The Jupyter widgets packages are developed in the `https://github.com/jupyter-widgets/ipywidgets <https://github.com/jupyter-widgets/ipywidgets>`_ git repository. See the issue tracker, README, and other Github documents for the most recent information.
+
+
+Scope of Ipywidgets
+-------------------
+
+``ipywidgets`` is a framework to provide eventful python objects that have a representation in the browser (see :doc:`examples/Widget Basics.ipynb`for more on the definition of widgets). This requires two components:
+
+1. The framework for widget interactions between the widgets represented in the Python kernel and the (javascript) representation of the widgets in the browser.
+2. A set of implemented widgets that *use* this framework.
+
+The framework is the foremost purpose of ipywidgets. ``ipywidgets`` does also provides a set of reference widgets for those objects (and supports them), but these are intentionally relatively lightweight.  Hence ``ipywidgets`` intentionally encourages other browser-level javascript frameworks, as this allows exploration of UI idioms while keeping a shared kernel/Python-level API.
+
+
+Additional Developer Docs
+-------------------------
 
 .. toctree::
    :maxdepth: 3

--- a/docs/source/developer_docs.rst
+++ b/docs/source/developer_docs.rst
@@ -4,15 +4,15 @@ Developer Docs
 The Jupyter widgets packages are developed in the `https://github.com/jupyter-widgets/ipywidgets <https://github.com/jupyter-widgets/ipywidgets>`_ git repository. See the issue tracker, README, and other Github documents for the most recent information.
 
 
-Scope of Ipywidgets
+Scope of ipywidgets
 -------------------
 
-``ipywidgets`` is a framework to provide eventful python objects that have a representation in the browser (see :doc:`examples/Widget Basics.ipynb`for more on the definition of widgets). This requires two components:
+``ipywidgets`` is a framework to provide eventful python objects that have a representation in the browser (see :doc:`examples/Widget Basics.ipynb` for more on the definition of widgets). This requires two components:
 
 1. The framework for widget interactions between the widgets represented in the Python kernel and the (javascript) representation of the widgets in the browser.
-2. A set of implemented widgets that *use* this framework.
+2. A basic, lightweight set of form controls that *use* this framework, based on standard HTML form controls. These included controls include a text area, text box, select and multiselect controls, checkbox, etc., plus a few more advanced controls that are very popular, such as a slider and basic tab panels.
 
-The framework is the foremost purpose of ipywidgets. ``ipywidgets`` does also provides a set of reference widgets for those objects (and supports them), but these are intentionally relatively lightweight.  Hence ``ipywidgets`` intentionally encourages other browser-level javascript frameworks, as this allows exploration of UI idioms while keeping a shared kernel/Python-level API.
+The framework for building rich interactive objects is the foremost purpose of the ipywidgets project, and the set of included reference form controls is purposefully kept small and self-contained. We encourage and support a robust ecosystem of packages built on top of the ipywidgets framework to provide more complicated interactive objects, such as maps or 2d and 3d visualizations, or form control systems built on a variety of popular Javascript frameworks such as Material or Vue.
 
 
 Additional Developer Docs

--- a/docs/source/developer_docs.rst
+++ b/docs/source/developer_docs.rst
@@ -12,7 +12,7 @@ Scope of ipywidgets
 1. The framework for widget interactions between the widgets represented in the Python kernel and the (javascript) representation of the widgets in the browser.
 2. A basic, lightweight set of form controls that *use* this framework, based on standard HTML form controls. These included controls include a text area, text box, select and multiselect controls, checkbox, etc. A few more advanced controls that are very popular are also included, such as a slider and basic tab panels.
 
-The framework for building rich interactive objects is the foremost purpose of the ipywidgets project, and the set of included reference form controls is purposefully kept small and self-contained. We encourage and support a robust ecosystem of packages built on top of the ipywidgets framework to provide more complicated interactive objects, such as maps or 2d and 3d visualizations, or other form control systems built on a variety of popular Javascript frameworks such as Material or Vue.
+The framework for building rich interactive objects is the foremost purpose of the ipywidgets project, and the set of included reference form controls is purposefully kept small and self-contained to serve as something like a reference implementation. We encourage and support a robust ecosystem of packages built on top of the ipywidgets framework to provide more complicated interactive objects, such as maps or 2d and 3d visualizations, or other form control systems built on a variety of popular Javascript frameworks such as Material or Vue.
 
 
 Additional Developer Docs

--- a/docs/source/developer_docs.rst
+++ b/docs/source/developer_docs.rst
@@ -10,9 +10,9 @@ Scope of ipywidgets
 ``ipywidgets`` is a framework to provide eventful python objects that have a representation in the browser (see :doc:`examples/Widget Basics.ipynb` for more on the definition of widgets). This requires two components:
 
 1. The framework for widget interactions between the widgets represented in the Python kernel and the (javascript) representation of the widgets in the browser.
-2. A basic, lightweight set of form controls that *use* this framework, based on standard HTML form controls. These included controls include a text area, text box, select and multiselect controls, checkbox, etc., plus a few more advanced controls that are very popular, such as a slider and basic tab panels.
+2. A basic, lightweight set of form controls that *use* this framework, based on standard HTML form controls. These included controls include a text area, text box, select and multiselect controls, checkbox, etc. A few more advanced controls that are very popular are also included, such as a slider and basic tab panels.
 
-The framework for building rich interactive objects is the foremost purpose of the ipywidgets project, and the set of included reference form controls is purposefully kept small and self-contained. We encourage and support a robust ecosystem of packages built on top of the ipywidgets framework to provide more complicated interactive objects, such as maps or 2d and 3d visualizations, or form control systems built on a variety of popular Javascript frameworks such as Material or Vue.
+The framework for building rich interactive objects is the foremost purpose of the ipywidgets project, and the set of included reference form controls is purposefully kept small and self-contained. We encourage and support a robust ecosystem of packages built on top of the ipywidgets framework to provide more complicated interactive objects, such as maps or 2d and 3d visualizations, or other form control systems built on a variety of popular Javascript frameworks such as Material or Vue.
 
 
 Additional Developer Docs


### PR DESCRIPTION
This PR was prompted by an out-of-band discussion with @jasongrout - this PR adds some words in the developer docs stating explicitly that `ipywidgets` is both a framework and a set of "reference implementations".  This is my first attempt at trying to channel *my* understanding, so I might have missed the mark on something though - please correct if any of this wording is a misunderstanding of the imagined scope.
 
I put this in the dev docs at the suggestion of @jasongrout - a summary of this distinction *might* also belong on the index page although the description in this PR may be a bit too technical for that?