### PR TITLE
Move widgetsnbextension, jupyterlab_widgets from install_requires to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,19 +115,15 @@ install_requires = setuptools_args['install_requires'] = [
     # Requiring nbformat to specify bugfix version which is not required by
     # notebook.
     'nbformat>=4.2.0',
-    # TODO: Dynamically add this dependency
-    # only if notebook 4.x is installed in this
-    # interpreter, to allow ipywidgets to be
-    # installed on bare kernels.
-    'widgetsnbextension~=3.5.0'
 ]
 
 extras_require = setuptools_args['extras_require'] = {
     ':python_version<"3.3"' : ['ipython>=4.0.0,<6.0.0'],
     ':python_version>="3.3"': ['ipython>=4.0.0'],
-    ':python_version>="3.6"': ['jupyterlab_widgets>=1.0.0'],
     'test:python_version=="2.7"': ['mock'],
     'test': ['pytest>=3.6.0', 'pytest-cov'],
+    'notebook': ['widgetsnbextension~=3.5.0'],
+    'jupyterlab': ['widgetsnbextension~=3.5.0', 'jupyterlab_widgets>=1.0.0'],
 }
 
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
A longstanding TODO in the `ipywidgets` `setup.py`: "Dynamically add [the dependency on `widgetsnbextension`] only if notebook 4.x is installed in this interpreter, to allow ipywidgets to be installed on bare kernels."

Such conditional dependencies, of course, are incompatible with modern Python packaging.

Recent versions of `ipywidgets` have added another dependency that is in the way of the goal of installs on bare kernels: an `extras_require` that pulls in all of JupyterLab via `jupyterlab_widgets`: `':python_version>="3.6"': ['jupyterlab_widgets>=1.0.0']`

In this pull request, we change these problematic dependencies to `extra_requires`. 

Cross-ref: https://trac.sagemath.org/ticket/31278

