### PR TITLE
Mention adding a sharedPackages configuration when updating to JLab 3.

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -14,9 +14,23 @@ This is accomplished with the new python package `jupyterlab_widgets` version 1.
 
 ### Updates for Widget Maintainers
 
-Custom widget maintainers will need to update their `@jupyter-widgets/base` dependency version to work in JupyterLab 3.0. For example, if you had a dependency on `@jupyter-widgets/base` version `^2 || ^3`, update to `^2 || ^3 || ^4` for your widget to work in classic Jupyter Notebook, JupyterLab 1, JupyterLab 2, and JupyterLab 3. See [#2472](https://github.com/jupyter-widgets/ipywidgets/pull/2472) for background.
+Custom widget maintainers will need to make two changes to update for JupyterLab 3:
 
-Separately from this update of the version of the `@jupyter-widgets/base` dependency version range, you might consider making your widget's JupyterLab extension a prebuilt extension for JupyterLab 3.0. Users will be able to install your JupyterLab 3.0 prebuilt extension without rebuilding JupyterLab or needing Node.js. See the [JupyterLab 3 extension developer documentation](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html) or the new [widget extension cookiecutter](https://github.com/jupyter-widgets/widget-ts-cookiecutter) for more details.
+1. Update the `@jupyter-widgets/base` dependency version to include `^4` to work in JupyterLab 3.0. For example, if you had a dependency on `@jupyter-widgets/base` version `^2 || ^3`, update to `^2 || ^3 || ^4` for your widget to work in classic Jupyter Notebook, JupyterLab 1, JupyterLab 2, and JupyterLab 3. See [#2472](https://github.com/jupyter-widgets/ipywidgets/pull/2472) for background.
+2. In the `package.json`, add the following `sharedPackages` configuration inside the `jupyterlab` key. See the [JupyterLab extension documentation](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#requiring-a-service) for more information.
+
+   ```json
+     "jupyterlab": {
+       "sharedPackages": {
+         "@jupyter-widgets/base": {
+           "bundled": false,
+           "singleton": true
+         }
+       }
+     }
+   ```
+
+Separate from these two steps to update for JupyterLab 3, we also recommend that you make your widget's JupyterLab extension a prebuilt extension for JupyterLab 3.0. Users will be able to install your JupyterLab 3.0 prebuilt extension without rebuilding JupyterLab or needing Node.js. See the [JupyterLab 3 extension developer documentation](https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html) or the new [widget extension cookiecutter](https://github.com/jupyter-widgets/widget-ts-cookiecutter/tree/jlab3) for more details.
 
 
 7.5


### PR DESCRIPTION
This adds more help for widget authors needing to update their packages.