### PR TITLE
Add event listener for resize events

### DIFF
--- a/examples/web1/webpack.config.js
+++ b/examples/web1/webpack.config.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
@@ -14,5 +15,13 @@ module.exports = {
       // jquery-ui loads some images
       { test: /\.(jpg|png|gif)$/, use: 'file-loader' }
     ]
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
+      'process.env': '{}',
+      // Needed for various packages using cwd(), like the path polyfill
+      process: { cwd: () => '/' }
+    })
+  ]
 };

--- a/examples/web2/webpack.config.js
+++ b/examples/web2/webpack.config.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
@@ -57,5 +58,13 @@ module.exports = {
         }
       }
     ]
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
+      'process.env': '{}',
+      // Needed for various packages using cwd(), like the path polyfill
+      process: { cwd: () => '/' }
+    })
+  ]
 };

--- a/examples/web3/package.json
+++ b/examples/web3/package.json
@@ -18,7 +18,6 @@
     "@jupyter-widgets/controls": "^4.0.0-alpha.3",
     "@jupyter-widgets/html-manager": "^0.21.0-alpha.3",
     "@jupyterlab/services": "^6.0.0",
-    "@lumino/widgets": "^1.11.1",
     "codemirror": "^5.48.0",
     "font-awesome": "^4.7.0",
     "http-server": "^0.12.3"

--- a/examples/web3/src/index.ts
+++ b/examples/web3/src/index.ts
@@ -3,7 +3,6 @@ import 'codemirror/lib/codemirror.css';
 import 'codemirror/mode/python/python';
 import 'font-awesome/css/font-awesome.css';
 import { WidgetManager } from './manager';
-import * as luminoWidget from '@lumino/widgets';
 
 import {
   KernelManager,
@@ -62,8 +61,7 @@ document.addEventListener('DOMContentLoaded', async function(event) {
       if (widgetData !== undefined && widgetData.version_major === 2) {
         const model = await manager.get_model(widgetData.model_id);
         if (model !== undefined) {
-          const view = await manager.create_view(model);
-          luminoWidget.Widget.attach(view.luminoWidget, widgetarea);
+          manager.display_view(manager.create_view(model), widgetarea);
         }
       }
     }

--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -1,5 +1,6 @@
 const postcss = require('postcss');
 var path = require('path');
+var webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
@@ -88,5 +89,13 @@ module.exports = {
         }
       }
     ]
-  }
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
+      'process.env': '{}',
+      // Needed for various packages using cwd(), like the path polyfill
+      process: { cwd: () => '/' }
+    })
+  ]
 };

--- a/examples/web4/webpack.config.js
+++ b/examples/web4/webpack.config.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
@@ -57,4 +58,12 @@ module.exports = {
       },
     ],
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
+      'process.env': '{}',
+      // Needed for various packages using cwd(), like the path polyfill
+      process: { cwd: () => '/' }
+    })
+  ]
 };

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -915,18 +915,6 @@ export class DOMWidgetView extends WidgetView {
           oldLayoutView.remove();
         }
 
-        const resizeFunc = () => {
-          MessageLoop.postMessage(
-            this.pWidget,
-            Widget.ResizeMessage.UnknownSize
-          );
-        };
-
-        window.addEventListener('resize', resizeFunc);
-        this.once('remove', () => {
-          window.removeEventListener('resize', resizeFunc);
-        });
-
         return this.create_child_view(layout)
           .then(view => {
             // Trigger the displayed event of the child view.

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -915,6 +915,18 @@ export class DOMWidgetView extends WidgetView {
           oldLayoutView.remove();
         }
 
+        const resizeFunc = () => {
+          MessageLoop.postMessage(
+            this.pWidget,
+            Widget.ResizeMessage.UnknownSize
+          );
+        };
+
+        window.addEventListener('resize', resizeFunc);
+        this.once('remove', () => {
+          window.removeEventListener('resize', resizeFunc);
+        });
+
         return this.create_child_view(layout)
           .then(view => {
             // Trigger the displayed event of the child view.

--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -44,6 +44,7 @@
     "@jupyterlab/outputarea": "^3.0.0",
     "@jupyterlab/rendermime": "^3.0.0",
     "@jupyterlab/rendermime-interfaces": "^3.0.0",
+    "@lumino/messaging": "^1.3.3",
     "@lumino/widgets": "^1.11.1",
     "ajv": "^8.6.0",
     "jquery": "^3.1.1"

--- a/packages/html-manager/src/htmlmanager.ts
+++ b/packages/html-manager/src/htmlmanager.ts
@@ -6,7 +6,6 @@ import * as base from '@jupyter-widgets/base';
 import * as outputWidgets from './output';
 import { ManagerBase } from '@jupyter-widgets/base-manager';
 import { MessageLoop } from '@lumino/messaging';
-import { Widget } from '@lumino/widgets';
 
 import * as LuminoWidget from '@lumino/widgets';
 import {
@@ -40,7 +39,7 @@ export class HTMLManager extends ManagerBase {
       this._viewList.forEach(view => {
         MessageLoop.postMessage(
           view.lmWidget,
-          Widget.ResizeMessage.UnknownSize
+          LuminoWidget.Widget.ResizeMessage.UnknownSize
         );
       });
     });

--- a/packages/html-manager/src/htmlmanager.ts
+++ b/packages/html-manager/src/htmlmanager.ts
@@ -38,7 +38,7 @@ export class HTMLManager extends ManagerBase {
     window.addEventListener('resize', () => {
       this._viewList.forEach(view => {
         MessageLoop.postMessage(
-          view.lmWidget,
+          view.luminoWidget,
           LuminoWidget.Widget.ResizeMessage.UnknownSize
         );
       });

--- a/widgetsnbextension/src/extension.js
+++ b/widgetsnbextension/src/extension.js
@@ -79,7 +79,7 @@ function register_events(Jupyter, events, outputarea) {
     Object.keys(views).forEach(viewKey => {
       LuminoMessaging.MessageLoop.postMessage(
         views[viewKey].lmWidget,
-        Widget.ResizeMessage.UnknownSize
+        LuminoWidget.Widget.ResizeMessage.UnknownSize
       );
     });
   });

--- a/widgetsnbextension/src/extension.js
+++ b/widgetsnbextension/src/extension.js
@@ -76,7 +76,7 @@ function register_events(Jupyter, events, outputarea) {
   var views = {};
 
   window.addEventListener('resize', () => {
-    Objects.keys(views).forEach(viewKey => {
+    Object.keys(views).forEach(viewKey => {
       LuminoMessaging.MessageLoop.postMessage(
         views[viewKey].lmWidget,
         Widget.ResizeMessage.UnknownSize

--- a/widgetsnbextension/src/extension.js
+++ b/widgetsnbextension/src/extension.js
@@ -19,6 +19,7 @@ var mngr = require('./manager');
 require('./save_state');
 require('./embed_widgets');
 var LuminoWidget = require('@lumino/widgets');
+var LuminoMessaging = require('@lumino/messaging');
 
 /**
  * Create a widget manager for a kernel instance.
@@ -73,6 +74,16 @@ function register_events(Jupyter, events, outputarea) {
    * method when a view is removed from the page.
    */
   var views = {};
+
+  window.addEventListener('resize', () => {
+    Objects.keys(views).forEach(viewKey => {
+      LuminoMessaging.MessageLoop.postMessage(
+        views[viewKey].lmWidget,
+        Widget.ResizeMessage.UnknownSize
+      );
+    });
+  });
+
   var removeView = function(event, data) {
     var output = data.cell ? data.cell.output_area : data.output_area;
     var viewids = output ? output._jupyterWidgetViews : void 0;

--- a/widgetsnbextension/src/extension.js
+++ b/widgetsnbextension/src/extension.js
@@ -78,7 +78,7 @@ function register_events(Jupyter, events, outputarea) {
   window.addEventListener('resize', () => {
     Object.keys(views).forEach(viewKey => {
       LuminoMessaging.MessageLoop.postMessage(
-        views[viewKey].lmWidget,
+        views[viewKey].luminoWidget,
         LuminoWidget.Widget.ResizeMessage.UnknownSize
       );
     });


### PR DESCRIPTION
This PR adds an event listener so that `lumino` based widgets rendered in a classic notebook can receive a resize message when a window resize event triggers.