### PR TITLE
Fix Widget List notebook syntax

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -1243,7 +1243,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.6.4"
-       "value": {},
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #2702. 

The "Widget Lists" notebook was not a valid JSON file (https://github.com/jupyter-widgets/ipywidgets/commit/6fd5a2555c97ae339b702320901f88ca70a9a432#diff-56c909671b522b7514d1a582303db2bf).