### PR TITLE
Install test extras_require in dev_install

### DIFF
--- a/dev-install.sh
+++ b/dev-install.sh
@@ -49,7 +49,7 @@ jupyter nbextension enable --py $nbExtFlags widgetsnbextension
 cd ..
 
 echo -n "ipywidgets"
-pip install -v -e .
+pip install -v -e ".[test]"
 
 if test "$skip_jupyter_lab" != yes; then
     jupyter labextension link ./packages/base --no-build


### PR DESCRIPTION
To avoid an extra `python -m pip install ".[test]"` afterwards to run the tests locally.