### PR TITLE
Privatize Widgets.widget

### DIFF
--- a/ipywidgets/embed.py
+++ b/ipywidgets/embed.py
@@ -129,7 +129,7 @@ def _get_recursive_state(widget, store=None, drop_defaults=False):
 
 def add_resolved_links(store, drop_defaults):
     """Adds the state of any link models between two models in store"""
-    for widget_id, widget in Widget.widgets.items(): # go over all widgets
+    for widget_id, widget in Widget._active_widgets.items(): # go over all widgets
         if isinstance(widget, Link) and widget_id not in store:
             if widget.source[0].model_id in store and widget.target[0].model_id in store:
                 store[widget.model_id] = widget._get_embed_state(drop_defaults=drop_defaults)
@@ -207,7 +207,7 @@ def embed_data(views, drop_defaults=True, state=None):
         view_specs: a list of widget view specs
     """
     if views is None:
-        views = [w for w in Widget.widgets.values() if isinstance(w, DOMWidget)]
+        views = [w for w in Widget._active_widgets.values() if isinstance(w, DOMWidget)]
     else:
         try:
             views[0]

--- a/ipywidgets/tests/test_embed.py
+++ b/ipywidgets/tests/test_embed.py
@@ -29,7 +29,7 @@ class CaseWidget(Widget):
 class TestEmbed:
 
     def teardown(self):
-        for w in tuple(Widget.widgets.values()):
+        for w in tuple(Widget._active_widgets.values()):
             w.close()
 
     def test_embed_data_simple(self):

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -247,7 +247,7 @@ class WidgetRegistry:
 def register(widget):
     """A decorator registering a widget class in the widget registry."""
     w = widget.class_traits()
-    Widget.widget_types.register(w['_model_module'].default_value,
+    Widget._widget_types.register(w['_model_module'].default_value,
                                  w['_model_module_version'].default_value,
                                  w['_model_name'].default_value,
                                  w['_view_module'].default_value,
@@ -266,8 +266,8 @@ class Widget(LoggingHasTraits):
     # _active_widgets is a dictionary of all active widget objects
     _active_widgets = {}
 
-    # widget_types is a registry of widgets by module, version, and name:
-    widget_types = WidgetRegistry()
+    # _widget_types is a registry of widgets by module, version, and name:
+    _widget_types = WidgetRegistry()
 
     @classmethod
     def close_all(cls):
@@ -299,7 +299,7 @@ class Widget(LoggingHasTraits):
         state = data['state']
 
         # Find the widget class to instantiate in the registered widgets
-        widget_class = Widget.widget_types.get(state['_model_module'],
+        widget_class = Widget._widget_types.get(state['_model_module'],
                                                state['_model_module_version'],
                                                state['_model_name'],
                                                state['_view_module'],

--- a/packages/schema/generate-spec.py
+++ b/packages/schema/generate-spec.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     format = args.format
 
-    widgets_to_document = sorted(widgets.Widget.widget_types.items())
+    widgets_to_document = sorted(widgets.Widget._widget_types.items())
     spec = create_spec(widgets_to_document)
     if format == 'json':
         print(json.dumps(spec, sort_keys=True))


### PR DESCRIPTION
Closes: https://github.com/jupyter-widgets/ipywidgets/issues/2944

Using such a generic name could lead to collisions with user code as in the linked issue. Here it is changed to a name far less likely to collide with a user subclass and privatized. I'm less sure about making it private but it seems as though doing this will increase future flexibility and clean up what shows up when tab completing on a widget subclass.

I also gave the same treatment to `widget_types` for consistency. 