### PR TITLE
Updated generate_spec.py

### DIFF
--- a/packages/schema/generate-spec.py
+++ b/packages/schema/generate-spec.py
@@ -68,10 +68,6 @@ def trait_type(trait, widget_list):
                                                      widgets.Widget):
         w_type = 'reference'
         attributes['widget'] = trait.klass.__name__
-        # ADD the widget to this documenting list
-        if (trait.klass not in [i[1] for i in widget_list]
-                and trait.klass is not widgets.Widget):
-            widget_list.append((trait.klass.__name__, trait.klass))
     elif isinstance(trait, Any):
         # In our case, these all happen to be values that are converted to
         # strings
@@ -194,7 +190,7 @@ def create_markdown(spec):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Description of your program')
-    parser.add_argument('-f', '--format', choices=['json', 'json-pretty', 'markdown'], 
+    parser.add_argument('-f', '--format', choices=['json', 'json-pretty', 'markdown'],
         help='Format to generate', default='json')
     args = parser.parse_args()
     format = args.format


### PR DESCRIPTION
I'm using a modified version of `generate_spec.py` to generate json spec files that I use to generate models on clojure kernels.

One of the first things I had to change was to remove the lines of code that mutates `widget_list` when calling `trait_type` function.
I would argue that `trait_type` should just return the attributes dictionary and not touch `widget_list`.

The current behaviour is unintuitive and error prone and it might bite you sooner and later.

I realize after commiting that `trait_type` function signature can be changed to remove `widget_list` as argument. Let me know if you're interested in changing that too.
