### PR TITLE
Use data-jupyter-widgets-cdn-only attribute to load modules only from CDN

### DIFF
--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -124,6 +124,7 @@ html_template = """
     <!-- Load IPywidgets bundle for embedding. -->
     <script
       data-jupyter-widgets-cdn="https://cdn.jsdelivr.net/npm/"
+      data-jupyter-widgets-cdn-only
       src="https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js" 
       crossorigin="anonymous">
     </script>
@@ -180,6 +181,9 @@ documents, you may want to use a templating engine like
 
 We also change the CDN from its default of unpkg to use jsdelivr by setting the
 `data-jupyter-widgets-cdn` attribute.
+
+What's more, we only load modules from the CDN by setting the
+`data-jupyter-widgets-cdn-only` attribute.
 
 In all embedding functions in `ipywidgets.embed`, the state of all widgets
 known to the widget manager is included by default. You can alternatively
@@ -269,6 +273,11 @@ which holds the webpack bundle for the bqplot library.
 While the default CDN is using https://unpkg.com it can be configured by
 setting the optional `data-jupyter-widgets-cdn` attribute for script tag which loads `embed-amd.js`,
 as shown in the example above.
+
+While the default strategy is loading modules from the same site, and then
+falling back to CDN. This can be configured by setting the optional
+`data-jupyter-widgets-cdn-only` attribute for script tag which loads `embed-amd.js`
+as shown in the example above too.
 
 The [widget-cookiecutter](https://github.com/jupyter/widget-cookiecutter)
 template project contains a template project for a custom widget library

--- a/packages/html-manager/src/libembed-amd.ts
+++ b/packages/html-manager/src/libembed-amd.ts
@@ -11,7 +11,7 @@ const scripts = document.getElementsByTagName('script');
 Array.prototype.forEach.call(scripts, (script: HTMLScriptElement) => {
   cdn = script.getAttribute('data-jupyter-widgets-cdn') || cdn;
   onlyCDN =
-    onlyCDN || script.getAttribute('data-jupyter-widgets-cdn-only') != null;
+    onlyCDN || script.hasAttribute('data-jupyter-widgets-cdn-only');
 });
 
 /**


### PR DESCRIPTION
Resolves https://github.com/jupyter-widgets/ipywidgets/issues/2786

This PR's changes are learned from previous similar PR: https://github.com/jupyter-widgets/ipywidgets/commit/8aba1831fca8787d31761539e224fc6faf19319b

Hi @jasongrout!
Can you help me review this?

I'm not sure how to test, because if I run `yarn test`, this fails at build step already in master branch.