### PR TITLE
Fix call to readout_overflow for sliders

### DIFF
--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -188,7 +188,7 @@ abstract class BaseIntSliderView extends DescriptionView {
             const readout = this.model.get('readout');
             if (readout) {
                 this.readout.style.display = '';
-                this.displayed.then(function() {
+                this.displayed.then(() => {
                     if (this.readout_overflow()) {
                         this.readout.classList.add('overflow');
                     } else {


### PR DESCRIPTION
Fixes the following issue:

![readout_overflow_error](https://user-images.githubusercontent.com/591645/72155304-25872d80-33b3-11ea-8404-7bccfc130633.gif)
