### PR TITLE
Adding examples to the example doc how to change the size of the dropdown/radiobuttons

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -557,9 +557,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Box(\n",
+    "widgets.Box(\n",
     "    [\n",
-    "        Label(value='Pizza topping with a very long label:'), \n",
+    "        widgets.Label(value='Pizza topping with a very long label:'), \n",
     "        widgets.RadioButtons(options=['pepperoni', 'pineapple', 'anchovies', 'and the long name that will fit fine'])\n",
     "    ]\n",
     ")"

--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -537,9 +537,31 @@
    "source": [
     "widgets.RadioButtons(\n",
     "    options=['pepperoni', 'pineapple', 'anchovies'],\n",
-    "#     value='pineapple',\n",
+    "#    value='pineapple', # Defaults to 'pineapple'\n",
+    "#    layout={'width': 'max-content'}, # If the items' names are long\n",
     "    description='Pizza topping:',\n",
     "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### With dynamic layout, no width restriction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Box(\n",
+    "    [\n",
+    "        Label(value='Pizza topping with a very long label:'), \n",
+    "        widgets.RadioButtons(options=['pepperoni', 'pineapple', 'anchovies', 'and the long name that will fit fine'])\n",
+    "    ]\n",
     ")"
    ]
   },
@@ -1339,7 +1361,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -548,7 +548,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### With dynamic layout, no width restriction"
+    "#### With dynamic layout and very long labels"
    ]
   },
   {
@@ -560,7 +560,15 @@
     "widgets.Box(\n",
     "    [\n",
     "        widgets.Label(value='Pizza topping with a very long label:'), \n",
-    "        widgets.RadioButtons(options=['pepperoni', 'pineapple', 'anchovies', 'and the long name that will fit fine'])\n",
+    "        widgets.RadioButtons(\n",
+    "            options=[\n",
+    "                'pepperoni', \n",
+    "                'pineapple', \n",
+    "                'anchovies', \n",
+    "                'and the long name that will fit fine and the long name that will fit fine and the long name that will fit fine '\n",
+    "            ],\n",
+    "            layout={'width': 'max-content'}\n",
+    "        )\n",
     "    ]\n",
     ")"
    ]


### PR DESCRIPTION
Based on the discussion on https://github.com/jupyter-widgets/ipywidgets/issues/2050, a small update to the doc.