### PR TITLE
Make doc README link point to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/pypi/v/ipywidgets.svg)](https://pypi.python.org/pypi/ipywidgets)
 [![Build Status](https://travis-ci.org/jupyter-widgets/ipywidgets.svg?branch=master)](https://travis-ci.org/jupyter-widgets/ipywidgets)
-[![Documentation Status](http://readthedocs.org/projects/ipywidgets/badge/?version=latest)](https://ipywidgets.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](http://readthedocs.org/projects/ipywidgets/badge/?version=stable)](https://ipywidgets.readthedocs.io/)
 [![Join the chat at https://gitter.im/ipython/ipywidgets](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jupyter-widgets/Lobby)
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/master?filepath=docs%2Fsource%2Fexamples)
 


### PR DESCRIPTION
The current badge in the README points to the latest version on readthedocs. I suggest we switch to stable because:

- the majority of users have a stable release of ipywidgets
- any user who wants the latest documentation is probably sufficiently cognizant of readthedocs to switch to latest
- our latest documentation is less stable (see #2702 for instance).
- the embed-manager is whatever nbsphinx wants to ship, which is currently stable.

If we merge this, we should probably also change the default version on readthedocs.