### PR TITLE
Move @types/backbone to devDependencies

### DIFF
--- a/packages/jupyterlab-manager/package.json
+++ b/packages/jupyterlab-manager/package.json
@@ -56,12 +56,12 @@
     "@lumino/properties": "^1.1.0",
     "@lumino/signaling": "^1.2.0",
     "@lumino/widgets": "^1.3.0",
-    "@types/backbone": "^1.4.1",
     "jquery": "^3.1.1",
     "semver": "^6.1.1"
   },
   "devDependencies": {
     "@jupyterlab/cells": "^2.0.0-beta.2",
+    "@types/backbone": "^1.4.1",
     "@types/node": "^12.7.0",
     "@types/semver": "^6.0.1",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Best I can tell there is no reason this need to be in production deps. Pulling it in is causing some @types conflicts in one of my projects.