### PR TITLE
Consolidate FileUpload value by using a single top-level dict

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -1015,7 +1015,10 @@
     "uploader.value\n",
     "#=> [\n",
     "#=>   {\n",
-    "#=>     'metadata': {'name': 'example.txt', 'type': 'text/plain', 'size': 36, 'lastModified': 1578647380733}, \n",
+    "#=>     'name': 'example.txt',\n",
+    "#=>     'type': 'text/plain',\n",
+    "#=>     'size': 36,\n",
+    "#=>     'lastModified': 1578647380733, \n",
     "#=>     'content': <memory at 0x10c1b37c8>\n",
     "#=>   }\n",
     "#=> ]\n",
@@ -1061,9 +1064,9 @@
     "    \n",
     "The `FileUpload` changed significantly in ipywidgets 8:\n",
     "    \n",
-    "- The `.value` traitlet is now a list of dictionaries with a `metadata` and `content` entry, rather than a dictionary mapping the uploaded name to the content. To retrieve the original form, use `{f[\"metadata\"][\"name\"]: f[\"content\"].tobytes() for f in uploader.value}`.\n",
+    "- The `.value` traitlet is now a list of dictionaries, rather than a dictionary mapping the uploaded name to the content. To retrieve the original form, use `{f[\"name\"]: f[\"content\"].tobytes() for f in uploader.value}`.\n",
     "- The `.data` traitlet has been removed. To retrieve it, use `[f[\"content\"].tobytes() for f in uploader.value]`.\n",
-    "- The `.metadata` traitlet has been removed. To retrieve it, use `[f[\"metadata\"]. for f in uploader.value]`.\n",
+    "- The `.metadata` traitlet has been removed. To retrieve it, use `[{k: v for k, v in f.items() if k != \"content\"} for f in w.value]`.\n",
     "</div>"
    ]
   },

--- a/packages/controls/src/widget_upload.ts
+++ b/packages/controls/src/widget_upload.ts
@@ -96,7 +96,7 @@ export class FileUploadView extends DOMWidgetView {
                 .then(contents => {
                     const value = contents.map(c => {
                         return {
-                            metadata: c.metadata,
+                            ...c.metadata,
                             content: c.buffer
                         };
                     });


### PR DESCRIPTION
Fixes part of #2721.
Continuation of #2666. 

The `FileUpload` value now follows this structure:

```
uploader.value
#=> [
#=>   {
#=>     'name': 'example.txt',
#=>     'type': 'text/plain',
#=>     'size': 36,
#=>     'lastModified': 1578647380733, 
#=>     'content': <memory at 0x10c1b37c8>
#=>   }
#=> ]
```