### PR TITLE
Add play/pause methods to media widgets

### DIFF
--- a/docs/source/examples/Media widgets.ipynb
+++ b/docs/source/examples/Media widgets.ipynb
@@ -42,7 +42,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "video1"
+    "video1.pause()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "video1.play()"
    ]
   },
   {
@@ -61,7 +70,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Audio.from_file(\"images/Big.Buck.Bunny.mp3\", controls=True)"
+    "audio = Audio.from_file(\"images/Big.Buck.Bunny.mp3\", controls=True)\n",
+    "audio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "audio.pause()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "audio.play()"
    ]
   }
  ],
@@ -81,7 +109,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/ipywidgets/widgets/widget_media.py
+++ b/ipywidgets/widgets/widget_media.py
@@ -187,6 +187,18 @@ class Video(_Media):
     loop = Bool(True, help="When true, the video will start from the beginning after finishing").tag(sync=True)
     controls = Bool(True, help="Specifies that video controls should be displayed (such as a play/pause button etc)").tag(sync=True)
 
+    def play(self):
+        """
+        Start playing the video
+        """
+        self.send({ "msg": "play" })
+
+    def pause(self):
+        """
+        Pause the video
+        """
+        self.send({ "msg": "pause" })
+
     @classmethod
     def from_file(cls, filename, **kwargs):
         return cls._from_file('video', filename, **kwargs)
@@ -215,6 +227,18 @@ class Audio(_Media):
     autoplay = Bool(True, help="When true, the audio starts when it's displayed").tag(sync=True)
     loop = Bool(True, help="When true, the audio will start from the beginning after finishing").tag(sync=True)
     controls = Bool(True, help="Specifies that audio controls should be displayed (such as a play/pause button etc)").tag(sync=True)
+
+    def play(self):
+        """
+        Start playing the audio
+        """
+        self.send({ "msg": "play" })
+
+    def pause(self):
+        """
+        Pause the audio
+        """
+        self.send({ "msg": "pause" })
 
     @classmethod
     def from_file(cls, filename, **kwargs):

--- a/packages/controls/src/widget_audio.ts
+++ b/packages/controls/src/widget_audio.ts
@@ -37,6 +37,7 @@ export class AudioView extends DOMWidgetView {
     super.render();
     this.pWidget.addClass('jupyter-widgets');
     this.update(); // Set defaults.
+    this.model.on('msg:custom', this.handle_play_pause.bind(this));
   }
 
   update(): void {
@@ -72,6 +73,15 @@ export class AudioView extends DOMWidgetView {
     this.el.controls = this.model.get('controls');
 
     return super.update();
+  }
+
+  handle_play_pause(content: any): void {
+    if (content.msg == 'play') {
+      this.el.play();
+    }
+    if (content.msg == 'pause') {
+      this.el.pause();
+    }
   }
 
   remove(): void {

--- a/packages/controls/src/widget_video.ts
+++ b/packages/controls/src/widget_video.ts
@@ -40,6 +40,7 @@ export class VideoView extends DOMWidgetView {
     this.pWidget.addClass('jupyter-widgets');
     this.pWidget.addClass('widget-image');
     this.update(); // Set defaults.
+    this.model.on('msg:custom', this.handle_play_pause.bind(this));
   }
 
   update(): void {
@@ -90,6 +91,15 @@ export class VideoView extends DOMWidgetView {
     this.el.controls = this.model.get('controls');
 
     return super.update();
+  }
+
+  handle_play_pause(content: any): void {
+    if (content.msg == 'play') {
+      this.el.play();
+    }
+    if (content.msg == 'pause') {
+      this.el.pause();
+    }
   }
 
   remove(): void {


### PR DESCRIPTION
As discussed in #3063

I did not make a `playing` attribute as part of the model, the reason is that if we do this, changing the `playing` would trigger an `update()` call on the front-end view, resetting the video to its start.