### PR TITLE
Change graph example to receive a tuple instead of a dict

### DIFF
--- a/docs/source/examples/Exploring Graphs.ipynb
+++ b/docs/source/examples/Exploring Graphs.ipynb
@@ -74,21 +74,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "interact(plot_random_graph, n=(2,30), m=(1,10), k=(1,10), p=(0.0, 1.0, 0.001),\n",
-    "         generator={\n",
-    "             'lobster': random_lobster,\n",
-    "             'power law': powerlaw_cluster,\n",
-    "             'Newman-Watts-Strogatz': newman_watts_strogatz,\n",
-    "             u'Erdős-Rényi': erdos_renyi,\n",
-    "         });"
+    "interact(plot_random_graph, n=(2,30), m=(1,10), k=(1,10), p=(0.0, 0.99, 0.001),\n",
+    "         generator=[\n",
+    "             ('lobster', random_lobster),\n",
+    "             ('power law', powerlaw_cluster),\n",
+    "             ('Newman-Watts-Strogatz', newman_watts_strogatz),\n",
+    "             (u'Erdős-Rényi', erdos_renyi),\n",
+    "         ]);"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -107,7 +100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #3089 
I also changed the `p` value to `0.99` because I'd get an error saying the value should be smaller than 1.
I also got some errors saying I needed to have scipy installed when I tried to generate some graphs super fast. I wonder if it's a weird edge case or if we should add it to the notebook.