### PR TITLE
Revert "Bump jquery from 3.4.1 to 3.5.0"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5948,9 +5948,9 @@ istanbul@^0.4.0:
     wordwrap "^1.0.0"
 
 jquery@^3.1.1, jquery@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+  version "3.4.1"
+  resolved "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Reverts jupyter-widgets/ipywidgets#2857

Apparently jquery 3.5.0 has a breaking change: https://github.com/jquery/jquery/issues/4665