### PR TITLE
fix: when CDN is used as fallback, no module is returned

### DIFF
--- a/packages/html-manager/src/libembed-amd.ts
+++ b/packages/html-manager/src/libembed-amd.ts
@@ -85,7 +85,7 @@ export function requireLoader(
     if (failedId) {
       require.undef(failedId);
       console.log(`Falling back to ${cdn} for ${moduleName}@${moduleVersion}`);
-      loadFromCDN();
+      return loadFromCDN();
     }
   });
 }


### PR DESCRIPTION
git bisect revealed an issue in https://github.com/jupyter-widgets/ipywidgets/pull/2792
