### PR TITLE
Upgrade to es2017 javascript

### DIFF
--- a/packages/base-manager/test/tsconfig.json
+++ b/packages/base-manager/test/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "types": ["mocha"],
     "outDir": "build",
-    "rootDir": "src",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "target": "es5"
+    "rootDir": "src"
   },
   "include": ["src/*"],
   "references": [

--- a/packages/base-manager/tsconfig.json
+++ b/packages/base-manager/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "target": "es5"
+    "rootDir": "src"
   },
   "include": ["src/*"],
   "references": [

--- a/packages/base/test/tsconfig.json
+++ b/packages/base/test/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "types": ["mocha"],
     "outDir": "build",
-    "rootDir": "src",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "target": "es5"
+    "rootDir": "src"
   },
   "include": ["src/*"],
   "references": [

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "target": "es5"
+    "rootDir": "src"
   },
   "include": ["src/*"]
 }

--- a/packages/controls/test/tsconfig.json
+++ b/packages/controls/test/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "types": ["mocha"],
     "outDir": "build",
-    "rootDir": "src",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "target": "es5"
+    "rootDir": "src"
   },
   "include": ["src/**/*"],
   "references": [

--- a/packages/controls/tsconfig.json
+++ b/packages/controls/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "types": ["mathjax", "node"],
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "target": "es5"
+    "types": ["mathjax", "node"]
   },
   "include": ["src/**/*"],
   "references": [

--- a/packages/output/tsconfig.json
+++ b/packages/output/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfigbase",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src",
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
-    "target": "es5"
+    "rootDir": "src"
   },
   "include": ["src/**/*"],
   "references": [


### PR DESCRIPTION
This upgrades the js target to es2017, which means that we are now generating es2015 classes.

Because Backbone and es2015 classes are incompatible, this means that downstream libraries that use Backbone.extend will need to change to use es2015 classes. An example is given in this PR of moving the classic notebook output widget to es2015 classes.

See also https://benmccormick.org/2015/07/06/backbone-and-es6-classes-revisited or other articles about the differences between es2015 classes and backbone classes.