### PR TITLE
Do not rebuild jupyterlab_widgets assets if static directory exists

### DIFF
--- a/jupyterlab_widgets/MANIFEST.in
+++ b/jupyterlab_widgets/MANIFEST.in
@@ -8,8 +8,8 @@ include ts*.json
 graft jupyterlab_widgets/static
 
 # Javascript files
-graft src
-graft style
+prune src
+prune style
 prune **/node_modules
 prune lib
 


### PR DESCRIPTION
In making the conda-forge package (https://github.com/conda-forge/staged-recipes/pull/12791), we realized when building a wheel from the sdist package did not work. NodeJS compilation really only works in the context of this repo.

This change makes it so that static assets for jupyterlab_widgets are not rebuilt in the setup.py commands if they already exist.
