### PR TITLE
Bugfix/parameters in the from file method to be passed along in the media class 

### DIFF
--- a/ipywidgets/widgets/widget_media.py
+++ b/ipywidgets/widgets/widget_media.py
@@ -71,7 +71,7 @@ class _Media(DOMWidget, ValueWidget, CoreWidget):
             # If str, it needs to be encoded to bytes
             url = url.encode('utf-8')
 
-        return cls(value=url, format='url')
+        return cls(value=url, format='url', **kwargs)
 
     def set_value_from_file(self, filename):
         """


### PR DESCRIPTION
Extra parameters in the from_url() method do not get passed on to the super class.
this fix passes the parameters along.