### PR TITLE
add documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,29 @@
+---
+name: Documentation improvement
+about: Create a report to help us improve the documentation
+labels: docs
+---
+
+<!--To help us understand and resolve your issue, please fill out the form to the best of your ability.-->
+<!--You can feel free to delete the sections that do not apply.-->
+
+### Problem
+
+<!--
+If you are referencing an existing piece of documentation or example please provide a link.
+
+* I found [...] to be unclear because [...]
+* [...] made me think that [...] when really it should be [...]
+* There is no example showing how to do [...]
+-->
+
+
+### Suggested Improvement
+
+<!--
+If you have an idea to improve the documentation please suggest it here
+
+* This line should be be changed to say [...]
+* Include a paragraph explaining [...]
+* Add a figure showing [...]
+-->


### PR DESCRIPTION
Add structure for reporting documentation issues - I think this makes the new issue tab more inviting as you don't have to call a docs issue a `Bug Report` or call it a `Feature Request`

This template is a straight copy of the version I added to matplotlib in https://github.com/matplotlib/matplotlib/pull/18161