### PR TITLE
Correct widgetsnbextension version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ install_requires = setuptools_args['install_requires'] = [
     # only if notebook 4.x is installed in this
     # interpreter, to allow ipywidgets to be
     # installed on bare kernels.
-    'widgetsnbextension~=4.0a0',
+    'widgetsnbextension~=4.0.0a0',
 ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
There is no version `widgetsnbextension~=4.0a0`
The correct one is `widgetsnbextension~=4.0.0a0`