### PR TITLE
DOC: Add thread.join() in Output example

### DIFF
--- a/docs/source/examples/Output Widget.ipynb
+++ b/docs/source/examples/Output Widget.ipynb
@@ -383,7 +383,8 @@
     "thread = threading.Thread(\n",
     "    target=thread_func,\n",
     "    args=(\"some text\", out))\n",
-    "thread.start()"
+    "thread.start()\n",
+    "thread.join()"
    ]
   }
  ],

--- a/docs/source/examples/Output Widget.ipynb
+++ b/docs/source/examples/Output Widget.ipynb
@@ -383,7 +383,15 @@
     "thread = threading.Thread(\n",
     "    target=thread_func,\n",
     "    args=(\"some text\", out))\n",
-    "thread.start()\n",
+    "thread.start()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "thread.join()"
    ]
   }


### PR DESCRIPTION
This waits for the thread to finish, even when executed with `nbconvert --execute`.

There still seems to be a problem when creating the docs, though. In that case the output is shown twice for some reason ...