### PR TITLE
WidgetManagerBase: Improve create_view return type

### DIFF
--- a/packages/base-manager/src/manager-base.ts
+++ b/packages/base-manager/src/manager-base.ts
@@ -89,8 +89,9 @@ export abstract class ManagerBase<T> implements IWidgetManager {
      * Make sure the view creation is not out of order with
      * any state updates.
      */
-    create_view(model: DOMWidgetModel, options: any): Promise<DOMWidgetView>;
-    create_view(model: WidgetModel, options = {}): Promise<WidgetView> {
+    create_view<VT extends DOMWidgetView = DOMWidgetView>(model: DOMWidgetModel, options?: any): Promise<VT>;
+    create_view<VT extends WidgetView = WidgetView>(model: WidgetModel, options?: any): Promise<VT>;
+    create_view<VT extends WidgetView = WidgetView>(model: WidgetModel, options = {}): Promise<VT> {
         const viewPromise = model.state_change = model.state_change.then(() => {
             return this.loadClass(model.get('_view_name'),
                 model.get('_view_module'),

--- a/packages/base/src/manager.ts
+++ b/packages/base/src/manager.ts
@@ -170,8 +170,8 @@ interface IWidgetManager {
      * Make sure the view creation is not out of order with
      * any state updates.
      */
-    create_view(model: DOMWidgetModel, options?: unknown): Promise<DOMWidgetView>;
-    create_view(model: WidgetModel, options?: unknown): Promise<WidgetView>;
+    create_view<VT extends DOMWidgetView = DOMWidgetView>(model: DOMWidgetModel, options?: unknown): Promise<VT>;
+    create_view<VT extends WidgetView = WidgetView>(model: WidgetModel, options?: unknown): Promise<VT>;
 
     /**
      * callback handlers specific to a view

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -691,9 +691,11 @@ class WidgetView extends NativeView<WidgetModel> {
     /**
      * Create and promise that resolves to a child view of a given model
      */
-    create_child_view(child_model: WidgetModel, options = {}): Promise<DOMWidgetView> {
+    create_child_view<VT extends DOMWidgetView = DOMWidgetView>(child_model: DOMWidgetModel, options?: any): Promise<VT>;
+    create_child_view<VT extends WidgetView = WidgetView>(child_model: WidgetModel, options?: any): Promise<VT>;
+    create_child_view<VT extends WidgetView = WidgetView>(child_model: WidgetModel, options = {}): Promise<VT> {
         options = { parent: this, ...options};
-        return this.model.widget_manager.create_view(child_model, options)
+        return this.model.widget_manager.create_view<VT>(child_model, options)
             .catch(utils.reject('Could not create child view', true));
     }
 


### PR DESCRIPTION
Given a video widget model `VideoModel` which has an associated view `VideoView`.  The following code does not compile:

```TypeScript
createVideo(videoModel: VideoModel) {
    this.create_child_view(videoModel).then((videoView: VideoView) => {
        // Do something
    });
}
```

With the following error:
```
Argument of type '(videoView: VideoView) => VideoView' is not assignable to parameter of type '(value: DOMWidgetView) => VideoView | PromiseLike<VideoView>'.
  Types of parameters 'videoView' and 'value' are incompatible.
    Type 'DOMWidgetView' is not assignable to type 'VideoView'.
```

This PR allows doing:
```TypeScript
createVideo(videoModel: VideoModel) {
    this.create_child_view<VideoView>(videoModel).then((videoView: VideoView) => {
        // Do something
    });
}
```