### PR TITLE
Existence of attributes in html video tags makes the attribute to be true.

### DIFF
--- a/packages/controls/src/widget_video.ts
+++ b/packages/controls/src/widget_video.ts
@@ -85,9 +85,30 @@ export class VideoView extends DOMWidgetView {
     }
 
     // Video attributes
-    this.el.loop = this.model.get('loop');
-    this.el.autoplay = this.model.get('autoplay');
-    this.el.controls = this.model.get('controls');
+    const loop  = this.model.get('loop');
+    if (loop != undefined && loop !== false)
+    {
+      this.el.setAttribute('loop', loop);
+    } else {
+      this.el.removeAttribute('loop')
+    }
+
+    const autoplay  = this.model.get('autoplay');
+    if (autoplay != undefined && autoplay !== false)
+    {
+      this.el.setAttribute('autoplay', loop);
+    } else {
+      this.el.removeAttribute('autoplay')
+    }
+
+    const controls  = this.model.get('controls');
+    if (controls != undefined && controls !== false)
+    {
+      this.el.setAttribute('controls', loop);
+    } else {
+      this.el.removeAttribute('controls')
+    }
+
 
     return super.update();
   }

--- a/packages/controls/src/widget_video.ts
+++ b/packages/controls/src/widget_video.ts
@@ -86,7 +86,7 @@ export class VideoView extends DOMWidgetView {
 
     // Video attributes
     const loop  = this.model.get('loop');
-    if (loop != undefined && loop !== false)
+    if (loop != undefined && loop)
     {
       this.el.setAttribute('loop', loop);
     } else {
@@ -94,17 +94,17 @@ export class VideoView extends DOMWidgetView {
     }
 
     const autoplay  = this.model.get('autoplay');
-    if (autoplay != undefined && autoplay !== false)
+    if (autoplay != undefined && autoplay)
     {
-      this.el.setAttribute('autoplay', loop);
+      this.el.setAttribute('autoplay', autoplay);
     } else {
       this.el.removeAttribute('autoplay')
     }
 
     const controls  = this.model.get('controls');
-    if (controls != undefined && controls !== false)
+    if (controls != undefined && controls)
     {
-      this.el.setAttribute('controls', loop);
+      this.el.setAttribute('controls', controls);
     } else {
       this.el.removeAttribute('controls')
     }


### PR DESCRIPTION
The correct way of setting/unsetting the tags in the html video element for 'looping', 'autoplay' and 'controls'
is to make the tag available (with any value) or removing it.

https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes
https://stackoverflow.com/questions/14161516/html5-video-completely-hide-controls
 