### PR TITLE
prevent npm install, yarn install should be used

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
     "widgetsnbextension",
     "examples/*"
   ],
+  "engines": {
+    "npm": "please-use-yarn",
+    "node": ">=10.15.3",
+    "yarn": ">=1.15.0"
+  },
   "scripts": {
     "build": "lerna run build --ignore \"@jupyter-widgets/example-*\"",
     "build:examples": "lerna run build --scope \"@jupyter-widgets/example-*\" --include-filtered-dependencies",


### PR DESCRIPTION
prevent running `npm install`.
error message will contain `please-use-yarn`