### PR TITLE
Change media widgets to use memory views.

### DIFF
--- a/ipywidgets/widgets/tests/test_widget_image.py
+++ b/ipywidgets/widgets/tests/test_widget_image.py
@@ -149,8 +149,9 @@ def test_value_repr_length():
     with get_logo_png() as LOGO_PNG:
         with open(LOGO_PNG, 'rb') as f:
             img = Image.from_file(f)
-            assert len(img.__repr__()) < 120
-            assert img.__repr__().endswith("...')")
+            assert len(img.__repr__()) < 140
+            assert img.__repr__().endswith(")")
+            assert img.__repr__()[-5:-2] == '...'
 
 
 def test_value_repr_url():

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -146,6 +146,32 @@ date_serialization = {
     'to_json': date_to_json
 }
 
+class ByteMemoryView(traitlets.TraitType):
+    """A trait for memory views of bytes."""
+
+    default_value = memoryview(b'')
+    info_text = 'a memory view object'
+
+    def validate(self, obj, value):
+        if isinstance(value, memoryview) and value.format == 'B':
+            return value
+        self.error(obj, value)
+
+
+class CByteMemoryView(ByteMemoryView):
+    """A casting version of the byte memory view trait."""
+
+    def validate(self, obj, value):
+        if isinstance(value, memoryview) and value.format == 'B':
+            return value
+
+        try:
+            mv = memoryview(value)
+            if mv.format != 'B':
+                mv = mv.cast('B')
+            return mv
+        except Exception:
+            self.error(obj, value)
 
 class InstanceDict(traitlets.Instance):
     """An instance trait which coerces a dict to an instance.

--- a/ipywidgets/widgets/trait_types.py
+++ b/ipywidgets/widgets/trait_types.py
@@ -157,6 +157,8 @@ class ByteMemoryView(traitlets.TraitType):
             return value
         self.error(obj, value)
 
+    def default_value_repr(self):
+        return repr(self.default_value.tobytes())
 
 class CByteMemoryView(ByteMemoryView):
     """A casting version of the byte memory view trait."""

--- a/ipywidgets/widgets/widget_media.py
+++ b/ipywidgets/widgets/widget_media.py
@@ -117,12 +117,10 @@ class _Media(DOMWidget, ValueWidget, CoreWidget):
         # Return value first like a ValueWidget
         signature = []
 
-        # strip off the starting b' and ending ' so we can truncate if needed
-        sig_value = repr(self.value[:100].tobytes())[2:-1]
-
-        if self.value.nbytes > 100:
-            sig_value += '...'
-        signature.append("{}=b'{}'".format('value', sig_value))
+        sig_value = 'value={!r}'.format(self.value[:100].tobytes())
+        if len(sig_value) > 120:
+            sig_value = sig_value[:-1]+"..."+sig_value[-1]
+        signature.append(sig_value)
 
         for key in super(cls, self)._repr_keys():
             if key == 'value':

--- a/ipywidgets/widgets/widget_media.py
+++ b/ipywidgets/widgets/widget_media.py
@@ -117,8 +117,8 @@ class _Media(DOMWidget, ValueWidget, CoreWidget):
         # Return value first like a ValueWidget
         signature = []
 
-        sig_value = 'value={!r}'.format(self.value[:30].tobytes())
-        if self.value.nbytes > 30:
+        sig_value = 'value={!r}'.format(self.value[:40].tobytes())
+        if self.value.nbytes > 40:
             sig_value = sig_value[:-1]+"..."+sig_value[-1]
         signature.append(sig_value)
 

--- a/ipywidgets/widgets/widget_media.py
+++ b/ipywidgets/widgets/widget_media.py
@@ -117,8 +117,8 @@ class _Media(DOMWidget, ValueWidget, CoreWidget):
         # Return value first like a ValueWidget
         signature = []
 
-        sig_value = 'value={!r}'.format(self.value[:100].tobytes())
-        if len(sig_value) > 120:
+        sig_value = 'value={!r}'.format(self.value[:30].tobytes())
+        if self.value.nbytes > 30:
             sig_value = sig_value[:-1]+"..."+sig_value[-1]
         signature.append(sig_value)
 

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -100,7 +100,7 @@ Attribute        | Type             | Default          | Help
 `loop`           | boolean          | `true`           | When true, the audio will start from the beginning after finishing
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
-`value`          | Bytes            | `b''`            | The media data as a byte string.
+`value`          | Bytes            | `b''`            | The media data as a memory view of bytes.
 
 ### BoundedFloatTextModel (@jupyter-widgets/controls, 1.5.0); FloatTextView (@jupyter-widgets/controls, 1.5.0)
 
@@ -330,7 +330,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
-`value`          | Bytes            | `b''`            | The media data as a byte string.
+`value`          | Bytes            | `b''`            | The media data as a memory view of bytes.
 
 ### DatePickerModel (@jupyter-widgets/controls, 1.5.0); DatePickerView (@jupyter-widgets/controls, 1.5.0)
 
@@ -630,7 +630,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
-`value`          | Bytes            | `b''`            | The media data as a byte string.
+`value`          | Bytes            | `b''`            | The media data as a memory view of bytes.
 `width`          | string           | `''`             | Width of the image in pixels. Use layout.width for styling the widget.
 
 ### IntProgressModel (@jupyter-widgets/controls, 1.5.0); ProgressView (@jupyter-widgets/controls, 1.5.0)
@@ -1136,7 +1136,7 @@ Attribute        | Type             | Default          | Help
 `loop`           | boolean          | `true`           | When true, the video will start from the beginning after finishing
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
-`value`          | Bytes            | `b''`            | The media data as a byte string.
+`value`          | Bytes            | `b''`            | The media data as a memory view of bytes.
 `width`          | string           | `''`             | Width of the video in pixels.
 
 ### OutputModel (@jupyter-widgets/output, 1.0.0); OutputView (@jupyter-widgets/output, 1.0.0)


### PR DESCRIPTION
This can be more efficient with fewer copies in some cases, such as uploading a file and setting the value from the file content. Also, the deserialization does not involve a copy anymore.

CC @pbugnion, @maartenbreddels 