### PR TITLE
Remove extra requirements from doc to fix RTD build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 bqplot
 ipykernel
-ipyleaflet
 jupyter_client
 matplotlib
 nbsphinx>=0.5


### PR DESCRIPTION
This was causing the RTD build to fail as ipyleaflet requires ipywidgets<8

See: https://github.com/jupyter-widgets/ipywidgets/issues/3093

Removing this shouldn't affect builds of the docs as it seems that the only affected notebook is not executed during the build (https://ipywidgets.readthedocs.io/en/latest/examples/Layout%20Example.html?highlight=ipyleaflet) because it would require an Open Street Map API key.