### PR TITLE
Add dragging behaviour properties to sliders

### DIFF
--- a/docs/source/examples/Output Widget.ipynb
+++ b/docs/source/examples/Output Widget.ipynb
@@ -350,7 +350,7 @@
     "\n",
     "This always prints in the currently active cell, not the cell that started the background thread.\n",
     "\n",
-    "This can lead to surprising behaviour in output widgets. During the time in which output is captured by the output widget, *any* output generated in the notebook, regardless of thread, will go into the output widget.\n",
+    "This can lead to surprising behavior in output widgets. During the time in which output is captured by the output widget, *any* output generated in the notebook, regardless of thread, will go into the output widget.\n",
     "\n",
     "The best way to avoid surprises is to *never* use an output widget's context manager in a context where multiple threads generate output. Instead, we can pass an output widget to the function executing in a thread, and use `append_display_data()`, `append_stdout()`, or `append_stderr()` methods to append displayable output to the output widget."
    ]

--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -336,7 +336,7 @@
     "\n",
     "#### align-items\n",
     "\n",
-    "`align-items` can be one of `flex-start`, `flex-end`, `center`, `baseline`, `stretch`. This defines the default behaviour for how flex items are laid out along the cross axis on the current line. Think of it as the justify-content version for the cross-axis (perpendicular to the main-axis).\n",
+    "`align-items` can be one of `flex-start`, `flex-end`, `center`, `baseline`, `stretch`. This defines the default behavior for how flex items are laid out along the cross axis on the current line. Think of it as the justify-content version for the cross-axis (perpendicular to the main-axis).\n",
     "   ![Items](./images/align-items.svg)\n",
     "   \n",
     "#### align-content\n",

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -159,8 +159,8 @@ class FloatSlider(_BoundedFloat):
         default is 'horizontal', orientation of the slider
     readout : {True, False}
         default is True, display the current value of the slider next to it
-    behaviour : str
-        slider handle and connector dragging behaviour. Default is 'drag-tap'.
+    behavior : str
+        slider handle and connector dragging behavior. Default is 'drag-tap'.
     readout_format : str
         default is '.2f', specifier for the format function used to represent
         slider value for human consumption, modeled after Python 3's format
@@ -177,8 +177,8 @@ class FloatSlider(_BoundedFloat):
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
-    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
-        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
+    behavior = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behavior.").tag(sync=True)
 
 
 @register
@@ -203,8 +203,8 @@ class FloatLogSlider(_BoundedLogFloat):
         default is 'horizontal', orientation of the slider
     readout : {True, False}
         default is True, display the current value of the slider next to it
-    behaviour : str
-        slider handle and connector dragging behaviour. Default is 'drag-tap'.
+    behavior : str
+        slider handle and connector dragging behavior. Default is 'drag-tap'.
     readout_format : str
         default is '.3g', specifier for the format function used to represent
         slider value for human consumption, modeled after Python 3's format
@@ -222,8 +222,8 @@ class FloatLogSlider(_BoundedLogFloat):
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
     base = CFloat(10., help="Base for the logarithm").tag(sync=True)
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
-    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
-        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
+    behavior = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behavior.").tag(sync=True)
 
 
 @register
@@ -349,8 +349,8 @@ class FloatRangeSlider(_BoundedFloatRange):
         default is 'horizontal'
     readout : {True, False}
         default is True, display the current value of the slider next to it
-    behaviour : str
-        slider handle and connector dragging behaviour. Default is 'drag-tap'.
+    behavior : str
+        slider handle and connector dragging behavior. Default is 'drag-tap'.
     readout_format : str
         default is '.2f', specifier for the format function used to represent
         slider value for human consumption, modeled after Python 3's format
@@ -367,5 +367,5 @@ class FloatRangeSlider(_BoundedFloatRange):
     continuous_update = Bool(True, help="Update the value of the widget as the user is sliding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
-    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
-        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
+    behavior = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behavior.").tag(sync=True)

--- a/ipywidgets/widgets/widget_float.py
+++ b/ipywidgets/widgets/widget_float.py
@@ -159,6 +159,8 @@ class FloatSlider(_BoundedFloat):
         default is 'horizontal', orientation of the slider
     readout : {True, False}
         default is True, display the current value of the slider next to it
+    behaviour : str
+        slider handle and connector dragging behaviour. Default is 'drag-tap'.
     readout_format : str
         default is '.2f', specifier for the format function used to represent
         slider value for human consumption, modeled after Python 3's format
@@ -174,8 +176,9 @@ class FloatSlider(_BoundedFloat):
         '.2f', help="Format for the readout").tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
-
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
+    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
 
 
 @register
@@ -200,6 +203,8 @@ class FloatLogSlider(_BoundedLogFloat):
         default is 'horizontal', orientation of the slider
     readout : {True, False}
         default is True, display the current value of the slider next to it
+    behaviour : str
+        slider handle and connector dragging behaviour. Default is 'drag-tap'.
     readout_format : str
         default is '.3g', specifier for the format function used to represent
         slider value for human consumption, modeled after Python 3's format
@@ -216,8 +221,9 @@ class FloatLogSlider(_BoundedLogFloat):
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
     base = CFloat(10., help="Base for the logarithm").tag(sync=True)
-
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
+    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
 
 
 @register
@@ -343,6 +349,8 @@ class FloatRangeSlider(_BoundedFloatRange):
         default is 'horizontal'
     readout : {True, False}
         default is True, display the current value of the slider next to it
+    behaviour : str
+        slider handle and connector dragging behaviour. Default is 'drag-tap'.
     readout_format : str
         default is '.2f', specifier for the format function used to represent
         slider value for human consumption, modeled after Python 3's format
@@ -358,5 +366,6 @@ class FloatRangeSlider(_BoundedFloatRange):
         '.2f', help="Format for the readout").tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is sliding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
-
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
+    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -34,6 +34,8 @@ max: integer
     The upper limit for the value.
 step: integer
     The step between allowed values.
+behaviour : str
+    slider handle and connector dragging behaviour. Default is 'drag-tap'.
 """
 
 def _int_doc(cls):
@@ -165,8 +167,9 @@ class IntSlider(_BoundedInt):
         'd', help="Format for the readout").tag(sync=True)
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
-
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
+    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
 
 
 @register
@@ -289,6 +292,20 @@ class IntRangeSlider(_BoundedIntRange):
         The lowest allowed value for `lower`
     max : int
         The highest allowed value for `upper`
+    step : int
+        step of the trackbar
+    description : str
+        name of the slider
+    orientation : {'horizontal', 'vertical'}
+        default is 'horizontal'
+    readout : {True, False}
+        default is True, display the current value of the slider next to it
+    behaviour : str
+        slider handle and connector dragging behaviour. Default is 'drag-tap'.
+    readout_format : str
+        default is '.2f', specifier for the format function used to represent
+        slider value for human consumption, modeled after Python 3's format
+        specification mini-language (PEP 3101).
     """
     _view_name = Unicode('IntRangeSliderView').tag(sync=True)
     _model_name = Unicode('IntRangeSliderModel').tag(sync=True)
@@ -301,3 +318,5 @@ class IntRangeSlider(_BoundedIntRange):
     continuous_update = Bool(True, help="Update the value of the widget as the user is sliding the slider.").tag(sync=True)
     style = InstanceDict(SliderStyle, help="Slider style customizations.").tag(sync=True, **widget_serialization)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
+    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)

--- a/ipywidgets/widgets/widget_int.py
+++ b/ipywidgets/widgets/widget_int.py
@@ -34,8 +34,8 @@ max: integer
     The upper limit for the value.
 step: integer
     The step between allowed values.
-behaviour : str
-    slider handle and connector dragging behaviour. Default is 'drag-tap'.
+behavior : str
+    slider handle and connector dragging behavior. Default is 'drag-tap'.
 """
 
 def _int_doc(cls):
@@ -168,8 +168,8 @@ class IntSlider(_BoundedInt):
     continuous_update = Bool(True, help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
-    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
-        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
+    behavior = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behavior.").tag(sync=True)
 
 
 @register
@@ -300,8 +300,8 @@ class IntRangeSlider(_BoundedIntRange):
         default is 'horizontal'
     readout : {True, False}
         default is True, display the current value of the slider next to it
-    behaviour : str
-        slider handle and connector dragging behaviour. Default is 'drag-tap'.
+    behavior : str
+        slider handle and connector dragging behavior. Default is 'drag-tap'.
     readout_format : str
         default is '.2f', specifier for the format function used to represent
         slider value for human consumption, modeled after Python 3's format
@@ -318,5 +318,5 @@ class IntRangeSlider(_BoundedIntRange):
     continuous_update = Bool(True, help="Update the value of the widget as the user is sliding the slider.").tag(sync=True)
     style = InstanceDict(SliderStyle, help="Slider style customizations.").tag(sync=True, **widget_serialization)
     disabled = Bool(False, help="Enable or disable user changes").tag(sync=True)
-    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
-        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
+    behavior = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behavior.").tag(sync=True)

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -573,6 +573,8 @@ class SelectionSlider(_SelectionNonempty):
         help="Display the current selected label next to the slider").tag(sync=True)
     continuous_update = Bool(True,
         help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
+    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
 
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
 
@@ -627,3 +629,5 @@ class SelectionRangeSlider(_MultipleSelectionNonempty):
         help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
 
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
+    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)

--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -573,8 +573,8 @@ class SelectionSlider(_SelectionNonempty):
         help="Display the current selected label next to the slider").tag(sync=True)
     continuous_update = Bool(True,
         help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
-    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
-        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
+    behavior = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behavior.").tag(sync=True)
 
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
 
@@ -629,5 +629,5 @@ class SelectionRangeSlider(_MultipleSelectionNonempty):
         help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
 
     style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
-    behaviour = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
-        default_value='drag-tap', help="Slider dragging behaviour.").tag(sync=True)
+    behavior = CaselessStrEnum(values=['drag-tap', 'drag-snap', 'tap', 'drag', 'snap'],
+        default_value='drag-tap', help="Slider dragging behavior.").tag(sync=True)

--- a/packages/controls/src/widget_float.ts
+++ b/packages/controls/src/widget_float.ts
@@ -147,11 +147,11 @@ export class FloatLogSliderView extends BaseIntSliderView {
 
   createSlider(): void {
     const orientation = this.model.get('orientation');
-    const behaviour = this.model.get('behaviour');
+    const behavior = this.model.get('behavior');
 
     noUiSlider.create(this.$slider, {
       start: this.logCalc(this.model.get('value')),
-      behaviour: behaviour,
+      behaviour: behavior,
       range: {
         min: this.model.get('min'),
         max: this.model.get('max'),

--- a/packages/controls/src/widget_float.ts
+++ b/packages/controls/src/widget_float.ts
@@ -147,8 +147,11 @@ export class FloatLogSliderView extends BaseIntSliderView {
 
   createSlider(): void {
     const orientation = this.model.get('orientation');
+    const behaviour = this.model.get('behaviour');
+
     noUiSlider.create(this.$slider, {
       start: this.logCalc(this.model.get('value')),
+      behaviour: behaviour,
       range: {
         min: this.model.get('min'),
         max: this.model.get('max'),

--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -203,12 +203,12 @@ export abstract class BaseIntSliderView extends DescriptionView {
    */
   createSlider(): void {
     const orientation = this.model.get('orientation');
-    const behaviour = this.model.get('behaviour');
+    const behavior = this.model.get('behavior');
 
     noUiSlider.create(this.$slider, {
       start: this.model.get('value'),
       connect: true,
-      behaviour: behaviour,
+      behaviour: behavior,
       range: {
         min: this.model.get('min'),
         max: this.model.get('max'),

--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -203,9 +203,12 @@ export abstract class BaseIntSliderView extends DescriptionView {
    */
   createSlider(): void {
     const orientation = this.model.get('orientation');
+    const behaviour = this.model.get('behaviour');
+
     noUiSlider.create(this.$slider, {
       start: this.model.get('value'),
       connect: true,
+      behaviour: behaviour,
       range: {
         min: this.model.get('min'),
         max: this.model.get('max'),

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -746,12 +746,12 @@ export class SelectionSliderView extends DescriptionView {
     const min = 0;
     const max = labels.length - 1;
     const orientation = this.model.get('orientation');
-    const behaviour = this.model.get('behaviour');
+    const behavior = this.model.get('behavior');
 
     noUiSlider.create(this.$slider, {
       start: this.model.get('index'),
       connect: true,
-      behaviour: behaviour,
+      behaviour: behavior,
       range: {
         min: min,
         max: max,

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -746,10 +746,12 @@ export class SelectionSliderView extends DescriptionView {
     const min = 0;
     const max = labels.length - 1;
     const orientation = this.model.get('orientation');
+    const behaviour = this.model.get('behaviour');
 
     noUiSlider.create(this.$slider, {
       start: this.model.get('index'),
       connect: true,
+      behaviour: behaviour,
       range: {
         min: min,
         max: max,

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -509,6 +509,7 @@ Attribute        | Type             | Default          | Help
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'FloatLogSliderView'` | 
 `base`           | number (float)   | `10.0`           | Base for the logarithm
+`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -559,6 +560,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'FloatRangeSliderView'` | 
+`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is sliding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -586,6 +588,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'FloatSliderView'` | 
+`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -807,6 +810,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'IntRangeSliderView'` | 
+`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is sliding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -834,6 +838,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'IntSliderView'` | 
+`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -1112,6 +1117,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'SelectionRangeSliderView'` | 
+`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -1136,6 +1142,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'SelectionSliderView'` | 
+`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -509,7 +509,7 @@ Attribute        | Type             | Default          | Help
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'FloatLogSliderView'` | 
 `base`           | number (float)   | `10.0`           | Base for the logarithm
-`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
+`behavior`       | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behavior.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -560,7 +560,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'FloatRangeSliderView'` | 
-`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
+`behavior`       | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behavior.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is sliding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -588,7 +588,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'FloatSliderView'` | 
-`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
+`behavior`       | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behavior.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -810,7 +810,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'IntRangeSliderView'` | 
-`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
+`behavior`       | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behavior.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is sliding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -838,7 +838,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'IntSliderView'` | 
-`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
+`behavior`       | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behavior.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -1117,7 +1117,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'SelectionRangeSliderView'` | 
-`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
+`behavior`       | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behavior.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.
@@ -1142,7 +1142,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'SelectionSliderView'` | 
-`behaviour`      | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behaviour.
+`behavior`       | string (one of `'drag-tap'`, `'drag-snap'`, `'tap'`, `'drag'`, `'snap'`) | `'drag-tap'`     | Slider dragging behavior.
 `continuous_update` | boolean          | `true`           | Update the value of the widget as the user is holding the slider.
 `description`    | string           | `''`             | Description of the control.
 `description_allow_html` | boolean          | `false`          | Accept HTML in the description.


### PR DESCRIPTION
This PR adds functionality requested in #2832 . The drag behaviour API has been exposed on the python side and now allows four selections:

1. Tap (current default behaviour)
2. Snap (new option)
3. Drag-tap (new default behaviour for all sliders - no change in behaviour for non-range sliders)
4. Drag-snap

There are no breaking API changes, but a new `behaviour` attribute has been added to the python side.

![devw_drag_behaviour1](https://user-images.githubusercontent.com/24281433/77391612-707bd480-6d56-11ea-92e3-b7b28676eb22.gif)
