### PR TITLE
Add Play widget interval to the Widget List docs

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -888,11 +888,11 @@
    "outputs": [],
    "source": [
     "play = widgets.Play(\n",
-    "#     interval=10,\n",
     "    value=50,\n",
     "    min=0,\n",
     "    max=100,\n",
     "    step=1,\n",
+    "    interval=500,\n",
     "    description=\"Press play\",\n",
     "    disabled=False\n",
     ")\n",

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -224,7 +224,7 @@ class _IntRange(_Int):
 class Play(_BoundedInt):
     """Play/repeat buttons to step through values automatically, and optionally loop.
     """
-    interval = CInt(100, help="The maximum value for the play control.").tag(sync=True)
+    interval = CInt(100, help="The time between two animation steps (ms).").tag(sync=True)
     step = CInt(1, help="Increment step").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
 

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -752,7 +752,7 @@ Attribute        | Type             | Default          | Help
 `description`    | string           | `''`             | Description of the control.
 `description_tooltip` | `null` or string | `null`           | Tooltip for the description (defaults to description).
 `disabled`       | boolean          | `false`          | Enable or disable user changes
-`interval`       | number (integer) | `100`            | The maximum value for the play control.
+`interval`       | number (integer) | `100`            | The time between two animation steps (ms).
 `layout`         | reference to Layout widget | reference to new instance | 
 `max`            | number (integer) | `100`            | Max value
 `min`            | number (integer) | `0`              | Min value


### PR DESCRIPTION
This was brought up in https://github.com/jupyter-widgets/ipywidgets/issues/2631.

We can add `interval` to the docs so it's more discoverable.