### PR TITLE
Fix checkbox description width

### DIFF
--- a/docs/source/examples/Widget Styling.ipynb
+++ b/docs/source/examples/Widget Styling.ipynb
@@ -182,6 +182,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import Checkbox\n",
+    "\n",
+    "style = {'description_width': 'initial',\n",
+    "         'description_max_width': \"none\"}\n",
+    "Checkbox(description=\"A too long description that doesn't fit with default settings\", \n",
+    "         style=style)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1413,7 +1427,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/ipywidgets/widgets/widget_description.py
+++ b/ipywidgets/widgets/widget_description.py
@@ -15,6 +15,7 @@ class DescriptionStyle(Style, CoreWidget, Widget):
     """Description style widget."""
     _model_name = Unicode('DescriptionStyleModel').tag(sync=True)
     description_width = Unicode(help="Width of the description to the side of the control.").tag(sync=True)
+    description_max_width = Unicode(help="Maximum width of the description to the side of the control.").tag(sync=True)
 
 
 class DescriptionWidget(DOMWidget, CoreWidget):

--- a/packages/controls/src/widget_bool.ts
+++ b/packages/controls/src/widget_bool.ts
@@ -45,7 +45,7 @@ export class CheckboxView extends DescriptionView {
 
     // label containing the checkbox and description span
     this.checkboxLabel = document.createElement('label');
-    this.checkboxLabel.classList.add('widget-label-basic');
+    this.checkboxLabel.classList.add('widget-label');
     this.el.appendChild(this.checkboxLabel);
 
     // checkbox

--- a/packages/controls/src/widget_description.ts
+++ b/packages/controls/src/widget_description.ts
@@ -26,6 +26,11 @@ export class DescriptionStyleModel extends StyleModel {
       selector: '.widget-label',
       attribute: 'width',
       default: null as any
+    },
+    description_max_width: {
+      selector: '.widget-label',
+      attribute: 'max-width',
+      default: null as any
     }
   };
 }

--- a/packages/schema/jupyterwidgetmodels.latest.json
+++ b/packages/schema/jupyterwidgetmodels.latest.json
@@ -1384,6 +1384,117 @@
         "type": "string"
       },
       {
+        "default": "ColorsInputModel",
+        "help": "",
+        "name": "_model_name",
+        "type": "string"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_view_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_view_module_version",
+        "type": "string"
+      },
+      {
+        "default": "ColorsInputView",
+        "help": "",
+        "name": "_view_name",
+        "type": "string"
+      },
+      {
+        "default": true,
+        "help": "",
+        "name": "allow_duplicates",
+        "type": "bool"
+      },
+      {
+        "default": [],
+        "help": "",
+        "name": "allowed_tags",
+        "type": "array"
+      },
+      {
+        "default": "",
+        "help": "Description of the control.",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "",
+        "name": "layout",
+        "type": "reference",
+        "widget": "Layout"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "Styling customizations",
+        "name": "style",
+        "type": "reference",
+        "widget": "DescriptionStyle"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "Is widget tabbable?",
+        "name": "tabbable",
+        "type": "bool"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "A tooltip caption.",
+        "name": "tooltip",
+        "type": "string"
+      },
+      {
+        "default": [],
+        "help": "List of string tags",
+        "name": "value",
+        "type": "array"
+      }
+    ],
+    "model": {
+      "module": "@jupyter-widgets/controls",
+      "name": "ColorsInputModel",
+      "version": "2.0.0"
+    },
+    "view": {
+      "module": "@jupyter-widgets/controls",
+      "name": "ColorsInputView",
+      "version": "2.0.0"
+    }
+  },
+  {
+    "attributes": [
+      {
+        "default": [],
+        "help": "CSS classes applied to widget DOM element",
+        "items": {
+          "type": "string"
+        },
+        "name": "_dom_classes",
+        "type": "array"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_model_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_model_module_version",
+        "type": "string"
+      },
+      {
         "default": "ComboboxModel",
         "help": "",
         "name": "_model_name",
@@ -2029,6 +2140,12 @@
         "default": "StyleView",
         "help": "",
         "name": "_view_name",
+        "type": "string"
+      },
+      {
+        "default": "",
+        "help": "Maximum width of the description to the side of the control.",
+        "name": "description_max_width",
         "type": "string"
       },
       {
@@ -3060,6 +3177,144 @@
     "view": {
       "module": "@jupyter-widgets/controls",
       "name": "FloatTextView",
+      "version": "2.0.0"
+    }
+  },
+  {
+    "attributes": [
+      {
+        "default": [],
+        "help": "CSS classes applied to widget DOM element",
+        "items": {
+          "type": "string"
+        },
+        "name": "_dom_classes",
+        "type": "array"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_model_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_model_module_version",
+        "type": "string"
+      },
+      {
+        "default": "FloatsInputModel",
+        "help": "",
+        "name": "_model_name",
+        "type": "string"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_view_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_view_module_version",
+        "type": "string"
+      },
+      {
+        "default": "FloatsInputView",
+        "help": "",
+        "name": "_view_name",
+        "type": "string"
+      },
+      {
+        "default": true,
+        "help": "",
+        "name": "allow_duplicates",
+        "type": "bool"
+      },
+      {
+        "default": [],
+        "help": "",
+        "name": "allowed_tags",
+        "type": "array"
+      },
+      {
+        "default": "",
+        "help": "Description of the control.",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "default": ".1f",
+        "help": "",
+        "name": "format",
+        "type": "string"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "",
+        "name": "layout",
+        "type": "reference",
+        "widget": "Layout"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "",
+        "name": "max",
+        "type": "float"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "",
+        "name": "min",
+        "type": "float"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "Styling customizations",
+        "name": "style",
+        "type": "reference",
+        "widget": "DescriptionStyle"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "Is widget tabbable?",
+        "name": "tabbable",
+        "type": "bool"
+      },
+      {
+        "default": "",
+        "enum": ["primary", "success", "info", "warning", "danger", ""],
+        "help": "Use a predefined styling for the tags.",
+        "name": "tag_style",
+        "type": "string"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "A tooltip caption.",
+        "name": "tooltip",
+        "type": "string"
+      },
+      {
+        "default": [],
+        "help": "List of float tags",
+        "name": "value",
+        "type": "array"
+      }
+    ],
+    "model": {
+      "module": "@jupyter-widgets/controls",
+      "name": "FloatsInputModel",
+      "version": "2.0.0"
+    },
+    "view": {
+      "module": "@jupyter-widgets/controls",
+      "name": "FloatsInputView",
       "version": "2.0.0"
     }
   },
@@ -4133,6 +4388,144 @@
         "type": "string"
       },
       {
+        "default": "IntsInputModel",
+        "help": "",
+        "name": "_model_name",
+        "type": "string"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_view_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_view_module_version",
+        "type": "string"
+      },
+      {
+        "default": "IntsInputView",
+        "help": "",
+        "name": "_view_name",
+        "type": "string"
+      },
+      {
+        "default": true,
+        "help": "",
+        "name": "allow_duplicates",
+        "type": "bool"
+      },
+      {
+        "default": [],
+        "help": "",
+        "name": "allowed_tags",
+        "type": "array"
+      },
+      {
+        "default": "",
+        "help": "Description of the control.",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "default": ".3g",
+        "help": "",
+        "name": "format",
+        "type": "string"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "",
+        "name": "layout",
+        "type": "reference",
+        "widget": "Layout"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "",
+        "name": "max",
+        "type": "int"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "",
+        "name": "min",
+        "type": "int"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "Styling customizations",
+        "name": "style",
+        "type": "reference",
+        "widget": "DescriptionStyle"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "Is widget tabbable?",
+        "name": "tabbable",
+        "type": "bool"
+      },
+      {
+        "default": "",
+        "enum": ["primary", "success", "info", "warning", "danger", ""],
+        "help": "Use a predefined styling for the tags.",
+        "name": "tag_style",
+        "type": "string"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "A tooltip caption.",
+        "name": "tooltip",
+        "type": "string"
+      },
+      {
+        "default": [],
+        "help": "List of int tags",
+        "name": "value",
+        "type": "array"
+      }
+    ],
+    "model": {
+      "module": "@jupyter-widgets/controls",
+      "name": "IntsInputModel",
+      "version": "2.0.0"
+    },
+    "view": {
+      "module": "@jupyter-widgets/controls",
+      "name": "IntsInputView",
+      "version": "2.0.0"
+    }
+  },
+  {
+    "attributes": [
+      {
+        "default": [],
+        "help": "CSS classes applied to widget DOM element",
+        "items": {
+          "type": "string"
+        },
+        "name": "_dom_classes",
+        "type": "array"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_model_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_model_module_version",
+        "type": "string"
+      },
+      {
         "default": "LabelModel",
         "help": "",
         "name": "_model_name",
@@ -4584,6 +4977,12 @@
         "default": null,
         "help": "Color of the progress bar.",
         "name": "bar_color",
+        "type": "string"
+      },
+      {
+        "default": "",
+        "help": "Maximum width of the description to the side of the control.",
+        "name": "description_max_width",
         "type": "string"
       },
       {
@@ -5269,6 +5668,12 @@
       },
       {
         "default": "",
+        "help": "Maximum width of the description to the side of the control.",
+        "name": "description_max_width",
+        "type": "string"
+      },
+      {
+        "default": "",
         "help": "Width of the description to the side of the control.",
         "name": "description_width",
         "type": "string"
@@ -5515,6 +5920,124 @@
     "view": {
       "module": "@jupyter-widgets/controls",
       "name": "TabView",
+      "version": "2.0.0"
+    }
+  },
+  {
+    "attributes": [
+      {
+        "default": [],
+        "help": "CSS classes applied to widget DOM element",
+        "items": {
+          "type": "string"
+        },
+        "name": "_dom_classes",
+        "type": "array"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_model_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_model_module_version",
+        "type": "string"
+      },
+      {
+        "default": "TagsInputModel",
+        "help": "",
+        "name": "_model_name",
+        "type": "string"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_view_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_view_module_version",
+        "type": "string"
+      },
+      {
+        "default": "TagsInputView",
+        "help": "",
+        "name": "_view_name",
+        "type": "string"
+      },
+      {
+        "default": true,
+        "help": "",
+        "name": "allow_duplicates",
+        "type": "bool"
+      },
+      {
+        "default": [],
+        "help": "",
+        "name": "allowed_tags",
+        "type": "array"
+      },
+      {
+        "default": "",
+        "help": "Description of the control.",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "",
+        "name": "layout",
+        "type": "reference",
+        "widget": "Layout"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "Styling customizations",
+        "name": "style",
+        "type": "reference",
+        "widget": "DescriptionStyle"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "Is widget tabbable?",
+        "name": "tabbable",
+        "type": "bool"
+      },
+      {
+        "default": "",
+        "enum": ["primary", "success", "info", "warning", "danger", ""],
+        "help": "Use a predefined styling for the tags.",
+        "name": "tag_style",
+        "type": "string"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "A tooltip caption.",
+        "name": "tooltip",
+        "type": "string"
+      },
+      {
+        "default": [],
+        "help": "List of string tags",
+        "name": "value",
+        "type": "array"
+      }
+    ],
+    "model": {
+      "module": "@jupyter-widgets/controls",
+      "name": "TagsInputModel",
+      "version": "2.0.0"
+    },
+    "view": {
+      "module": "@jupyter-widgets/controls",
+      "name": "TagsInputView",
       "version": "2.0.0"
     }
   },
@@ -6060,6 +6583,12 @@
         "default": "",
         "help": "The width of each button.",
         "name": "button_width",
+        "type": "string"
+      },
+      {
+        "default": "",
+        "help": "Maximum width of the description to the side of the control.",
+        "name": "description_max_width",
         "type": "string"
       },
       {

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -384,6 +384,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/base'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'StyleView'`    | 
+`description_max_width` | string           | `''`             | Maximum width of the description to the side of the control.
 `description_width` | string           | `''`             | Width of the description to the side of the control.
 
 ### DirectionalLinkModel (@jupyter-widgets/controls, 2.0.0); None (@jupyter-widgets/controls, 2.0.0)
@@ -889,6 +890,7 @@ Attribute        | Type             | Default          | Help
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'StyleView'`    | 
 `bar_color`      | `null` or string | `null`           | Color of the progress bar.
+`description_max_width` | string           | `''`             | Maximum width of the description to the side of the control.
 `description_width` | string           | `''`             | Width of the description to the side of the control.
 
 ### RadioButtonsModel (@jupyter-widgets/controls, 2.0.0); RadioButtonsView (@jupyter-widgets/controls, 2.0.0)
@@ -1009,6 +1011,7 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/base'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'StyleView'`    | 
+`description_max_width` | string           | `''`             | Maximum width of the description to the side of the control.
 `description_width` | string           | `''`             | Width of the description to the side of the control.
 `handle_color`   | `null` or string | `null`           | Color of the slider handle.
 
@@ -1169,6 +1172,7 @@ Attribute        | Type             | Default          | Help
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | string           | `'StyleView'`    | 
 `button_width`   | string           | `''`             | The width of each button.
+`description_max_width` | string           | `''`             | Maximum width of the description to the side of the control.
 `description_width` | string           | `''`             | Width of the description to the side of the control.
 `font_weight`    | string           | `''`             | Text font weight of each button.
 


### PR DESCRIPTION
Currently `Checkbox` doesn't support long descriptions (see #861). Using `description_width` style doesn't solve it.

This PR fixes it.

Changes:

- Changed checkbox description label style from `widget-label-basic` to `widget-label`.
- Added `description_max_width` to `DescriptionStyle` class.
- Added example to documentation.