### PR TITLE
Fix typo in documentation dev docs

### DIFF
--- a/docs/source/dev_docs.md
+++ b/docs/source/dev_docs.md
@@ -8,7 +8,7 @@ First create a [conda environment](http://conda.pydata.org/docs/using/envs.html#
 
 ```bash
 # create the environment
-conda env create -n ipywidgets_docs -c conda-forge python pip
+conda create -n ipywidgets_docs -c conda-forge python pip
 
 # activate the environment
 conda activate ipywidgets_docs   # Linux and OS X


### PR DESCRIPTION
A small typo fix as a follow-up to https://github.com/jupyter-widgets/ipywidgets/pull/2769.