### PR TITLE
perf: use class_traits with a cache to speed up creation of widgets

### DIFF
--- a/ipywidgets/widgets/tests/test_traits.py
+++ b/ipywidgets/widgets/tests/test_traits.py
@@ -11,7 +11,7 @@ from unittest import TestCase
 from traitlets import HasTraits, Int, TraitError
 from traitlets.tests.test_traitlets import TraitTestBase
 
-from ipywidgets import Color, NumberFormat
+from ipywidgets import Button, Color, NumberFormat
 from ipywidgets.widgets.widget import _remove_buffers, _put_buffers
 from ipywidgets.widgets.trait_types import date_serialization, TypedTuple
 
@@ -243,3 +243,13 @@ def test_typed_tuple_positional_default():
 
     obj = TestCase()
     assert obj.value == (1, 2, 3)
+
+
+def test_add_trait():
+    button = Button()
+    keys = list(button.keys)
+    assert 'foobar' not in keys
+    button.add_traits(foobar=Int().tag(sync=True))
+    assert 'foobar' in button.keys
+    assert 'foobar' not in Button().keys
+    assert set(button.keys) != set(keys)


### PR DESCRIPTION
Benchmark results for creating a button `widgets.Button()`
```
------------------------------------------------ benchmark: 1 tests -----------------------------------------------
Name (time in ms)              Min      Max    Mean  StdDev  Median     IQR  Outliers       OPS  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------
test_performance_create     2.8579  36.1314  3.3029  2.0412  3.0983  0.2583      1;22  302.7645     266           1
-------------------------------------------------------------------------------------------------------------------
```

After this PR, in combination with https://github.com/ipython/traitlets/pull/639

```
------------------------------------------------ benchmark: 1 tests -----------------------------------------------
Name (time in ms)              Min      Max    Mean  StdDev  Median     IQR  Outliers       OPS  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------
test_performance_create     2.0695  62.7899  2.9496  3.6363  2.3238  0.8066      2;27  339.0254     290           1
-------------------------------------------------------------------------------------------------------------------
```

Which is a 30% performance increase.

Note that `.class_traits` is the same as `.traits` but is a classmethod, so that we can cache on a class level. Note that add_trait will create a new class, so will play nice with the cache. This is tested in case this changes.