### PR TITLE
Fixed style of password field #2492

### DIFF
--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -416,16 +416,16 @@
     width: var(--jp-widgets-inline-width);
 }
 
-.widget-text input[type="text"], .widget-text input[type="number"]{
+.widget-text input[type="text"], .widget-text input[type="number"], .widget-text input[type="password"] {
     height: var(--jp-widgets-inline-height);
     line-height: var(--jp-widgets-inline-height);
 }
 
-.widget-text input[type="text"]:disabled, .widget-text input[type="number"]:disabled, .widget-textarea textarea:disabled {
+.widget-text input[type="text"]:disabled, .widget-text input[type="number"]:disabled, .widget-text input[type="password"]:disabled, .widget-textarea textarea:disabled {
     opacity: var(--jp-widgets-disabled-opacity);
 }
 
-.widget-text input[type="text"], .widget-text input[type="number"], .widget-textarea textarea {
+.widget-text input[type="text"], .widget-text input[type="number"], .widget-text input[type="password"], .widget-textarea textarea {
     box-sizing: border-box;
     border: var(--jp-widgets-input-border-width) solid var(--jp-widgets-input-border-color);
     background-color: var(--jp-widgets-input-background-color);
@@ -437,7 +437,7 @@
     outline: none !important;
 }
     
-.widget-text input[type="text"], .widget-textarea textarea {
+.widget-text input[type="text"], .widget-text input[type="password"], .widget-textarea textarea {
     padding: var(--jp-widgets-input-padding) calc( var(--jp-widgets-input-padding) *  2);
 }
 


### PR DESCRIPTION
This pull request addresses the issue referenced in #2492 . 

It also sets the same way as for the `input[type="text"]`:
 - the opacity (when `disabled=True`)
 - the padding

_Example:_

**Before**:
![ipywidgets_fix_pwd_before](https://user-images.githubusercontent.com/6230036/69284623-589d1400-0bef-11ea-97d9-e7af07287d10.png)

**After**:
![ipywidgets_fix_pwd_after](https://user-images.githubusercontent.com/6230036/69284630-5aff6e00-0bef-11ea-96a2-af6e150534ee.png)
