### PR TITLE
Require jupyterlab_widgets only on Python >=3.5

### DIFF
--- a/docs/source/dev_release.md
+++ b/docs/source/dev_release.md
@@ -114,6 +114,7 @@ Using the above script, you can do:
 ```
 hashes dist/*
 hashes widgetsnbextension/dist/*
+hashes jupyterlab_widgets/dist/*
 ```
 
 Commit the changes you've made above, and include the uploaded files hashes in the commit message. Tag the release if ipywidgets was released. Push to origin master (and include the tag in the push).

--- a/setup.py
+++ b/setup.py
@@ -119,13 +119,13 @@ install_requires = setuptools_args['install_requires'] = [
     # only if notebook 4.x is installed in this
     # interpreter, to allow ipywidgets to be
     # installed on bare kernels.
-    'widgetsnbextension~=3.5.0',
-    'jupyterlab_widgets>=1.0.0',
+    'widgetsnbextension~=3.5.0'
 ]
 
 extras_require = setuptools_args['extras_require'] = {
     ':python_version<"3.3"' : ['ipython>=4.0.0,<6.0.0'],
     ':python_version>="3.3"': ['ipython>=4.0.0'],
+    ':python_version>="3.5"': ['jupyterlab_widgets>=1.0.0'],
     'test:python_version=="2.7"': ['mock'],
     'test': ['pytest>=3.6.0', 'pytest-cov'],
 }


### PR DESCRIPTION
Fixes #3049 