### PR TITLE
Add requirements.txt and postBuild for Binder

### DIFF
--- a/.binder/README
+++ b/.binder/README
@@ -1,0 +1,10 @@
+This directory holds configuration files for https://mybinder.org/.
+
+The interactive notebooks can be accessed with this link:
+https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/master?filepath=docs/source/examples
+
+To check out a different version, just replace "master" with the desired
+branch/tag name or commit hash.
+
+To use JupyterLab, use:
+https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/master?urlpath=lab/tree/docs/source/examples

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+npm install -g yarn
+
+./dev-install.sh

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,0 +1,9 @@
+bqplot
+ipyleaflet
+matplotlib
+networkx
+numpy
+pandas
+scikit-image
+scikit-learn
+sympy

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,5 +1,6 @@
 bqplot
 ipyleaflet
+jupyterlab>=2.0.0b2
 matplotlib
 networkx
 numpy

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,6 +1,6 @@
 bqplot
 ipyleaflet
-jupyterlab>=2
+jupyterlab~=3.0
 matplotlib
 networkx
 numpy

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,6 +1,6 @@
 bqplot
 ipyleaflet
-jupyterlab>=2.0.0b2
+jupyterlab>=2
 matplotlib
 networkx
 numpy


### PR DESCRIPTION
This is an alternative to #2659 which also tries to fix #2301.

Closes #2659

Using `jupyterlab==1` in `requirements.txt` I can avoid the error from #2659 and the Binder image finally finishes building and is actually launched.

The problem, however, is that it still doesn't work. The widgets are not displayed in JupyterLab (but they work fine in the Classic Notebook).

Here's the Binder link: https://mybinder.org/v2/gh/mgeier/ipywidgets/binder-requirements?urlpath=lab/tree/docs/source/examples