### PR TITLE
Tests and tidy file upload

### DIFF
--- a/packages/controls/src/widget_upload.ts
+++ b/packages/controls/src/widget_upload.ts
@@ -73,8 +73,8 @@ export class FileUploadView extends DOMWidgetView {
               size: file.size,
               lastModified: file.lastModified
             };
-            this.fileReader = new FileReader();
-            this.fileReader.onload = (event): any => {
+            const fileReader = new FileReader();
+            fileReader.onload = (event): any => {
               const buffer = (event as any).target.result;
               resolve({
                 buffer,
@@ -82,11 +82,11 @@ export class FileUploadView extends DOMWidgetView {
                 error: ''
               });
             };
-            this.fileReader.onerror = (): any => {
+            fileReader.onerror = (): any => {
               reject();
             };
-            this.fileReader.onabort = this.fileReader.onerror;
-            this.fileReader.readAsArrayBuffer(file);
+            fileReader.onabort = fileReader.onerror;
+            fileReader.readAsArrayBuffer(file);
           })
         );
       });

--- a/packages/controls/src/widget_upload.ts
+++ b/packages/controls/src/widget_upload.ts
@@ -72,18 +72,15 @@ export class FileUploadView extends DOMWidgetView {
       Array.from(this.fileInput.files ?? []).forEach((file: File) => {
         promisesFile.push(
           new Promise((resolve, reject) => {
-            const metadata = {
-              name: file.name,
-              type: file.type,
-              size: file.size,
-              lastModified: file.lastModified
-            };
             const fileReader = new FileReader();
             fileReader.onload = (event): any => {
               const content = (event as any).target.result;
               resolve({
                 content,
-                ...metadata,
+                name: file.name,
+                type: file.type,
+                size: file.size,
+                lastModified: file.lastModified,
                 error: ''
               });
             };

--- a/packages/controls/src/widget_upload.ts
+++ b/packages/controls/src/widget_upload.ts
@@ -75,7 +75,7 @@ export class FileUploadView extends DOMWidgetView {
             fileReader.onload = () => {
               // We know we can read the result as an array buffer since
               // we use the `.readAsArrayBuffer` method
-              const content: ArrayBuffer = <ArrayBuffer>fileReader.result;
+              const content: ArrayBuffer = fileReader.result as ArrayBuffer;
               resolve({
                 content,
                 name: file.name,

--- a/packages/controls/src/widget_upload.ts
+++ b/packages/controls/src/widget_upload.ts
@@ -48,7 +48,6 @@ export class FileUploadView extends DOMWidgetView {
     this.fileInput = document.createElement('input');
     this.fileInput.type = 'file';
     this.fileInput.style.display = 'none';
-    this.el.appendChild(this.fileInput);
 
     this.el.addEventListener('click', () => {
       this.fileInput.click();

--- a/packages/controls/src/widget_upload.ts
+++ b/packages/controls/src/widget_upload.ts
@@ -4,6 +4,15 @@
 import { CoreDOMWidgetModel } from './widget_core';
 import { DOMWidgetView } from '@jupyter-widgets/base';
 
+interface IFileUploaded {
+  content: any;
+  name: string;
+  size: number;
+  type: string;
+  lastModified: number;
+  error: string;
+}
+
 export class FileUploadModel extends CoreDOMWidgetModel {
   defaults(): Backbone.ObjectHash {
     return {
@@ -58,16 +67,9 @@ export class FileUploadView extends DOMWidgetView {
     });
 
     this.fileInput.addEventListener('change', () => {
-      const promisesFile: Promise<{
-        content: any;
-        name: string;
-        size: number;
-        type: string;
-        lastModified: number;
-        error: string;
-      }>[] = [];
+      const promisesFile: Promise<IFileUploaded>[] = [];
 
-      Array.from(this.fileInput.files ?? []).forEach(file => {
+      Array.from(this.fileInput.files ?? []).forEach((file: File) => {
         promisesFile.push(
           new Promise((resolve, reject) => {
             const metadata = {

--- a/packages/controls/src/widget_upload.ts
+++ b/packages/controls/src/widget_upload.ts
@@ -72,7 +72,7 @@ export class FileUploadView extends DOMWidgetView {
         promisesFile.push(
           new Promise((resolve, reject) => {
             const fileReader = new FileReader();
-            fileReader.onload = () => {
+            fileReader.onload = (): void => {
               // We know we can read the result as an array buffer since
               // we use the `.readAsArrayBuffer` method
               const content: ArrayBuffer = fileReader.result as ArrayBuffer;
@@ -85,7 +85,7 @@ export class FileUploadView extends DOMWidgetView {
                 error: ''
               });
             };
-            fileReader.onerror = () => {
+            fileReader.onerror = (): void => {
               reject();
             };
             fileReader.onabort = fileReader.onerror;

--- a/packages/controls/src/widget_upload.ts
+++ b/packages/controls/src/widget_upload.ts
@@ -41,7 +41,6 @@ export class FileUploadModel extends CoreDOMWidgetModel {
 export class FileUploadView extends DOMWidgetView {
   el: HTMLButtonElement;
   fileInput: HTMLInputElement;
-  fileReader: FileReader;
 
   get tagName(): string {
     return 'button';

--- a/packages/controls/src/widget_upload.ts
+++ b/packages/controls/src/widget_upload.ts
@@ -59,8 +59,11 @@ export class FileUploadView extends DOMWidgetView {
 
     this.fileInput.addEventListener('change', () => {
       const promisesFile: Promise<{
-        buffer: any;
-        metadata: any;
+        content: any;
+        name: string;
+        size: number;
+        type: string;
+        lastModified: number;
         error: string;
       }>[] = [];
 
@@ -75,10 +78,10 @@ export class FileUploadView extends DOMWidgetView {
             };
             const fileReader = new FileReader();
             fileReader.onload = (event): any => {
-              const buffer = (event as any).target.result;
+              const content = (event as any).target.result;
               resolve({
-                buffer,
-                metadata,
+                content,
+                ...metadata,
                 error: ''
               });
             };
@@ -92,15 +95,9 @@ export class FileUploadView extends DOMWidgetView {
       });
 
       Promise.all(promisesFile)
-        .then(contents => {
-          const value = contents.map(c => {
-            return {
-              ...c.metadata,
-              content: c.buffer
-            };
-          });
+        .then(files => {
           this.model.set({
-            value,
+            value: files,
             error: ''
           });
           this.touch();

--- a/packages/controls/test/src/index.ts
+++ b/packages/controls/test/src/index.ts
@@ -3,4 +3,5 @@
 
 import './widget_date_test';
 import './widget_string_test';
+import './widget_upload_test';
 import './lumino/currentselection_test';

--- a/packages/controls/test/src/widget_upload_test.ts
+++ b/packages/controls/test/src/widget_upload_test.ts
@@ -138,6 +138,6 @@ describe('FileUploadView', function() {
       );
       expect(contentInModel).to.equal('some file content');
       done();
-    }, 1000);
+    }, 100);
   });
 });

--- a/packages/controls/test/src/widget_upload_test.ts
+++ b/packages/controls/test/src/widget_upload_test.ts
@@ -1,0 +1,59 @@
+import { DummyManager } from './dummy-manager';
+
+import { expect } from 'chai';
+
+import * as widgets from '../../lib';
+
+function getFileInput(view: widgets.FileUploadView): HTMLInputElement {
+  const elem = view.fileInput;
+  return elem as HTMLInputElement;
+}
+
+function getProxyButton(view: widgets.FileUploadView): HTMLButtonElement {
+  const elem = view.el;
+  return elem as HTMLButtonElement;
+}
+
+describe.only('FileUploadView', function() {
+  beforeEach(async function() {
+    this.manager = new DummyManager();
+    const modelId = 'u-u-i-d';
+    this.model = await this.manager.new_model(
+      {
+        model_name: 'FileUploadModel',
+        model_module: '@jupyter-widgets/controls',
+        model_module_version: '1.0.0',
+        model_id: modelId
+      },
+      {}
+    );
+  });
+
+  it('construction', function() {
+    const options = { model: this.model };
+    const view = new widgets.FileUploadView(options);
+    expect(view).to.not.be.undefined;
+  });
+
+  it('default options', function() {
+    const options = { model: this.model };
+    const view = new widgets.FileUploadView(options);
+    view.render();
+    const fileInput = getFileInput(view);
+    const proxyButton = getProxyButton(view);
+    expect(fileInput.disabled).to.be.false;
+    expect(fileInput.multiple).to.be.false;
+    expect(proxyButton.innerText).to.equal('Upload (0)');
+    expect(proxyButton.querySelector('i')).to.not.be.undefined;
+    expect(proxyButton.querySelector('i')!.className).to.equal('fa fa-upload');
+  });
+
+  it('multiple', function() {
+    const options = { model: this.model };
+    this.model.set('multiple', true);
+    const view = new widgets.FileUploadView(options);
+    view.render();
+    const fileInput = getFileInput(view);
+    expect(fileInput.multiple).to.be.true;
+  });
+});

--- a/packages/controls/test/src/widget_upload_test.ts
+++ b/packages/controls/test/src/widget_upload_test.ts
@@ -14,7 +14,7 @@ function getProxyButton(view: widgets.FileUploadView): HTMLButtonElement {
   return elem as HTMLButtonElement;
 }
 
-function fileInputForModel(model: widgets.FileUploadModel) {
+function fileInputForModel(model: widgets.FileUploadModel): HTMLInputElement {
   // For a given model, create and render a view and return the
   // view's input.
   const options = { model };
@@ -23,21 +23,23 @@ function fileInputForModel(model: widgets.FileUploadModel) {
   return getFileInput(view);
 }
 
-function proxyButtonForModel(model: widgets.FileUploadModel) {
+function proxyButtonForModel(
+  model: widgets.FileUploadModel
+): HTMLButtonElement {
   const options = { model };
   const view = new widgets.FileUploadView(options);
   view.render();
   return getProxyButton(view);
 }
 
-function simulateUpload(fileInput: HTMLInputElement, files: Array<File>) {
+function simulateUpload(fileInput: HTMLInputElement, files: Array<File>): void {
   // The 'files' property on an input element is normally not writeable
   // programmatically, so we explicitly overwrite it.
 
   // The type of fileInput.files is FileList, an Array with an
   // extra `.item` method.
   const fileList: any = files;
-  fileList.item = (index: number) => files[index];
+  fileList.item = (index: number): File => files[index];
   Object.defineProperty(fileInput, 'files', {
     value: fileList,
     writable: false

--- a/packages/controls/test/src/widget_upload_test.ts
+++ b/packages/controls/test/src/widget_upload_test.ts
@@ -14,6 +14,22 @@ function getProxyButton(view: widgets.FileUploadView): HTMLButtonElement {
   return elem as HTMLButtonElement;
 }
 
+function fileInputForModel(model: widgets.FileUploadModel) {
+  // For a given model, create and render a view and return the
+  // view's input.
+  const options = { model };
+  const view = new widgets.FileUploadView(options);
+  view.render();
+  return getFileInput(view);
+}
+
+function proxyButtonForModel(model: widgets.FileUploadModel) {
+  const options = { model };
+  const view = new widgets.FileUploadView(options);
+  view.render();
+  return getProxyButton(view);
+}
+
 function simulateUpload(fileInput: HTMLInputElement, files: Array<File>) {
   // The 'files' property on an input element is normally not writeable
   // programmatically, so we explicitly overwrite it.
@@ -29,7 +45,7 @@ function simulateUpload(fileInput: HTMLInputElement, files: Array<File>) {
   fileInput.dispatchEvent(new Event('change', { bubbles: true }));
 }
 
-describe.only('FileUploadView construction', function() {
+describe('FileUploadView', function() {
   beforeEach(async function() {
     this.manager = new DummyManager();
     const modelId = 'u-u-i-d';
@@ -43,22 +59,6 @@ describe.only('FileUploadView construction', function() {
       {}
     );
   });
-
-  function fileInputForModel(model: widgets.FileUploadModel) {
-    // For a given model, create and render a view and return the
-    // view's input.
-    const options = { model };
-    const view = new widgets.FileUploadView(options);
-    view.render();
-    return getFileInput(view);
-  }
-
-  function proxyButtonForModel(model: widgets.FileUploadModel) {
-    const options = { model };
-    const view = new widgets.FileUploadView(options);
-    view.render();
-    return getProxyButton(view);
-  }
 
   it('construction', function() {
     const options = { model: this.model };

--- a/packages/controls/test/src/widget_upload_test.ts
+++ b/packages/controls/test/src/widget_upload_test.ts
@@ -29,6 +29,22 @@ describe.only('FileUploadView', function() {
     );
   });
 
+  function fileInputForModel(model: widgets.FileUploadModel) {
+    // For a given model, create and render a view and return the
+    // view's input.
+    const options = { model };
+    const view = new widgets.FileUploadView(options);
+    view.render();
+    return getFileInput(view);
+  }
+
+  function proxyButtonForModel(model: widgets.FileUploadModel) {
+    const options = { model };
+    const view = new widgets.FileUploadView(options);
+    view.render();
+    return getProxyButton(view);
+  }
+
   it('construction', function() {
     const options = { model: this.model };
     const view = new widgets.FileUploadView(options);
@@ -44,16 +60,44 @@ describe.only('FileUploadView', function() {
     expect(fileInput.disabled).to.be.false;
     expect(fileInput.multiple).to.be.false;
     expect(proxyButton.innerText).to.equal('Upload (0)');
-    expect(proxyButton.querySelector('i')).to.not.be.undefined;
+    expect(proxyButton.querySelector('i')).to.not.be.null;
     expect(proxyButton.querySelector('i')!.className).to.equal('fa fa-upload');
   });
 
   it('multiple', function() {
-    const options = { model: this.model };
     this.model.set('multiple', true);
-    const view = new widgets.FileUploadView(options);
-    view.render();
-    const fileInput = getFileInput(view);
+    const fileInput = fileInputForModel(this.model);
     expect(fileInput.multiple).to.be.true;
+  });
+
+  it('accept', function() {
+    this.model.set('accept', 'text/csv');
+    const fileInput = fileInputForModel(this.model);
+    expect(fileInput.accept).to.equal('text/csv');
+  });
+
+  it('disabled', function() {
+    this.model.set('disabled', true);
+    const proxyButton = proxyButtonForModel(this.model);
+    expect(proxyButton.disabled).to.be.true;
+  });
+
+  it('no icon', function() {
+    this.model.set('icon', '');
+    const proxyButton = proxyButtonForModel(this.model);
+    expect(proxyButton.querySelector('i')).to.be.null;
+  });
+
+  it('other icon', function() {
+    this.model.set('icon', 'check');
+    const proxyButton = proxyButtonForModel(this.model);
+    expect(proxyButton.querySelector('i')).to.not.be.null;
+    expect(proxyButton.querySelector('i')!.className).to.equal('fa fa-check');
+  });
+
+  it('description', function() {
+    this.model.set('description', 'some text');
+    const proxyButton = proxyButtonForModel(this.model);
+    expect(proxyButton.innerText).to.equal('some text (0)');
   });
 });


### PR DESCRIPTION
This PR makes no functional changes. It tidies up the client side of the upload widget. It's the first step towards addressing issue #2727 .

In particular, this PR:
- adds tests
- clarifies the logic that follows a file upload -- a lot of effort went into creating intermediate objects that were unnecessary.
- adds tighter types
- removes an unnecessary DOM mount of the file upload input. The input was mounted, then immediately unmounted in the line `this.el.textContent = ''`. Since the input is never meant to be pressed by the user, it doesn't need to actually be mounted in the DOM.
- avoids binding attributes to `this.` unnecessarily.