### PR TITLE
Only install jupyterlab_widgets if py3.6 or above

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ install_requires = setuptools_args['install_requires'] = [
 extras_require = setuptools_args['extras_require'] = {
     ':python_version<"3.3"' : ['ipython>=4.0.0,<6.0.0'],
     ':python_version>="3.3"': ['ipython>=4.0.0'],
-    ':python_version>="3.5"': ['jupyterlab_widgets>=1.0.0'],
+    ':python_version>="3.6"': ['jupyterlab_widgets>=1.0.0'],
     'test:python_version=="2.7"': ['mock'],
     'test': ['pytest>=3.6.0', 'pytest-cov'],
 }


### PR DESCRIPTION
For jupyterlab_widgets 1.0.0, only Python 3.6 and above are supported, so
restrict it as part of the extra_requires.

Fixes https://github.com/jupyter-widgets/ipywidgets/issues/3058.

jupyterlab_widgets 1.0.0 documentation:
https://pypi.org/project/jupyterlab-widgets/1.0.0/