### PR TITLE
Build docs consistently on Python 3.7

### DIFF
--- a/.github/workflows/testdocs.yml
+++ b/.github/workflows/testdocs.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.7
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - nbformat
 - nbsphinx
 - notebook>=4.2
-- python=3.6
+- python=3.7
 - sphinx>=1.4.6
 - sphinx_rtd_theme
 - tornado


### PR DESCRIPTION
Prior to this PR, we tested building the docs on Python 3.5 and built the docs on read the docs on Python 3.6.

This PR changes both to 3.7.

Another inconsistency is that when testing, we install dependencies with pip (referencing `docs/requirements.txt`), but in readthedocs, we install dependencies with conda (referencing `docs/environment.yml`). Right now, support for conda in GitHub actions is a bit sparse, so I suggest not changing that for now.