### PR TITLE
Fix css calc space

### DIFF
--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -684,10 +684,10 @@
   line-height: var(--jp-widgets-inline-height);
   /* line-height doesn't work on some browsers for select options */
   padding-top: calc(
-    var(--jp-widgets-inline-height)-var(--jp-widgets-font-size) / 2
+    var(--jp-widgets-inline-height) - var(--jp-widgets-font-size) / 2
   );
   padding-bottom: calc(
-    var(--jp-widgets-inline-height)-var(--jp-widgets-font-size) / 2
+    var(--jp-widgets-inline-height) - var(--jp-widgets-font-size) / 2
   );
 }
 


### PR DESCRIPTION
Missing space in css `calc()` may cause building error in React.