### PR TITLE
Add comments to the lock bot

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -14,12 +14,11 @@ exemptLabels: []
 lockLabel: resolved-locked
 
 # Comment to post before locking. Set to `false` to disable
-lockComment: false
 
-# lockComment: >
-#   This thread has been automatically locked since there has not been
-#   any recent activity after it was closed. Please open a [new issue](https://github.com/jupyterlab/jupyterlab/issues/new/choose)
-#   for related discussion.
+lockComment: >
+   This thread has been automatically locked since there has not been
+   any recent activity after it was closed. Please open a [new issue](https://github.com/jupyter-widgets/ipywidgets/issues/new/choose)
+   for related discussion.
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true


### PR DESCRIPTION
The stated goal of the lock bot on this repo is ([ref](https://github.com/jupyter-widgets/ipywidgets/pull/2876#issue-417536199))

> This encourages people to open a new issue with full details of their situation rather than resurrecting one that has been closed and resolved.

This makes that explicit to a user encountering a locked thread.

@jasongrout you originally added the lock, do you oppose this?