### PR TITLE
Add comments specifying valid values for `icon` for `Button` and `ToggleButton`

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -397,7 +397,7 @@
     "    disabled=False,\n",
     "    button_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
     "    tooltip='Description',\n",
-    "    icon='check'\n",
+    "    icon='check' # (FontAwesome names without the `fa-` prefix)\n",
     ")"
    ]
   },
@@ -854,7 +854,7 @@
     "    disabled=False,\n",
     "    button_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
     "    tooltip='Click me',\n",
-    "    icon='check'\n",
+    "    icon='check' # (FontAwesome names without the `fa-` prefix)\n",
     ")"
    ]
   },


### PR DESCRIPTION
Currently (as far as I could find), both `Button` and `ToggleButton` seem to take an `icon` value, but there is no documentation as to what the possible values are other than the example usage of `check`. This PR adds two small comments to help the user figure out what the valid values are without digging in the source code.