### PR TITLE
Add settings for Binder

### DIFF
--- a/.binder/README
+++ b/.binder/README
@@ -1,0 +1,10 @@
+This directory holds configuration files for https://mybinder.org/.
+
+The interactive notebooks can be accessed with this link:
+https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/master?filepath=docs/source/examples
+
+To check out a different version, just replace "master" with the desired
+branch/tag name or commit hash.
+
+To use JupyterLab, use:
+https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/master?urlpath=lab/tree/docs/source/examples

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,15 @@
+name: ipywidgets_binder
+channels:
+  - conda-forge
+dependencies:
+  - bqplot
+  - ipyleaflet
+  - jupyterlab
+  - matplotlib
+  - networkx
+  - numpy
+  - pandas
+  - scikit-image
+  - scikit-learn
+  - sympy
+  - yarn

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - bqplot
   - ipyleaflet
-  - jupyterlab
+  - jupyterlab=1
   - matplotlib
   - networkx
   - numpy

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+./dev-install.sh


### PR DESCRIPTION
Sadly, this doesn't work yet.

There is an error when running `./dev-install.sh` on Binder:

```
ValueError:                                                                                                           
"@jupyter-widgets/jupyterlab-manager@1.1.0" is not compatible with the current JupyterLab                             
Conflicting Dependencies:                                                                                             
JupyterLab                        Extension      Package                                                              
>=1.2.1 <1.3.0                    >=2.0.0-beta.1 <3.0.0@jupyterlab/application                                        
>=1.2.2 <1.3.0                    >=2.0.0-beta.1 <3.0.0@jupyterlab/notebook                                           
>=1.2.1 <1.3.0                    >=2.0.0-beta.1 <3.0.0@jupyterlab/rendermime                                         
>=1.5.0 <1.6.0                    >=2.0.0-beta.1 <3.0.0@jupyterlab/rendermime-interfaces                              
>=4.2.0 <4.3.0                    >=5.0.0-beta.1 <6.0.0@jupyterlab/services                                           
```

Apparently, the JupyterLab and `jupyter-widgets/jupyterlab-manager` versions have to match (see https://github.com/jupyter-widgets/ipywidgets/blob/master/packages/jupyterlab-manager/README.md), but I don't know how to handle this in a development installation ...

Any ideas?

See #2301.