### PR TITLE
New HTML attr.: Tabindex

### DIFF
--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -63,13 +63,13 @@ class DOMWidget(Widget):
         """
         self.tabindex = i
 
-    def set_tabbable(self):
+    def make_tabbable(self):
         """Make this DOM element reachable
         to keyboard tabulation navigation.
         """
         self.set_tabindex(0)
 
-    def set_untabbable(self):
+    def make_untabbable(self):
         """Make this DOM element unreachable
         to keyboard tabulation navigation.
         """

--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -62,3 +62,15 @@ class DOMWidget(Widget):
             Order in the keyboard tabulation.
         """
         self.tabindex = i
+
+    def set_tabbable(self):
+        """Make this DOM element reachable
+        to keyboard tabulation navigation.
+        """
+        self.set_tabindex(0)
+
+    def set_untabbable(self):
+        """Make this DOM element unreachable
+        to keyboard tabulation navigation.
+        """
+        self.set_tabindex(-1)

--- a/ipywidgets/widgets/domwidget.py
+++ b/ipywidgets/widgets/domwidget.py
@@ -3,7 +3,7 @@
 
 """Contains the DOMWidget class"""
 
-from traitlets import Unicode
+from traitlets import Int, Unicode
 from .widget import Widget, widget_serialization
 from .trait_types import InstanceDict, TypedTuple
 from .widget_layout import Layout
@@ -15,6 +15,7 @@ class DOMWidget(Widget):
 
     _model_name = Unicode('DOMWidgetModel').tag(sync=True)
     _dom_classes = TypedTuple(trait=Unicode(), help="CSS classes applied to widget DOM element").tag(sync=True)
+    tabindex = Int(help="Tabulation index.").tag(sync=True)
     layout = InstanceDict(Layout).tag(sync=True, **widget_serialization)
 
     def add_class(self, className):
@@ -48,3 +49,16 @@ class DOMWidget(Widget):
         # We also need to include _dom_classes in repr for reproducibility
         if self._dom_classes:
             yield '_dom_classes'
+
+    def set_tabindex(self, i=0):
+        """Set tabindex for this DOM element.
+        NB: this method is here for completeness
+        but should be avoided for i>0.
+        (see https://developer.paciellogroup.com/blog/2014/08/using-the-tabindex-attribute/)
+
+        Parameters
+        ----------
+        i: integer
+            Order in the keyboard tabulation.
+        """
+        self.tabindex = i

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -577,7 +577,8 @@ class DOMWidgetModel extends WidgetModel {
 
     defaults() {
         return utils.assign(super.defaults(), {
-            _dom_classes: []
+            _dom_classes: [],
+            tabindex: null
             // We do not declare defaults for the layout and style attributes.
             // Those defaults are constructed on the kernel side and synced here
             // as needed, and our code here copes with those attributes being
@@ -964,6 +965,12 @@ class DOMWidgetView extends WidgetView {
         } else {
             this.pWidget.addClass('jupyter-widgets-disconnected');
         }
+    }
+
+    updateTabindex() {
+        let tabindex = this.model.get('tabindex');
+        if (tabindex) this.el.setAttribute('tabIndex', tabindex);
+        else this.el.removeAttribute('tabIndex');
     }
 
     '$el': any;

--- a/packages/controls/src/widget_bool.ts
+++ b/packages/controls/src/widget_bool.ts
@@ -68,10 +68,12 @@ class CheckboxView extends DescriptionView {
         this.checkboxLabel.appendChild(this.descriptionSpan);
 
         this.listenTo(this.model, 'change:indent', this.updateIndent);
+        this.listenTo(this.model, 'change:tabindex', this.updateTabindex);
 
         this.update(); // Set defaults.
         this.updateDescription();
         this.updateIndent();
+        this.updateTabindex();
     }
 
     /**
@@ -99,6 +101,13 @@ class CheckboxView extends DescriptionView {
     updateIndent() {
         let indent = this.model.get('indent');
         this.label.style.display = indent ? '' : 'none';
+    }
+
+    updateTabindex() {
+        if (!this.checkbox) return; // we might be constructing the parent
+        let tabindex = this.model.get('tabindex');
+        if (tabindex) this.checkbox.setAttribute('tabIndex', tabindex);
+        else this.checkbox.removeAttribute('tabIndex');
     }
 
     events(): {[e: string]: string} {

--- a/packages/controls/src/widget_bool.ts
+++ b/packages/controls/src/widget_bool.ts
@@ -164,6 +164,7 @@ class ToggleButtonView extends DOMWidgetView {
         this.el.classList.add('jupyter-button');
         this.el.classList.add('widget-toggle-button');
         this.listenTo(this.model, 'change:button_style', this.update_button_style);
+        this.listenTo(this.model, 'change:tabindex', this.updateTabindex);
         this.set_button_style();
         this.update(); // Set defaults.
     }
@@ -191,6 +192,7 @@ class ToggleButtonView extends DOMWidgetView {
 
         if (options === undefined || options.updated_view !== this) {
             this.el.disabled = this.model.get('disabled');
+            this.el.setAttribute('tabIndex', this.model.get('tabindex'));
             this.el.setAttribute('title', this.model.get('tooltip'));
 
             let description = this.model.get('description');
@@ -208,6 +210,7 @@ class ToggleButtonView extends DOMWidgetView {
                 this.el.appendChild(document.createTextNode(description));
             }
         }
+        this.updateTabindex();
         return super.update();
     }
 

--- a/packages/controls/src/widget_bool.ts
+++ b/packages/controls/src/widget_bool.ts
@@ -106,8 +106,8 @@ class CheckboxView extends DescriptionView {
     updateTabindex() {
         if (!this.checkbox) return; // we might be constructing the parent
         let tabindex = this.model.get('tabindex');
-        if (tabindex) this.checkbox.setAttribute('tabIndex', tabindex);
-        else this.checkbox.removeAttribute('tabIndex');
+        if (tabindex === null) this.checkbox.removeAttribute('tabIndex');
+        else this.checkbox.setAttribute('tabIndex', tabindex);
     }
 
     events(): {[e: string]: string} {

--- a/packages/controls/src/widget_button.ts
+++ b/packages/controls/src/widget_button.ts
@@ -67,6 +67,7 @@ class ButtonView extends DOMWidgetView {
         this.el.classList.add('jupyter-button');
         this.el.classList.add('widget-button');
         this.listenTo(this.model, 'change:button_style', this.update_button_style);
+        this.listenTo(this.model, 'change:tabindex', this.updateTabindex);
         this.set_button_style();
         this.update(); // Set defaults.
     }
@@ -79,6 +80,7 @@ class ButtonView extends DOMWidgetView {
      */
     update() {
         this.el.disabled = this.model.get('disabled');
+        this.el.setAttribute('tabIndex', this.model.get('tabindex'));
         this.el.setAttribute('title', this.model.get('tooltip'));
 
         let description = this.model.get('description');

--- a/packages/controls/src/widget_description.ts
+++ b/packages/controls/src/widget_description.ts
@@ -58,7 +58,9 @@ class DescriptionView extends DOMWidgetView {
 
         this.listenTo(this.model, 'change:description', this.updateDescription);
         this.listenTo(this.model, 'change:description_tooltip', this.updateDescription);
+        this.listenTo(this.model, 'change:tabindex', this.updateTabindex);
         this.updateDescription();
+        this.updateTabindex();
     }
 
     typeset(element: HTMLElement, text?: string){

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -30,6 +30,48 @@ class SelectionModel extends CoreDescriptionModel {
 }
 
 export
+class SelectionView extends DescriptionView {
+    /**
+     * Called when view is rendered.
+     */
+    render() {
+        super.render(); // Incl. setting some defaults.
+        this.el.classList.add('jupyter-widgets');
+        this.el.classList.add('widget-inline-hbox');
+    }
+
+    /**
+     * Update the contents of this view
+     *
+     * Called when the model is changed.  The model may have been
+     * changed by another view or by a state update from the back-end.
+     */
+    update() {
+        super.update();
+
+        // Disable listbox if needed
+        if (this.listbox) {
+            this.listbox.disabled = this.model.get('disabled');
+        }
+
+        // Set tabindex
+        this.updateTabindex();
+    }
+
+    updateTabindex() {
+        if (!this.listbox) return; // we might be constructing the parent
+        let tabindex = this.model.get('tabindex');
+        if (tabindex === null) {
+            this.listbox.removeAttribute('tabindex');
+        } else {
+        this.listbox.setAttribute('tabindex', tabindex);
+        }
+    }
+
+    listbox: HTMLSelectElement;
+}
+
+export
 class DropdownModel extends SelectionModel {
     defaults() {
         return {...super.defaults(),
@@ -48,7 +90,7 @@ class DropdownModel extends SelectionModel {
 // For the old code, see commit f68bfbc566f3a78a8f3350b438db8ed523ce3642
 
 export
-class DropdownView extends DescriptionView {
+class DropdownView extends SelectionView {
     /**
      * Public constructor.
      */
@@ -63,8 +105,6 @@ class DropdownView extends DescriptionView {
     render() {
         super.render();
 
-        this.el.classList.add('jupyter-widgets');
-        this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-dropdown');
 
         this.listbox = document.createElement('select');
@@ -78,9 +118,6 @@ class DropdownView extends DescriptionView {
      * Update the contents of this view
      */
     update() {
-        // Disable listbox if needed
-        this.listbox.disabled = this.model.get('disabled');
-
         // Select the correct element
         let index = this.model.get('index');
         this.listbox.selectedIndex = index === null ? -1 : index;
@@ -113,8 +150,6 @@ class DropdownView extends DescriptionView {
         this.model.set('index', this.listbox.selectedIndex === -1 ? null : this.listbox.selectedIndex);
         this.touch();
     }
-
-    listbox: HTMLSelectElement;
 }
 
 
@@ -131,7 +166,7 @@ class SelectModel extends SelectionModel {
 }
 
 export
-class SelectView extends DescriptionView {
+class SelectView extends SelectionView {
     /**
      * Public constructor.
      */
@@ -148,9 +183,6 @@ class SelectView extends DescriptionView {
      */
     render() {
         super.render();
-
-        this.el.classList.add('jupyter-widgets');
-        this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-select');
 
         this.listbox.id = this.label.htmlFor = uuid();
@@ -165,7 +197,6 @@ class SelectView extends DescriptionView {
      */
     update() {
         super.update();
-        this.listbox.disabled = this.model.get('disabled');
         let rows = this.model.get('rows');
         if (rows === null) {
             rows = '';
@@ -207,8 +238,6 @@ class SelectView extends DescriptionView {
         this.model.set('index', this.listbox.selectedIndex, {updated_view: this});
         this.touch();
     }
-
-    listbox: HTMLSelectElement;
 }
 
 export
@@ -233,8 +262,6 @@ class RadioButtonsView extends DescriptionView {
     render() {
         super.render();
 
-        this.el.classList.add('jupyter-widgets');
-        this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-radio');
 
         this.container = document.createElement('div');
@@ -401,8 +428,6 @@ class ToggleButtonsView extends DescriptionView {
     render() {
         super.render();
 
-        this.el.classList.add('jupyter-widgets');
-        this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-toggle-buttons');
 
         this.buttongroup = document.createElement('div');
@@ -586,8 +611,6 @@ class SelectionSliderView extends DescriptionView {
     render () {
         super.render();
 
-        this.el.classList.add('jupyter-widgets');
-        this.el.classList.add('widget-inline-hbox');
         this.el.classList.add('widget-hslider');
         this.el.classList.add('widget-slider');
 

--- a/packages/controls/src/widget_string.ts
+++ b/packages/controls/src/widget_string.ts
@@ -212,8 +212,8 @@ class TextareaView extends DescriptionView {
     updateTabindex() {
         if (!this.textbox) return; // we might be constructing the parent
         let tabindex = this.model.get('tabindex');
-        if (tabindex) this.textbox.setAttribute('tabIndex', tabindex);
-        else this.textbox.removeAttribute('tabIndex');
+        if (tabindex === null) this.textbox.removeAttribute('tabIndex');
+        else this.textbox.setAttribute('tabIndex', tabindex);
     }
 
     events() {

--- a/packages/controls/src/widget_string.ts
+++ b/packages/controls/src/widget_string.ts
@@ -209,6 +209,13 @@ class TextareaView extends DescriptionView {
         return super.update();
     }
 
+    updateTabindex() {
+        if (!this.textbox) return; // we might be constructing the parent
+        let tabindex = this.model.get('tabindex');
+        if (tabindex) this.textbox.setAttribute('tabIndex', tabindex);
+        else this.textbox.removeAttribute('tabIndex');
+    }
+
     events() {
         return {
             'keydown input': 'handleKeyDown',
@@ -294,6 +301,7 @@ class TextView extends DescriptionView {
 
         this.update_placeholder();
         this.update_title();
+        this.updateTabindex();
     }
 
     update_placeholder(value?: string) {
@@ -307,6 +315,13 @@ class TextView extends DescriptionView {
         } else if (this.model.get('description').length === 0) {
             this.textbox.setAttribute('title', title);
         }
+    }
+
+    updateTabindex() {
+        if (!this.textbox) return; // we might be constructing the parent
+        let tabindex = this.model.get('tabindex');
+        if (tabindex === null) this.textbox.removeAttribute('tabIndex');
+        else this.textbox.setAttribute('tabIndex', tabindex);
     }
 
     update(options?: any) {

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -74,6 +74,7 @@ Attribute        | Type             | Default          | Help
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
 `selected_index` | `null` or number (integer) | `0`              | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### AudioModel (@jupyter-widgets/controls, 1.5.0); AudioView (@jupyter-widgets/controls, 1.5.0)
 
@@ -91,6 +92,7 @@ Attribute        | Type             | Default          | Help
 `format`         | string           | `'mp3'`          | The format of the audio.
 `layout`         | reference to Layout widget | reference to new instance | 
 `loop`           | boolean          | `true`           | When true, the audio will start from the beginning after finishing
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | Bytes            | `b''`            | The media data as a byte string.
 
 ### BoundedFloatTextModel (@jupyter-widgets/controls, 1.5.0); FloatTextView (@jupyter-widgets/controls, 1.5.0)
@@ -113,6 +115,7 @@ Attribute        | Type             | Default          | Help
 `min`            | number (float)   | `0.0`            | Min value
 `step`           | `null` or number (float) | `null`           | Minimum step to increment the value
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (float)   | `0.0`            | Float value
 
 ### BoundedIntTextModel (@jupyter-widgets/controls, 1.5.0); IntTextView (@jupyter-widgets/controls, 1.5.0)
@@ -135,6 +138,7 @@ Attribute        | Type             | Default          | Help
 `min`            | number (integer) | `0`              | Min value
 `step`           | number (integer) | `1`              | Minimum step to increment the value
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (integer) | `0`              | Int value
 
 ### BoxModel (@jupyter-widgets/controls, 1.5.0); BoxView (@jupyter-widgets/controls, 1.5.0)
@@ -151,6 +155,7 @@ Attribute        | Type             | Default          | Help
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### ButtonModel (@jupyter-widgets/controls, 1.5.0); ButtonView (@jupyter-widgets/controls, 1.5.0)
 
@@ -169,6 +174,7 @@ Attribute        | Type             | Default          | Help
 `icon`           | string           | `''`             | Font-awesome icon name, without the 'fa-' prefix.
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to ButtonStyle widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `tooltip`        | string           | `''`             | Tooltip caption of the button.
 
 ### ButtonStyleModel (@jupyter-widgets/controls, 1.5.0); StyleView (@jupyter-widgets/base, 1.2.0)
@@ -201,6 +207,7 @@ Attribute        | Type             | Default          | Help
 `indent`         | boolean          | `true`           | Indent the control to align with other controls with a description.
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | boolean          | `false`          | Bool value
 
 ### ColorPickerModel (@jupyter-widgets/controls, 1.5.0); ColorPickerView (@jupyter-widgets/controls, 1.5.0)
@@ -220,6 +227,7 @@ Attribute        | Type             | Default          | Help
 `disabled`       | boolean          | `false`          | Enable or disable user changes.
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | string           | `'black'`        | The color value.
 
 ### ComboboxModel (@jupyter-widgets/controls, 1.5.0); ComboboxView (@jupyter-widgets/controls, 1.5.0)
@@ -242,6 +250,7 @@ Attribute        | Type             | Default          | Help
 `options`        | array of string  | `[]`             | Dropdown options for the combobox
 `placeholder`    | string           | `'\u200b'`       | Placeholder text to display when nothing has been typed
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | string           | `''`             | String value
 
 ### ControllerAxisModel (@jupyter-widgets/controls, 1.5.0); ControllerAxisView (@jupyter-widgets/controls, 1.5.0)
@@ -256,6 +265,7 @@ Attribute        | Type             | Default          | Help
 `_view_module_version` | string           | `'1.5.0'`        | 
 `_view_name`     | string           | `'ControllerAxisView'` | 
 `layout`         | reference to Layout widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (float)   | `0.0`            | The value of the axis.
 
 ### ControllerButtonModel (@jupyter-widgets/controls, 1.5.0); ControllerButtonView (@jupyter-widgets/controls, 1.5.0)
@@ -271,6 +281,7 @@ Attribute        | Type             | Default          | Help
 `_view_name`     | string           | `'ControllerButtonView'` | 
 `layout`         | reference to Layout widget | reference to new instance | 
 `pressed`        | boolean          | `false`          | Whether the button is pressed.
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (float)   | `0.0`            | The value of the button.
 
 ### ControllerModel (@jupyter-widgets/controls, 1.5.0); ControllerView (@jupyter-widgets/controls, 1.5.0)
@@ -291,6 +302,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `mapping`        | string           | `''`             | The name of the control mapping.
 `name`           | string           | `''`             | The name of the controller.
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `timestamp`      | number (float)   | `0.0`            | The last time the data from this gamepad was updated.
 
 ### DOMWidgetModel (@jupyter-widgets/controls, 1.5.0); None (@jupyter-widgets/controls, 1.5.0)
@@ -305,6 +317,7 @@ Attribute        | Type             | Default          | Help
 `_view_module_version` | string           | `'1.5.0'`        | 
 `_view_name`     | `null` or string | `null`           | Name of the view.
 `layout`         | reference to Layout widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | Bytes            | `b''`            | The media data as a byte string.
 
 ### DatePickerModel (@jupyter-widgets/controls, 1.5.0); DatePickerView (@jupyter-widgets/controls, 1.5.0)
@@ -323,6 +336,7 @@ Attribute        | Type             | Default          | Help
 `disabled`       | boolean          | `false`          | Enable or disable user changes.
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | `null` or Date   | `null`           | 
 
 ### DescriptionStyleModel (@jupyter-widgets/controls, 1.5.0); StyleView (@jupyter-widgets/base, 1.2.0)
@@ -368,6 +382,7 @@ Attribute        | Type             | Default          | Help
 `index`          | `null` or number (integer) | `null`           | Selected index
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### FileUploadModel (@jupyter-widgets/controls, 1.5.0); FileUploadView (@jupyter-widgets/controls, 1.5.0)
 
@@ -393,6 +408,7 @@ Attribute        | Type             | Default          | Help
 `metadata`       | array            | `[]`             | List of file metadata
 `multiple`       | boolean          | `false`          | If True, allow for multiple files upload
 `style`          | reference to ButtonStyle widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### FloatLogSliderModel (@jupyter-widgets/controls, 1.5.0); FloatLogSliderView (@jupyter-widgets/controls, 1.5.0)
 
@@ -418,6 +434,7 @@ Attribute        | Type             | Default          | Help
 `readout_format` | string           | `'.3g'`          | Format for the readout
 `step`           | number (float)   | `0.1`            | Minimum step in the exponent to increment the value
 `style`          | reference to SliderStyle widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (float)   | `1.0`            | Float value
 
 ### FloatProgressModel (@jupyter-widgets/controls, 1.5.0); ProgressView (@jupyter-widgets/controls, 1.5.0)
@@ -439,6 +456,7 @@ Attribute        | Type             | Default          | Help
 `min`            | number (float)   | `0.0`            | Min value
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `style`          | reference to ProgressStyle widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (float)   | `0.0`            | Float value
 
 ### FloatRangeSliderModel (@jupyter-widgets/controls, 1.5.0); FloatRangeSliderView (@jupyter-widgets/controls, 1.5.0)
@@ -464,6 +482,7 @@ Attribute        | Type             | Default          | Help
 `readout_format` | string           | `'.2f'`          | Format for the readout
 `step`           | number (float)   | `0.1`            | Minimum step to increment the value
 `style`          | reference to SliderStyle widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | array            | `[0.0, 1.0]`     | Tuple of (lower, upper) bounds
 
 ### FloatSliderModel (@jupyter-widgets/controls, 1.5.0); FloatSliderView (@jupyter-widgets/controls, 1.5.0)
@@ -489,6 +508,7 @@ Attribute        | Type             | Default          | Help
 `readout_format` | string           | `'.2f'`          | Format for the readout
 `step`           | number (float)   | `0.1`            | Minimum step to increment the value
 `style`          | reference to SliderStyle widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (float)   | `0.0`            | Float value
 
 ### FloatTextModel (@jupyter-widgets/controls, 1.5.0); FloatTextView (@jupyter-widgets/controls, 1.5.0)
@@ -509,6 +529,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `step`           | `null` or number (float) | `null`           | Minimum step to increment the value
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (float)   | `0.0`            | Float value
 
 ### GridBoxModel (@jupyter-widgets/controls, 1.5.0); GridBoxView (@jupyter-widgets/controls, 1.5.0)
@@ -525,6 +546,7 @@ Attribute        | Type             | Default          | Help
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### HBoxModel (@jupyter-widgets/controls, 1.5.0); HBoxView (@jupyter-widgets/controls, 1.5.0)
 
@@ -540,6 +562,7 @@ Attribute        | Type             | Default          | Help
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### HTMLMathModel (@jupyter-widgets/controls, 1.5.0); HTMLMathView (@jupyter-widgets/controls, 1.5.0)
 
@@ -557,6 +580,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `placeholder`    | string           | `'\u200b'`       | Placeholder text to display when nothing has been typed
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | string           | `''`             | String value
 
 ### HTMLModel (@jupyter-widgets/controls, 1.5.0); HTMLView (@jupyter-widgets/controls, 1.5.0)
@@ -575,6 +599,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `placeholder`    | string           | `'\u200b'`       | Placeholder text to display when nothing has been typed
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | string           | `''`             | String value
 
 ### ImageModel (@jupyter-widgets/controls, 1.5.0); ImageView (@jupyter-widgets/controls, 1.5.0)
@@ -591,6 +616,7 @@ Attribute        | Type             | Default          | Help
 `format`         | string           | `'png'`          | The format of the image.
 `height`         | string           | `''`             | Height of the image in pixels. Use layout.height for styling the widget.
 `layout`         | reference to Layout widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | Bytes            | `b''`            | The media data as a byte string.
 `width`          | string           | `''`             | Width of the image in pixels. Use layout.width for styling the widget.
 
@@ -613,6 +639,7 @@ Attribute        | Type             | Default          | Help
 `min`            | number (integer) | `0`              | Min value
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `style`          | reference to ProgressStyle widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (integer) | `0`              | Int value
 
 ### IntRangeSliderModel (@jupyter-widgets/controls, 1.5.0); IntRangeSliderView (@jupyter-widgets/controls, 1.5.0)
@@ -638,6 +665,7 @@ Attribute        | Type             | Default          | Help
 `readout_format` | string           | `'d'`            | Format for the readout
 `step`           | number (integer) | `1`              | Minimum step that the value can take
 `style`          | reference to SliderStyle widget | reference to new instance | Slider style customizations.
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | array            | `[0, 1]`         | Tuple of (lower, upper) bounds
 
 ### IntSliderModel (@jupyter-widgets/controls, 1.5.0); IntSliderView (@jupyter-widgets/controls, 1.5.0)
@@ -663,6 +691,7 @@ Attribute        | Type             | Default          | Help
 `readout_format` | string           | `'d'`            | Format for the readout
 `step`           | number (integer) | `1`              | Minimum step to increment the value
 `style`          | reference to SliderStyle widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (integer) | `0`              | Int value
 
 ### IntTextModel (@jupyter-widgets/controls, 1.5.0); IntTextView (@jupyter-widgets/controls, 1.5.0)
@@ -683,6 +712,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `step`           | number (integer) | `1`              | Minimum step to increment the value
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (integer) | `0`              | Int value
 
 ### LabelModel (@jupyter-widgets/controls, 1.5.0); LabelView (@jupyter-widgets/controls, 1.5.0)
@@ -701,6 +731,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `placeholder`    | string           | `'\u200b'`       | Placeholder text to display when nothing has been typed
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | string           | `''`             | String value
 
 ### LinkModel (@jupyter-widgets/controls, 1.5.0); None (@jupyter-widgets/controls, 1.5.0)
@@ -734,6 +765,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `placeholder`    | string           | `'\u200b'`       | Placeholder text to display when nothing has been typed
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | string           | `''`             | String value
 
 ### PlayModel (@jupyter-widgets/controls, 1.5.0); PlayView (@jupyter-widgets/controls, 1.5.0)
@@ -759,6 +791,7 @@ Attribute        | Type             | Default          | Help
 `show_repeat`    | boolean          | `true`           | Show the repeat toggle button in the widget.
 `step`           | number (integer) | `1`              | Increment step
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | number (integer) | `0`              | Int value
 
 ### ProgressStyleModel (@jupyter-widgets/controls, 1.5.0); StyleView (@jupyter-widgets/base, 1.2.0)
@@ -792,6 +825,7 @@ Attribute        | Type             | Default          | Help
 `index`          | `null` or number (integer) | `null`           | Selected index
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### SelectModel (@jupyter-widgets/controls, 1.5.0); SelectView (@jupyter-widgets/controls, 1.5.0)
 
@@ -812,6 +846,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `rows`           | number (integer) | `5`              | The number of rows to display.
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### SelectMultipleModel (@jupyter-widgets/controls, 1.5.0); SelectMultipleView (@jupyter-widgets/controls, 1.5.0)
 
@@ -832,6 +867,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `rows`           | number (integer) | `5`              | The number of rows to display.
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### SelectionRangeSliderModel (@jupyter-widgets/controls, 1.5.0); SelectionRangeSliderView (@jupyter-widgets/controls, 1.5.0)
 
@@ -854,6 +890,7 @@ Attribute        | Type             | Default          | Help
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `readout`        | boolean          | `true`           | Display the current selected label next to the slider
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### SelectionSliderModel (@jupyter-widgets/controls, 1.5.0); SelectionSliderView (@jupyter-widgets/controls, 1.5.0)
 
@@ -876,6 +913,7 @@ Attribute        | Type             | Default          | Help
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `readout`        | boolean          | `true`           | Display the current selected label next to the slider
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### SliderStyleModel (@jupyter-widgets/controls, 1.5.0); StyleView (@jupyter-widgets/base, 1.2.0)
 
@@ -906,6 +944,7 @@ Attribute        | Type             | Default          | Help
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
 `selected_index` | `null` or number (integer) | `0`              | The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### TextModel (@jupyter-widgets/controls, 1.5.0); TextView (@jupyter-widgets/controls, 1.5.0)
 
@@ -925,6 +964,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `placeholder`    | string           | `'\u200b'`       | Placeholder text to display when nothing has been typed
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | string           | `''`             | String value
 
 ### TextareaModel (@jupyter-widgets/controls, 1.5.0); TextareaView (@jupyter-widgets/controls, 1.5.0)
@@ -946,6 +986,7 @@ Attribute        | Type             | Default          | Help
 `placeholder`    | string           | `'\u200b'`       | Placeholder text to display when nothing has been typed
 `rows`           | `null` or number (integer) | `null`           | The number of rows to display.
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | string           | `''`             | String value
 
 ### ToggleButtonModel (@jupyter-widgets/controls, 1.5.0); ToggleButtonView (@jupyter-widgets/controls, 1.5.0)
@@ -966,6 +1007,7 @@ Attribute        | Type             | Default          | Help
 `icon`           | string           | `''`             | Font-awesome icon.
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `tooltip`        | string           | `''`             | Tooltip caption of the toggle button.
 `value`          | boolean          | `false`          | Bool value
 
@@ -989,6 +1031,7 @@ Attribute        | Type             | Default          | Help
 `index`          | `null` or number (integer) | `null`           | Selected index
 `layout`         | reference to Layout widget | reference to new instance | 
 `style`          | reference to ToggleButtonsStyle widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `tooltips`       | array of string  | `[]`             | Tooltips for each button.
 
 ### ToggleButtonsStyleModel (@jupyter-widgets/controls, 1.5.0); StyleView (@jupyter-widgets/base, 1.2.0)
@@ -1019,6 +1062,7 @@ Attribute        | Type             | Default          | Help
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 
 ### ValidModel (@jupyter-widgets/controls, 1.5.0); ValidView (@jupyter-widgets/controls, 1.5.0)
 
@@ -1037,6 +1081,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `readout`        | string           | `'Invalid'`      | Message displayed when the value is False
 `style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | boolean          | `false`          | Bool value
 
 ### VideoModel (@jupyter-widgets/controls, 1.5.0); VideoView (@jupyter-widgets/controls, 1.5.0)
@@ -1056,6 +1101,7 @@ Attribute        | Type             | Default          | Help
 `height`         | string           | `''`             | Height of the video in pixels.
 `layout`         | reference to Layout widget | reference to new instance | 
 `loop`           | boolean          | `true`           | When true, the video will start from the beginning after finishing
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 `value`          | Bytes            | `b''`            | The media data as a byte string.
 `width`          | string           | `''`             | Width of the video in pixels.
 
@@ -1073,4 +1119,5 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `msg_id`         | string           | `''`             | Parent message id of messages to capture
 `outputs`        | array of object  | `[]`             | The output messages synced from the frontend.
+`tabindex`       | number (integer) | `0`              | Tabulation index.
 

--- a/tests/test_tabindex.ipynb
+++ b/tests/test_tabindex.ipynb
@@ -6,9 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ipywidgets import *\n",
-    "#from ipywidgets.widget_description import DescriptionWidget\n",
-    "#dir(ipywidgets)"
+    "from ipywidgets import *"
    ]
   },
   {
@@ -28,30 +26,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d.tabindex"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#ToggleButton.__mro__\n",
-    "#Button.__mro__"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "b = Button()\n",
     "tb = ToggleButton()\n",
     "ta = Textarea()\n",
-    "t1 = Text(\"1\")\n",
-    "t2 = Text(\"2\")"
+    "t1 = Text(\"Text 1\")\n",
+    "t2 = Text(\"Text 2\")\n",
+    "cb = Checkbox()"
    ]
   },
   {
@@ -60,11 +40,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tb.set_tabindex(2)\n",
-    "b.set_tabindex(5)\n",
-    "ta.set_tabindex(0)\n",
-    "t1.set_tabindex(-1)\n",
-    "t2.set_tabindex(-1)"
+    "# After running this cell, go and tabulate over the controls\n",
+    "HBox((t1, b, tb, t2, ta, cb))"
    ]
   },
   {
@@ -73,7 +50,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HBox((t1, b, tb, t2, ta))"
+    "# After running this cell, try again to tabulate over these controls \n",
+    "t1.set_tabbable()\n",
+    "t2.set_untabbable()\n",
+    "b.set_tabbable()\n",
+    "tb.set_untabbable()\n",
+    "ta.set_untabbable()\n",
+    "cb.set_tabbable()"
    ]
   },
   {
@@ -82,17 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t1.tabindex, b.tabindex, tb.tabindex, t2.tabindex, ta.tabindex"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#tb.set_tabindex(-1)\n",
-    "#b.set_tabindex(-1)"
+    "t1.tabindex, b.tabindex, tb.tabindex, t2.tabindex, ta.tabindex, cb.tabindex"
    ]
   }
  ],
@@ -111,8 +84,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.16"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/tests/test_tabindex.ipynb
+++ b/tests/test_tabindex.ipynb
@@ -1,0 +1,120 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import *\n",
+    "#from ipywidgets.widget_description import DescriptionWidget\n",
+    "#dir(ipywidgets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d = DOMWidget()\n",
+    "d.set_tabindex(3)\n",
+    "d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "d.tabindex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#ToggleButton.__mro__\n",
+    "#Button.__mro__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b = Button()\n",
+    "tb = ToggleButton()\n",
+    "ta = Textarea()\n",
+    "t1 = Text(\"1\")\n",
+    "t2 = Text(\"2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tb.set_tabindex(2)\n",
+    "b.set_tabindex(5)\n",
+    "ta.set_tabindex(0)\n",
+    "t1.set_tabindex(-1)\n",
+    "t2.set_tabindex(-1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HBox((t1, b, tb, t2, ta))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t1.tabindex, b.tabindex, tb.tabindex, t2.tabindex, ta.tabindex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#tb.set_tabindex(-1)\n",
+    "#b.set_tabindex(-1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_tabindex.ipynb
+++ b/tests/test_tabindex.ipynb
@@ -30,6 +30,7 @@
     "tb = ToggleButton(description=\"ToggleButton\")\n",
     "ta = Textarea(\"Textarea\")\n",
     "t = Text(\"Text input\")\n",
+    "c = Combobox(options=[\"First\", \"Second\", \"Third\"])\n",
     "cb = Checkbox(description=\"Checkbox\")\n",
     "s = Select(options=(\"First\", \"Final\"))\n",
     "d = Dropdown(options=(\"First\", \"Final\"))"
@@ -42,7 +43,7 @@
    "outputs": [],
    "source": [
     "# After running this cell, go and tabulate over the controls\n",
-    "HBox((t, b, tb, ta, cb, s, d))"
+    "VBox((HBox((b, tb, t, ta)), HBox((cb, c, s, d)),))"
    ]
   },
   {
@@ -52,12 +53,12 @@
    "outputs": [],
    "source": [
     "# After running this cell, try again to tabulate over these controls \n",
-    "t1.set_tabbable()\n",
-    "t2.set_untabbable()\n",
+    "t.set_tabbable()\n",
     "b.set_tabbable()\n",
     "tb.set_untabbable()\n",
     "ta.set_untabbable()\n",
     "cb.set_tabbable()\n",
+    "c.set_untabbable()\n",
     "s.set_untabbable()\n",
     "d.set_tabbable()"
    ]
@@ -68,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t1.tabindex, b.tabindex, tb.tabindex, t2.tabindex, ta.tabindex, cb.tabindex, s.tabindex, d.tabindex"
+    "b.tabindex, tb.tabindex, t.tabindex, ta.tabindex, cb.tabindex, c.tabindex, s.tabindex, d.tabindex"
    ]
   }
  ],

--- a/tests/test_tabindex.ipynb
+++ b/tests/test_tabindex.ipynb
@@ -53,14 +53,14 @@
    "outputs": [],
    "source": [
     "# After running this cell, try again to tabulate over these controls \n",
-    "t.set_tabbable()\n",
-    "b.set_tabbable()\n",
-    "tb.set_untabbable()\n",
-    "ta.set_untabbable()\n",
-    "cb.set_tabbable()\n",
-    "c.set_untabbable()\n",
-    "s.set_untabbable()\n",
-    "d.set_tabbable()"
+    "t.make_tabbable()\n",
+    "b.make_tabbable()\n",
+    "tb.make_untabbable()\n",
+    "ta.make_untabbable()\n",
+    "cb.make_tabbable()\n",
+    "c.make_untabbable()\n",
+    "s.make_untabbable()\n",
+    "d.make_tabbable()"
    ]
   },
   {

--- a/tests/test_tabindex.ipynb
+++ b/tests/test_tabindex.ipynb
@@ -26,12 +26,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "b = Button()\n",
-    "tb = ToggleButton()\n",
-    "ta = Textarea()\n",
-    "t1 = Text(\"Text 1\")\n",
-    "t2 = Text(\"Text 2\")\n",
-    "cb = Checkbox()"
+    "b = Button(description=\"Button\")\n",
+    "tb = ToggleButton(description=\"ToggleButton\")\n",
+    "ta = Textarea(\"Textarea\")\n",
+    "t = Text(\"Text input\")\n",
+    "cb = Checkbox(description=\"Checkbox\")\n",
+    "s = Select(options=(\"First\", \"Final\"))\n",
+    "d = Dropdown(options=(\"First\", \"Final\"))"
    ]
   },
   {
@@ -41,7 +42,7 @@
    "outputs": [],
    "source": [
     "# After running this cell, go and tabulate over the controls\n",
-    "HBox((t1, b, tb, t2, ta, cb))"
+    "HBox((t, b, tb, ta, cb, s, d))"
    ]
   },
   {
@@ -56,7 +57,9 @@
     "b.set_tabbable()\n",
     "tb.set_untabbable()\n",
     "ta.set_untabbable()\n",
-    "cb.set_tabbable()"
+    "cb.set_tabbable()\n",
+    "s.set_untabbable()\n",
+    "d.set_tabbable()"
    ]
   },
   {
@@ -65,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t1.tabindex, b.tabindex, tb.tabindex, t2.tabindex, ta.tabindex, cb.tabindex"
+    "t1.tabindex, b.tabindex, tb.tabindex, t2.tabindex, ta.tabindex, cb.tabindex, s.tabindex, d.tabindex"
    ]
   }
  ],


### PR DESCRIPTION
This PR adds a `tabindex` HTML attribute to a bunch of ipywidgets widgets: Text, Textarea, Button, ToggleButton, Combobox, Checkbox, Dropdown and Select.

This new attribute is applied on the `DOMWidget` class level, allowing generalization to all widgets.

Explicitely setting tabindex is then possible, although that's not a very good practice in general. Yet, pecifying if a control  widget should `tabbable` or not is a most useful use case for web interfaces.