### PR TITLE
Add a workflow to test the packaging

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -42,6 +42,13 @@ jobs:
         cd jupyterlab_widgets
         python setup.py sdist bdist_wheel
         cp ./dist/* ../dist
+    - name: Build PyPI distributions for widgetsnbextension
+      run: |
+        jlpm
+        jlpm run build
+        cd widgetsnbextension
+        python setup.py sdist bdist_wheel
+        cp ./dist/* ../dist
     - name: Build checksum file
       run: |
         cd dist
@@ -67,6 +74,8 @@ jobs:
             dist: 'ipywidgets*.whl'
           - python: '3.9'
             dist: 'jupyterlab_widgets*.tar.gz'
+          - python: '3.9'
+            dist: 'widgetsnbextension*.tar.gz'
           - os: windows
             py_cmd: python
           - os: macos
@@ -95,12 +104,12 @@ jobs:
           ${{ matrix.py_cmd }} -m pip freeze
           ${{ matrix.py_cmd }} -m pip check
       - name: Validate the install
+        if: matrix.dist != 'widgetsnbextension*.tar.gz'
         run: |
           ${{ matrix.py_cmd }} -m pip install jupyterlab~=3.0
 
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -ie "@jupyter-widgets/jupyterlab-manager.*enabled.*ok" -
-
       - name: Check the Classic Notebook extension is installed
         if: matrix.dist != 'jupyterlab_widgets*.tar.gz'
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -67,11 +67,8 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         python: ['3.6', '3.9']
+        dist: ['ipywidgets*.tar.gz', 'ipywidgets*.whl']
         include:
-          - python: '3.6'
-            dist: 'ipywidgets*.tar.gz'
-          - python: '3.9'
-            dist: 'ipywidgets*.whl'
           - python: '3.9'
             dist: 'jupyterlab_widgets*.tar.gz'
           - python: '3.9'
@@ -103,7 +100,7 @@ jobs:
         run: |
           ${{ matrix.py_cmd }} -m pip freeze
           ${{ matrix.py_cmd }} -m pip check
-      - name: Validate the install
+      - name: Check the JupyterLab extension is installed
         if: matrix.dist != 'widgetsnbextension*.tar.gz'
         run: |
           ${{ matrix.py_cmd }} -m pip install jupyterlab~=3.0

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -28,6 +28,25 @@ jobs:
       with:
         python-version: '3.9'
         architecture: 'x64'
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - uses: actions/cache@v2
+      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
@@ -65,52 +84,64 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu, windows]
         python: ['3.6', '3.9']
-        dist: ['ipywidgets*.tar.gz', 'ipywidgets*.whl']
+        dist: ['ipywidgets*.tar.gz']
         include:
           - python: '3.9'
             dist: 'jupyterlab_widgets*.tar.gz'
+            os: 'ubuntu'
           - python: '3.9'
             dist: 'widgetsnbextension*.tar.gz'
-          - os: windows
-            py_cmd: python
-          - os: macos
-            py_cmd: python3
-          - os: ubuntu
-            py_cmd: python
+            os: 'ubuntu'
+          - python: '3.9'
+            dist: 'ipywidgets*.whl'
+            os: 'ubuntu'
     steps:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
           architecture: 'x64'
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install the prerequisites
+        run: |
+          python -m pip install pip wheel
       - uses: actions/download-artifact@v2
         with:
           name: dist ${{ github.run_number }}
           path: ./dist
-      - name: Install the prerequisites
-        run: |
-          ${{ matrix.py_cmd }} -m pip install pip wheel
       - name: Install the package
         run: |
           cd dist
-          ${{ matrix.py_cmd }} -m pip install -vv ${{ matrix.dist }}
+          python -m pip install -vv ${{ matrix.dist }}
       - name: Validate environment
         run: |
-          ${{ matrix.py_cmd }} -m pip freeze
-          ${{ matrix.py_cmd }} -m pip check
+          python -m pip freeze
+          python -m pip check
       - name: Check the JupyterLab extension is installed
         if: matrix.dist != 'widgetsnbextension*.tar.gz'
         run: |
-          ${{ matrix.py_cmd }} -m pip install jupyterlab~=3.0
+          python -m pip install jupyterlab~=3.0
 
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -ie "@jupyter-widgets/jupyterlab-manager.*enabled.*ok" -
       - name: Check the Classic Notebook extension is installed
         if: matrix.dist != 'jupyterlab_widgets*.tar.gz'
         run: |
-          ${{ matrix.py_cmd }} -m pip install notebook~=6.0
+          python -m pip install notebook~=6.0
 
           jupyter nbextension list
           jupyter nbextension list 2>&1 | grep -ie "jupyter-js-widgets/extension.*enabled" -

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -103,6 +103,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: 'x64'
+      - name: Checkout # For the cache keys
+        uses: actions/checkout@v2
 
       - name: Get pip cache dir
         id: pip-cache

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,108 @@
+name: Packaging
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: '*'
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+       node-version: '14.x'
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+        architecture: 'x64'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip wheel
+        python -m pip install setuptools jupyter_packaging "jupyterlab>=3,<4"
+    - name: Build PyPI distributions for ipywidgets
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Build PyPI distributions for jupyterlab_widgets
+      run: |
+        jlpm
+        jlpm run build
+        cd jupyterlab_widgets
+        python setup.py sdist bdist_wheel
+        cp ./dist/* ../dist
+    - name: Build checksum file
+      run: |
+        cd dist
+        sha256sum * | tee SHA256SUMS
+    - name: Upload distributions
+      uses: actions/upload-artifact@v2
+      with:
+        name: dist ${{ github.run_number }}
+        path: ./dist
+
+  install:
+    runs-on: ${{ matrix.os }}-latest
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+        python: ['3.6', '3.9']
+        include:
+          - python: '3.6'
+            dist: 'ipywidgets*.tar.gz'
+          - python: '3.9'
+            dist: 'ipywidgets*.whl'
+          - python: '3.9'
+            dist: 'jupyterlab_widgets*.tar.gz'
+          - os: windows
+            py_cmd: python
+          - os: macos
+            py_cmd: python3
+          - os: ubuntu
+            py_cmd: python
+    steps:
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: 'x64'
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist ${{ github.run_number }}
+          path: ./dist
+      - name: Install the prerequisites
+        run: |
+          ${{ matrix.py_cmd }} -m pip install pip wheel
+      - name: Install the package
+        run: |
+          cd dist
+          ${{ matrix.py_cmd }} -m pip install -vv ${{ matrix.dist }}
+      - name: Validate environment
+        run: |
+          ${{ matrix.py_cmd }} -m pip freeze
+          ${{ matrix.py_cmd }} -m pip check
+      - name: Validate the install
+        run: |
+          ${{ matrix.py_cmd }} -m pip install jupyterlab~=3.0
+
+          jupyter labextension list
+          jupyter labextension list 2>&1 | grep -ie "@jupyter-widgets/jupyterlab-manager.*enabled.*ok" -
+
+      - name: Check the Classic Notebook extension is installed
+        if: matrix.dist != 'jupyterlab_widgets*.tar.gz'
+        run: |
+          jupyter nbextension list
+          jupyter nbextension list 2>&1 | grep -ie "jupyter-js-widgets/extension.*enabled" -

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -113,5 +113,7 @@ jobs:
       - name: Check the Classic Notebook extension is installed
         if: matrix.dist != 'jupyterlab_widgets*.tar.gz'
         run: |
+          ${{ matrix.py_cmd }} -m pip install notebook~=6.0
+
           jupyter nbextension list
           jupyter nbextension list 2>&1 | grep -ie "jupyter-js-widgets/extension.*enabled" -


### PR DESCRIPTION
Follow-up to #3119 

This adds a new workflow on CI to test installing `ipywidgets` and `jupyterlab_widgets` with the whell and the sdist.

This can help check the extensions are correctly bundled and installed.