### PR TITLE
Traitlets 4 vs 5 changes defaults in message spec

### DIFF
--- a/packages/schema/jupyterwidgetmodels.latest.json
+++ b/packages/schema/jupyterwidgetmodels.latest.json
@@ -310,7 +310,13 @@
       {
         "allow_none": true,
         "default": null,
-        "enum": ["contain", "cover", "fill", "scale-down", "none"],
+        "enum": [
+          "contain",
+          "cover",
+          "fill",
+          "scale-down",
+          "none"
+        ],
         "help": "The object-fit CSS attribute.",
         "name": "object_fit",
         "type": "string"
@@ -360,7 +366,13 @@
       {
         "allow_none": true,
         "default": null,
-        "enum": ["visible", "hidden", "inherit", "initial", "unset"],
+        "enum": [
+          "visible",
+          "hidden",
+          "inherit",
+          "initial",
+          "unset"
+        ],
         "help": "The visibility CSS attribute.",
         "name": "visibility",
         "type": "string"
@@ -433,7 +445,13 @@
       },
       {
         "default": "",
-        "enum": ["success", "info", "warning", "danger", ""],
+        "enum": [
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the box.",
         "name": "box_style",
         "type": "string"
@@ -915,7 +933,13 @@
       },
       {
         "default": "",
-        "enum": ["success", "info", "warning", "danger", ""],
+        "enum": [
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the box.",
         "name": "box_style",
         "type": "string"
@@ -1012,7 +1036,14 @@
       },
       {
         "default": "",
-        "enum": ["primary", "success", "info", "warning", "danger", ""],
+        "enum": [
+          "primary",
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the button.",
         "name": "button_style",
         "type": "string"
@@ -1357,6 +1388,117 @@
     "view": {
       "module": "@jupyter-widgets/controls",
       "name": "ColorPickerView",
+      "version": "2.0.0"
+    }
+  },
+  {
+    "attributes": [
+      {
+        "default": [],
+        "help": "CSS classes applied to widget DOM element",
+        "items": {
+          "type": "string"
+        },
+        "name": "_dom_classes",
+        "type": "array"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_model_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_model_module_version",
+        "type": "string"
+      },
+      {
+        "default": "ColorsInputModel",
+        "help": "",
+        "name": "_model_name",
+        "type": "string"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_view_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_view_module_version",
+        "type": "string"
+      },
+      {
+        "default": "ColorsInputView",
+        "help": "",
+        "name": "_view_name",
+        "type": "string"
+      },
+      {
+        "default": true,
+        "help": "",
+        "name": "allow_duplicates",
+        "type": "bool"
+      },
+      {
+        "default": [],
+        "help": "",
+        "name": "allowed_tags",
+        "type": "array"
+      },
+      {
+        "default": "",
+        "help": "Description of the control.",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "",
+        "name": "layout",
+        "type": "reference",
+        "widget": "Layout"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "Styling customizations",
+        "name": "style",
+        "type": "reference",
+        "widget": "DescriptionStyle"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "Is widget tabbable?",
+        "name": "tabbable",
+        "type": "bool"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "A tooltip caption.",
+        "name": "tooltip",
+        "type": "string"
+      },
+      {
+        "default": [],
+        "help": "List of string tags",
+        "name": "value",
+        "type": "array"
+      }
+    ],
+    "model": {
+      "module": "@jupyter-widgets/controls",
+      "name": "ColorsInputModel",
+      "version": "2.0.0"
+    },
+    "view": {
+      "module": "@jupyter-widgets/controls",
+      "name": "ColorsInputView",
       "version": "2.0.0"
     }
   },
@@ -2089,13 +2231,13 @@
         "type": "string"
       },
       {
-        "default": [],
+        "default": null,
         "help": "The source (widget, 'trait_name') pair",
         "name": "source",
         "type": "array"
       },
       {
-        "default": [],
+        "default": null,
         "help": "The target (widget, 'trait_name') pair",
         "name": "target",
         "type": "array"
@@ -2282,7 +2424,14 @@
       },
       {
         "default": "",
-        "enum": ["primary", "success", "info", "warning", "danger", ""],
+        "enum": [
+          "primary",
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the button.",
         "name": "button_style",
         "type": "string"
@@ -2458,7 +2607,10 @@
       },
       {
         "default": "horizontal",
-        "enum": ["horizontal", "vertical"],
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
         "help": "Vertical or horizontal.",
         "name": "orientation",
         "type": "string"
@@ -2571,7 +2723,13 @@
       {
         "allow_none": true,
         "default": "",
-        "enum": ["success", "info", "warning", "danger", ""],
+        "enum": [
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the progess bar.",
         "name": "bar_style",
         "type": "string"
@@ -2603,7 +2761,10 @@
       },
       {
         "default": "horizontal",
-        "enum": ["horizontal", "vertical"],
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
         "help": "Vertical or horizontal.",
         "name": "orientation",
         "type": "string"
@@ -2733,7 +2894,10 @@
       },
       {
         "default": "horizontal",
-        "enum": ["horizontal", "vertical"],
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
         "help": "Vertical or horizontal.",
         "name": "orientation",
         "type": "string"
@@ -2779,7 +2943,10 @@
         "type": "string"
       },
       {
-        "default": [0.0, 1.0],
+        "default": [
+          0.0,
+          1.0
+        ],
         "help": "Tuple of (lower, upper) bounds",
         "name": "value",
         "type": "array"
@@ -2882,7 +3049,10 @@
       },
       {
         "default": "horizontal",
-        "enum": ["horizontal", "vertical"],
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
         "help": "Vertical or horizontal.",
         "name": "orientation",
         "type": "string"
@@ -3087,6 +3257,151 @@
         "type": "string"
       },
       {
+        "default": "FloatsInputModel",
+        "help": "",
+        "name": "_model_name",
+        "type": "string"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_view_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_view_module_version",
+        "type": "string"
+      },
+      {
+        "default": "FloatsInputView",
+        "help": "",
+        "name": "_view_name",
+        "type": "string"
+      },
+      {
+        "default": true,
+        "help": "",
+        "name": "allow_duplicates",
+        "type": "bool"
+      },
+      {
+        "default": [],
+        "help": "",
+        "name": "allowed_tags",
+        "type": "array"
+      },
+      {
+        "default": "",
+        "help": "Description of the control.",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "default": ".1f",
+        "help": "",
+        "name": "format",
+        "type": "string"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "",
+        "name": "layout",
+        "type": "reference",
+        "widget": "Layout"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "",
+        "name": "max",
+        "type": "float"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "",
+        "name": "min",
+        "type": "float"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "Styling customizations",
+        "name": "style",
+        "type": "reference",
+        "widget": "DescriptionStyle"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "Is widget tabbable?",
+        "name": "tabbable",
+        "type": "bool"
+      },
+      {
+        "default": "",
+        "enum": [
+          "primary",
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
+        "help": "Use a predefined styling for the tags.",
+        "name": "tag_style",
+        "type": "string"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "A tooltip caption.",
+        "name": "tooltip",
+        "type": "string"
+      },
+      {
+        "default": [],
+        "help": "List of float tags",
+        "name": "value",
+        "type": "array"
+      }
+    ],
+    "model": {
+      "module": "@jupyter-widgets/controls",
+      "name": "FloatsInputModel",
+      "version": "2.0.0"
+    },
+    "view": {
+      "module": "@jupyter-widgets/controls",
+      "name": "FloatsInputView",
+      "version": "2.0.0"
+    }
+  },
+  {
+    "attributes": [
+      {
+        "default": [],
+        "help": "CSS classes applied to widget DOM element",
+        "items": {
+          "type": "string"
+        },
+        "name": "_dom_classes",
+        "type": "array"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_model_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_model_module_version",
+        "type": "string"
+      },
+      {
         "default": "GridBoxModel",
         "help": "",
         "name": "_model_name",
@@ -3112,7 +3427,13 @@
       },
       {
         "default": "",
-        "enum": ["success", "info", "warning", "danger", ""],
+        "enum": [
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the box.",
         "name": "box_style",
         "type": "string"
@@ -3209,7 +3530,13 @@
       },
       {
         "default": "",
-        "enum": ["success", "info", "warning", "danger", ""],
+        "enum": [
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the box.",
         "name": "box_style",
         "type": "string"
@@ -3620,7 +3947,13 @@
       },
       {
         "default": "",
-        "enum": ["success", "info", "warning", "danger", ""],
+        "enum": [
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the progess bar.",
         "name": "bar_style",
         "type": "string"
@@ -3652,7 +3985,10 @@
       },
       {
         "default": "horizontal",
-        "enum": ["horizontal", "vertical"],
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
         "help": "Vertical or horizontal.",
         "name": "orientation",
         "type": "string"
@@ -3782,7 +4118,10 @@
       },
       {
         "default": "horizontal",
-        "enum": ["horizontal", "vertical"],
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
         "help": "Vertical or horizontal.",
         "name": "orientation",
         "type": "string"
@@ -3827,7 +4166,10 @@
         "type": "string"
       },
       {
-        "default": [0, 1],
+        "default": [
+          0,
+          1
+        ],
         "help": "Tuple of (lower, upper) bounds",
         "name": "value",
         "type": "array"
@@ -3930,7 +4272,10 @@
       },
       {
         "default": "horizontal",
-        "enum": ["horizontal", "vertical"],
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
         "help": "Vertical or horizontal.",
         "name": "orientation",
         "type": "string"
@@ -4133,6 +4478,151 @@
         "type": "string"
       },
       {
+        "default": "IntsInputModel",
+        "help": "",
+        "name": "_model_name",
+        "type": "string"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_view_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_view_module_version",
+        "type": "string"
+      },
+      {
+        "default": "IntsInputView",
+        "help": "",
+        "name": "_view_name",
+        "type": "string"
+      },
+      {
+        "default": true,
+        "help": "",
+        "name": "allow_duplicates",
+        "type": "bool"
+      },
+      {
+        "default": [],
+        "help": "",
+        "name": "allowed_tags",
+        "type": "array"
+      },
+      {
+        "default": "",
+        "help": "Description of the control.",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "default": ".3g",
+        "help": "",
+        "name": "format",
+        "type": "string"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "",
+        "name": "layout",
+        "type": "reference",
+        "widget": "Layout"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "",
+        "name": "max",
+        "type": "int"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "",
+        "name": "min",
+        "type": "int"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "Styling customizations",
+        "name": "style",
+        "type": "reference",
+        "widget": "DescriptionStyle"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "Is widget tabbable?",
+        "name": "tabbable",
+        "type": "bool"
+      },
+      {
+        "default": "",
+        "enum": [
+          "primary",
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
+        "help": "Use a predefined styling for the tags.",
+        "name": "tag_style",
+        "type": "string"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "A tooltip caption.",
+        "name": "tooltip",
+        "type": "string"
+      },
+      {
+        "default": [],
+        "help": "List of int tags",
+        "name": "value",
+        "type": "array"
+      }
+    ],
+    "model": {
+      "module": "@jupyter-widgets/controls",
+      "name": "IntsInputModel",
+      "version": "2.0.0"
+    },
+    "view": {
+      "module": "@jupyter-widgets/controls",
+      "name": "IntsInputView",
+      "version": "2.0.0"
+    }
+  },
+  {
+    "attributes": [
+      {
+        "default": [],
+        "help": "CSS classes applied to widget DOM element",
+        "items": {
+          "type": "string"
+        },
+        "name": "_dom_classes",
+        "type": "array"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_model_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_model_module_version",
+        "type": "string"
+      },
+      {
         "default": "LabelModel",
         "help": "",
         "name": "_model_name",
@@ -4254,13 +4744,13 @@
         "type": "string"
       },
       {
-        "default": [],
+        "default": null,
         "help": "The source (widget, 'trait_name') pair",
         "name": "source",
         "type": "array"
       },
       {
-        "default": [],
+        "default": null,
         "help": "The target (widget, 'trait_name') pair",
         "name": "target",
         "type": "array"
@@ -5038,7 +5528,10 @@
         "type": "bool"
       },
       {
-        "default": [0, 0],
+        "default": [
+          0,
+          0
+        ],
         "help": "Min and max selected indices",
         "name": "index",
         "type": "array"
@@ -5052,7 +5545,10 @@
       },
       {
         "default": "horizontal",
-        "enum": ["horizontal", "vertical"],
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
         "help": "Vertical or horizontal.",
         "name": "orientation",
         "type": "string"
@@ -5185,7 +5681,10 @@
       },
       {
         "default": "horizontal",
-        "enum": ["horizontal", "vertical"],
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
         "help": "Vertical or horizontal.",
         "name": "orientation",
         "type": "string"
@@ -5341,7 +5840,13 @@
       },
       {
         "default": "",
-        "enum": ["success", "info", "warning", "danger", ""],
+        "enum": [
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the box.",
         "name": "box_style",
         "type": "string"
@@ -5454,7 +5959,13 @@
       },
       {
         "default": "",
-        "enum": ["success", "info", "warning", "danger", ""],
+        "enum": [
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the box.",
         "name": "box_style",
         "type": "string"
@@ -5515,6 +6026,131 @@
     "view": {
       "module": "@jupyter-widgets/controls",
       "name": "TabView",
+      "version": "2.0.0"
+    }
+  },
+  {
+    "attributes": [
+      {
+        "default": [],
+        "help": "CSS classes applied to widget DOM element",
+        "items": {
+          "type": "string"
+        },
+        "name": "_dom_classes",
+        "type": "array"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_model_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_model_module_version",
+        "type": "string"
+      },
+      {
+        "default": "TagsInputModel",
+        "help": "",
+        "name": "_model_name",
+        "type": "string"
+      },
+      {
+        "default": "@jupyter-widgets/controls",
+        "help": "",
+        "name": "_view_module",
+        "type": "string"
+      },
+      {
+        "default": "2.0.0",
+        "help": "",
+        "name": "_view_module_version",
+        "type": "string"
+      },
+      {
+        "default": "TagsInputView",
+        "help": "",
+        "name": "_view_name",
+        "type": "string"
+      },
+      {
+        "default": true,
+        "help": "",
+        "name": "allow_duplicates",
+        "type": "bool"
+      },
+      {
+        "default": [],
+        "help": "",
+        "name": "allowed_tags",
+        "type": "array"
+      },
+      {
+        "default": "",
+        "help": "Description of the control.",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "",
+        "name": "layout",
+        "type": "reference",
+        "widget": "Layout"
+      },
+      {
+        "default": "reference to new instance",
+        "help": "Styling customizations",
+        "name": "style",
+        "type": "reference",
+        "widget": "DescriptionStyle"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "Is widget tabbable?",
+        "name": "tabbable",
+        "type": "bool"
+      },
+      {
+        "default": "",
+        "enum": [
+          "primary",
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
+        "help": "Use a predefined styling for the tags.",
+        "name": "tag_style",
+        "type": "string"
+      },
+      {
+        "allow_none": true,
+        "default": null,
+        "help": "A tooltip caption.",
+        "name": "tooltip",
+        "type": "string"
+      },
+      {
+        "default": [],
+        "help": "List of string tags",
+        "name": "value",
+        "type": "array"
+      }
+    ],
+    "model": {
+      "module": "@jupyter-widgets/controls",
+      "name": "TagsInputModel",
+      "version": "2.0.0"
+    },
+    "view": {
+      "module": "@jupyter-widgets/controls",
+      "name": "TagsInputView",
       "version": "2.0.0"
     }
   },
@@ -5808,7 +6444,14 @@
       },
       {
         "default": "",
-        "enum": ["primary", "success", "info", "warning", "danger", ""],
+        "enum": [
+          "primary",
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the button.",
         "name": "button_style",
         "type": "string"
@@ -5936,7 +6579,14 @@
       {
         "allow_none": true,
         "default": "",
-        "enum": ["primary", "success", "info", "warning", "danger", ""],
+        "enum": [
+          "primary",
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the buttons.",
         "name": "button_style",
         "type": "string"
@@ -6135,7 +6785,13 @@
       },
       {
         "default": "",
-        "enum": ["success", "info", "warning", "danger", ""],
+        "enum": [
+          "success",
+          "info",
+          "warning",
+          "danger",
+          ""
+        ],
         "help": "Use a predefined styling for the box.",
         "name": "box_style",
         "type": "string"

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -396,8 +396,8 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | `null` or string | `null`           | Name of the view.
-`source`         | array            | `[]`             | The source (widget, 'trait_name') pair
-`target`         | array            | `[]`             | The target (widget, 'trait_name') pair
+`source`         | array            | `null`           | The source (widget, 'trait_name') pair
+`target`         | array            | `null`           | The target (widget, 'trait_name') pair
 
 ### DropdownModel (@jupyter-widgets/controls, 2.0.0); DropdownView (@jupyter-widgets/controls, 2.0.0)
 
@@ -828,8 +828,8 @@ Attribute        | Type             | Default          | Help
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
 `_view_name`     | `null` or string | `null`           | Name of the view.
-`source`         | array            | `[]`             | The source (widget, 'trait_name') pair
-`target`         | array            | `[]`             | The target (widget, 'trait_name') pair
+`source`         | array            | `null`           | The source (widget, 'trait_name') pair
+`target`         | array            | `null`           | The target (widget, 'trait_name') pair
 
 ### PasswordModel (@jupyter-widgets/controls, 2.0.0); PasswordView (@jupyter-widgets/controls, 2.0.0)
 


### PR DESCRIPTION
We get these by these commands from the release docs:

```
python ./packages/schema/generate-spec.py -f json-pretty > packages/schema/jupyterwidgetmodels.latest.json
python ./packages/schema/generate-spec.py -f markdown > packages/schema/jupyterwidgetmodels.latest.md
```

I noticed that these gave updates that were not already in the files. It seems that our updated packages now give updated formatting to the json, so it's probably more instructive to look at the two small changes in the .md file.