### PR TITLE
Checking milestone and generating changelog

### DIFF
--- a/docs/source/dev_release.md
+++ b/docs/source/dev_release.md
@@ -125,6 +125,16 @@ Update conda-forge packages (if the requirements changed to ipywidgets, make sur
 Release Notes
 =============
 
+### Changelog
+
+- Modify `scripts/milestone_check.py` to include the release and commit range for the release, and run `python scripts/milestone_check.py` to check the issues assigned to this milestone
+- Write release highlights. You can use the list generated below as a starting point:
+  ```bash
+  loghub jupyter-widgets/ipywidgets -m XXX -t $GITHUB_TOKEN --template scripts/release_template.txt
+  ```
+
+### Example
+
 Here is an example of the release statistics for ipywidgets 7.0.
 
 It has been 157 days since the last release. In this release, we closed [127 issues](https://github.com/jupyter-widgets/ipywidgets/issues?q=is%3Aissue+is%3Aclosed+milestone%3A7.0) and [216 pull requests](https://github.com/jupyter-widgets/ipywidgets/pulls?q=is%3Apr+milestone%3A7.0+is%3Aclosed) with [1069](https://github.com/jupyter-widgets/ipywidgets/compare/6.0.0...7.0.0) commits, of which 851 are not merges.

--- a/scripts/release_template.txt
+++ b/scripts/release_template.txt
@@ -1,0 +1,18 @@
+`v{{ version }} <https://github.com/jupyter-widgets/ipywidgets/releases/tag/v{{ version }}>`__
+---------------------------------------------------------------------------
+
+{{ close_date }}
+^^^^^^^^^^^^^^^
+
+See the `ipywidgets
+{{ version }} <https://github.com/jupyter-widgets/ipywidgets/milestone/XXXX?closed=1>`__
+milestone on GitHub for the full list of pull requests and issues closed.
+
+{%   for pr in pull_requests -%}
+* {{ pr['title'] | capitalize }} (`#{{ pr['number'] }} <{{pr['html_url']}}>`__
+{%-      if pr['loghub_related_issues']|length %}
+{%-          for pri in pr['loghub_related_issues'] -%}
+                 , `#{{ pri['text'] }} <{{ pri['url'] }}>`__
+{%-          endfor -%}
+{%- endif %})
+{%   endfor %}

--- a/scripts/release_template.txt
+++ b/scripts/release_template.txt
@@ -1,18 +1,14 @@
-`v{{ version }} <https://github.com/jupyter-widgets/ipywidgets/releases/tag/v{{ version }}>`__
----------------------------------------------------------------------------
+### [v{{ version }}](https://github.com/jupyter-widgets/ipywidgets/releases/tag/v{{ version }}) ({{ close_date }})
 
-{{ close_date }}
-^^^^^^^^^^^^^^^
-
-See the `ipywidgets
-{{ version }} <https://github.com/jupyter-widgets/ipywidgets/milestone/XXXX?closed=1>`__
+See the [ipywidgets
+{{ version }}](https://github.com/jupyter-widgets/ipywidgets/milestone/XXXX?closed=1)
 milestone on GitHub for the full list of pull requests and issues closed.
 
 {%   for pr in pull_requests -%}
-* {{ pr['title'] | capitalize }} (`#{{ pr['number'] }} <{{pr['html_url']}}>`__
+* {{ pr['title'] | capitalize }} ([#{{ pr['number'] }}]({{pr['html_url']}})
 {%-      if pr['loghub_related_issues']|length %}
 {%-          for pri in pr['loghub_related_issues'] -%}
-                 , `#{{ pri['text'] }} <{{ pri['url'] }}>`__
+                 , [#{{ pri['text'] }}]({{ pri['url'] }})
 {%-          endfor -%}
 {%- endif %})
 {%   endfor %}


### PR DESCRIPTION
Add brief, rough instructions for checking the PR milestones and generating a list of PRs for release notes.

This is a template modified slightly from the JupyterLab template.

<details><summary>Here's what it generates right now, for example:</summary>

```
### [v8.0](https://github.com/jupyter-widgets/ipywidgets/releases/tag/v8.0) (2021/02/17)

See the [ipywidgets
8.0](https://github.com/jupyter-widgets/ipywidgets/milestone/XXXX?closed=1)
milestone on GitHub for the full list of pull requests and issues closed.

* Privatize widgets.widget ([#3122](https://github.com/jupyter-widgets/ipywidgets/pull/3122))
* Change cdn from unpkg to jsdelivr ([#3121](https://github.com/jupyter-widgets/ipywidgets/pull/3121), [#1627](https://github.com/jupyter-widgets/ipywidgets/issues/1627))
* Use python_requires >=3.5 ([#3120](https://github.com/jupyter-widgets/ipywidgets/pull/3120), [#3067](https://github.com/jupyter-widgets/ipywidgets/issues/3067))
* Update repo-detection ([#3119](https://github.com/jupyter-widgets/ipywidgets/pull/3119), [#3090](https://github.com/jupyter-widgets/ipywidgets/issues/3090))
* Change graph example to receive a tuple instead of a dict ([#3117](https://github.com/jupyter-widgets/ipywidgets/pull/3117), [#3089](https://github.com/jupyter-widgets/ipywidgets/issues/3089))
* Fix slider format ([#3113](https://github.com/jupyter-widgets/ipywidgets/pull/3113), [#3102](https://github.com/jupyter-widgets/ipywidgets/issues/3102))
* Remove step parameter from widget list notebook ([#3106](https://github.com/jupyter-widgets/ipywidgets/pull/3106), [#3105](https://github.com/jupyter-widgets/ipywidgets/issues/3105))
* Make doc structure more user friendly ([#3104](https://github.com/jupyter-widgets/ipywidgets/pull/3104), [#3096](https://github.com/jupyter-widgets/ipywidgets/issues/3096))
* Add reference to jupyter coc ([#3103](https://github.com/jupyter-widgets/ipywidgets/pull/3103))
* Refactor outdated readme ([#3099](https://github.com/jupyter-widgets/ipywidgets/pull/3099), [#3076](https://github.com/jupyter-widgets/ipywidgets/issues/3076))
* Remove extra requirements from doc to fix rtd build ([#3098](https://github.com/jupyter-widgets/ipywidgets/pull/3098))
* Add documentation issue template ([#3095](https://github.com/jupyter-widgets/ipywidgets/pull/3095))
* Update locking workflow ([#3092](https://github.com/jupyter-widgets/ipywidgets/pull/3092))
* Adapt the milestone_check script from jupyterlab for ipywidgets. ([#3091](https://github.com/jupyter-widgets/ipywidgets/pull/3091))
* Port 7.x changes to master ([#3086](https://github.com/jupyter-widgets/ipywidgets/pull/3086), [#3085](https://github.com/jupyter-widgets/ipywidgets/issues/3085))
* Fix bug report template ([#3082](https://github.com/jupyter-widgets/ipywidgets/pull/3082))
* Fix broken link ([#3062](https://github.com/jupyter-widgets/ipywidgets/pull/3062))
* Fix debouncing and throttling code ([#3060](https://github.com/jupyter-widgets/ipywidgets/pull/3060))
* Docs: remove reference to resolved bug ([#3040](https://github.com/jupyter-widgets/ipywidgets/pull/3040))
* Add alt text so images aren't duplicated in html ([#3013](https://github.com/jupyter-widgets/ipywidgets/pull/3013))
* Fix: when cdn is used as fallback, no module is returned ([#2984](https://github.com/jupyter-widgets/ipywidgets/pull/2984))
* Bump node-fetch from 2.6.0 to 2.6.1 ([#2969](https://github.com/jupyter-widgets/ipywidgets/pull/2969))
* Bump http-proxy from 1.18.0 to 1.18.1 ([#2964](https://github.com/jupyter-widgets/ipywidgets/pull/2964))
* Create issue templates ([#2938](https://github.com/jupyter-widgets/ipywidgets/pull/2938))
* Bump elliptic from 6.5.2 to 6.5.3 ([#2932](https://github.com/jupyter-widgets/ipywidgets/pull/2932))
* Bump lodash from 4.17.15 to 4.17.19 ([#2925](https://github.com/jupyter-widgets/ipywidgets/pull/2925))
* Fix missing return types ([#2885](https://github.com/jupyter-widgets/ipywidgets/pull/2885))
* Update installation instructions ([#2884](https://github.com/jupyter-widgets/ipywidgets/pull/2884))
* Lock closed issues that have been inactive for 30 days. ([#2876](https://github.com/jupyter-widgets/ipywidgets/pull/2876), [#2871](https://github.com/jupyter-widgets/ipywidgets/issues/2871))
* Fix tagsinputs linter warnings ([#2874](https://github.com/jupyter-widgets/ipywidgets/pull/2874))
* Bump jquery from 3.4.1 to 3.5.0 ([#2860](https://github.com/jupyter-widgets/ipywidgets/pull/2860))
* Revert "bump jquery from 3.4.1 to 3.5.0" ([#2859](https://github.com/jupyter-widgets/ipywidgets/pull/2859))
* Bump jquery from 3.4.1 to 3.5.0 ([#2857](https://github.com/jupyter-widgets/ipywidgets/pull/2857))
* Fix css calc space ([#2851](https://github.com/jupyter-widgets/ipywidgets/pull/2851))
* Bump acorn for security ([#2833](https://github.com/jupyter-widgets/ipywidgets/pull/2833))
* Remove old items from manifest.in and update content of setup.py ([#2830](https://github.com/jupyter-widgets/ipywidgets/pull/2830))
* Fix the logic for tab selection when the children changes to select a tab when possible ([#2827](https://github.com/jupyter-widgets/ipywidgets/pull/2827), [#2818](https://github.com/jupyter-widgets/ipywidgets/issues/2818))
* Update readme build status badge ([#2825](https://github.com/jupyter-widgets/ipywidgets/pull/2825), [#2672](https://github.com/jupyter-widgets/ipywidgets/issues/2672))
* Documentation fixes ([#2824](https://github.com/jupyter-widgets/ipywidgets/pull/2824))
* Add lab extension install command to readme ([#2823](https://github.com/jupyter-widgets/ipywidgets/pull/2823), [#2179](https://github.com/jupyter-widgets/ipywidgets/issues/2179))
* Update github action checkout to v2 for better performance ([#2819](https://github.com/jupyter-widgets/ipywidgets/pull/2819))
* Update for jlab 2.0.1 final ([#2817](https://github.com/jupyter-widgets/ipywidgets/pull/2817))
* Change fontawesome support to work for fontawesome 4 and 5. ([#2816](https://github.com/jupyter-widgets/ipywidgets/pull/2816), [#2794](https://github.com/jupyter-widgets/ipywidgets/issues/2794))
* Update jlab manager readme for 2.0 ([#2815](https://github.com/jupyter-widgets/ipywidgets/pull/2815))
* Fix eslint warnings ([#2808](https://github.com/jupyter-widgets/ipywidgets/pull/2808))
* Change css variable names to match lab ([#2801](https://github.com/jupyter-widgets/ipywidgets/pull/2801), [#2062](https://github.com/jupyter-widgets/ipywidgets/issues/2062))
* Docs: add warning concerning the fileupload widget ([#2799](https://github.com/jupyter-widgets/ipywidgets/pull/2799))
* Use data-jupyter-widgets-cdn-only attribute to load modules only from cdn ([#2792](https://github.com/jupyter-widgets/ipywidgets/pull/2792), [#2786](https://github.com/jupyter-widgets/ipywidgets/issues/2786))
* Updating documentation for widget 'button'. ([#2780](https://github.com/jupyter-widgets/ipywidgets/pull/2780))
* Fix misnamed attribute in _multipleselection ([#2775](https://github.com/jupyter-widgets/ipywidgets/pull/2775))
* Fix typo in documentation dev docs ([#2773](https://github.com/jupyter-widgets/ipywidgets/pull/2773))
* Update the docs for building the documentation ([#2769](https://github.com/jupyter-widgets/ipywidgets/pull/2769))
* Change upload value to contain python types ([#2767](https://github.com/jupyter-widgets/ipywidgets/pull/2767))
* Borders independently: `border_top`, `border_right`, `border_bottom`, `border_left` ([#2757](https://github.com/jupyter-widgets/ipywidgets/pull/2757))
* Tests and tidy file upload ([#2753](https://github.com/jupyter-widgets/ipywidgets/pull/2753))
* Delete display_model and display_view ([#2752](https://github.com/jupyter-widgets/ipywidgets/pull/2752), [#2751](https://github.com/jupyter-widgets/ipywidgets/issues/2751))
* Make selection container titles a tuple of strings ([#2746](https://github.com/jupyter-widgets/ipywidgets/pull/2746))
* Consolidate test github actions into a single file ([#2745](https://github.com/jupyter-widgets/ipywidgets/pull/2745))
* Drop underscore usage ([#2742](https://github.com/jupyter-widgets/ipywidgets/pull/2742))
* Prettier quotes for windows ([#2737](https://github.com/jupyter-widgets/ipywidgets/pull/2737))
* Adding examples to the example doc how to change the size of the dropdown/radiobuttons ([#2735](https://github.com/jupyter-widgets/ipywidgets/pull/2735))
* Format files with prettier ([#2734](https://github.com/jupyter-widgets/ipywidgets/pull/2734))
* Update the prettier configuration ([#2733](https://github.com/jupyter-widgets/ipywidgets/pull/2733))
* Upgrade to es2017 javascript ([#2725](https://github.com/jupyter-widgets/ipywidgets/pull/2725))
* Consolidate fileupload value by using a single top-level dict ([#2724](https://github.com/jupyter-widgets/ipywidgets/pull/2724))
* Change media widgets to use memory views. ([#2723](https://github.com/jupyter-widgets/ipywidgets/pull/2723))
* Avoid unnecessary copies in snippets for file upload ([#2722](https://github.com/jupyter-widgets/ipywidgets/pull/2722))
* Fix call to readout_overflow for sliders ([#2718](https://github.com/jupyter-widgets/ipywidgets/pull/2718))
* Install test extras_require in dev_install ([#2717](https://github.com/jupyter-widgets/ipywidgets/pull/2717))
* Update file upload widget documentation ([#2714](https://github.com/jupyter-widgets/ipywidgets/pull/2714))
* Upgrade font-awesome in html-manager ([#2713](https://github.com/jupyter-widgets/ipywidgets/pull/2713))
* Nouislider implementation ([#2712](https://github.com/jupyter-widgets/ipywidgets/pull/2712), [#630](https://github.com/jupyter-widgets/ipywidgets/issues/630))
* Split base manager into separate packages ([#2710](https://github.com/jupyter-widgets/ipywidgets/pull/2710), [#2561](https://github.com/jupyter-widgets/ipywidgets/issues/2561))
* Clean up ts project references ([#2709](https://github.com/jupyter-widgets/ipywidgets/pull/2709))
* Switch installing documentation dependencies to pip ([#2708](https://github.com/jupyter-widgets/ipywidgets/pull/2708))
* Auto-types ([#2707](https://github.com/jupyter-widgets/ipywidgets/pull/2707))
* Make doc readme link point to stable ([#2705](https://github.com/jupyter-widgets/ipywidgets/pull/2705))
* Fix widget list notebook syntax ([#2704](https://github.com/jupyter-widgets/ipywidgets/pull/2704), [#2702](https://github.com/jupyter-widgets/ipywidgets/issues/2702))
* Remove the pause button from the play widget ([#2703](https://github.com/jupyter-widgets/ipywidgets/pull/2703), [#2671](https://github.com/jupyter-widgets/ipywidgets/issues/2671))
* Eslint enhancements ([#2700](https://github.com/jupyter-widgets/ipywidgets/pull/2700))
* Prevent npm install, yarn install should be used ([#2699](https://github.com/jupyter-widgets/ipywidgets/pull/2699))
* Fix lint errors ([#2697](https://github.com/jupyter-widgets/ipywidgets/pull/2697))
* Remove deprecated decorator ([#2695](https://github.com/jupyter-widgets/ipywidgets/pull/2695))
* Remove deprecated alias ([#2694](https://github.com/jupyter-widgets/ipywidgets/pull/2694))
* Tabs -> spaces ([#2693](https://github.com/jupyter-widgets/ipywidgets/pull/2693))
* Fix focus() for checkbox ([#2692](https://github.com/jupyter-widgets/ipywidgets/pull/2692))
* Focus/blur on a radiobuttons widget. ([#2691](https://github.com/jupyter-widgets/ipywidgets/pull/2691))
* Fix focus() for select. ([#2690](https://github.com/jupyter-widgets/ipywidgets/pull/2690))
* Remove deprecated overflow properties ([#2688](https://github.com/jupyter-widgets/ipywidgets/pull/2688))
* Simplify calls to ipython api ([#2687](https://github.com/jupyter-widgets/ipywidgets/pull/2687))
* Build docs consistently on python 3.7 ([#2686](https://github.com/jupyter-widgets/ipywidgets/pull/2686))
* Fix regression on spinning icons ([#2685](https://github.com/jupyter-widgets/ipywidgets/pull/2685), [#2477](https://github.com/jupyter-widgets/ipywidgets/issues/2477))
* Update dependencies to jupyterlab 2.0b2 packages ([#2683](https://github.com/jupyter-widgets/ipywidgets/pull/2683))
* Change phosphor to lumino ([#2681](https://github.com/jupyter-widgets/ipywidgets/pull/2681))
* Tooltips everywhere ([#2680](https://github.com/jupyter-widgets/ipywidgets/pull/2680))
* Drop support for mapping types as selection options ([#2679](https://github.com/jupyter-widgets/ipywidgets/pull/2679), [#1958](https://github.com/jupyter-widgets/ipywidgets/issues/1958))
* Added sections on debouncing and throttling ([#2678](https://github.com/jupyter-widgets/ipywidgets/pull/2678))
* Remove notebook specific custom widget tutorial ([#2677](https://github.com/jupyter-widgets/ipywidgets/pull/2677), [#2379](https://github.com/jupyter-widgets/ipywidgets/issues/2379))
* Add link to the typescript cookiecutter in the low level docs ([#2675](https://github.com/jupyter-widgets/ipywidgets/pull/2675))
* Add play widget interval to the widget list docs ([#2674](https://github.com/jupyter-widgets/ipywidgets/pull/2674))
* Remove last travis test ([#2673](https://github.com/jupyter-widgets/ipywidgets/pull/2673))
* Minor docs updates ([#2669](https://github.com/jupyter-widgets/ipywidgets/pull/2669), [#2629](https://github.com/jupyter-widgets/ipywidgets/issues/2629), [#2625](https://github.com/jupyter-widgets/ipywidgets/issues/2625), [#1747](https://github.com/jupyter-widgets/ipywidgets/issues/1747))
* Delete travis tests that are duplicated by github actions. ([#2668](https://github.com/jupyter-widgets/ipywidgets/pull/2668))
* Fix upload widget counter value ([#2666](https://github.com/jupyter-widgets/ipywidgets/pull/2666), [#2480](https://github.com/jupyter-widgets/ipywidgets/issues/2480))
* Focus or blur a widget. ([#2664](https://github.com/jupyter-widgets/ipywidgets/pull/2664))
* Widgetmanagerbase: improve create_view return type ([#2662](https://github.com/jupyter-widgets/ipywidgets/pull/2662))
* Doc: add thread.join() in output example ([#2661](https://github.com/jupyter-widgets/ipywidgets/pull/2661))
* Doc: clean up settings ([#2660](https://github.com/jupyter-widgets/ipywidgets/pull/2660))
* Move to eslint and prettier ([#2657](https://github.com/jupyter-widgets/ipywidgets/pull/2657))
* Initial github action configuration ([#2656](https://github.com/jupyter-widgets/ipywidgets/pull/2656))
* Remove some more py3-related warnings and deprecations ([#2655](https://github.com/jupyter-widgets/ipywidgets/pull/2655))
* Package upgrades ([#2654](https://github.com/jupyter-widgets/ipywidgets/pull/2654))
* Tabbable or not tabbable ([#2640](https://github.com/jupyter-widgets/ipywidgets/pull/2640))
* Add comments specifying valid values for `icon` for `button` and `togglebutton` ([#2616](https://github.com/jupyter-widgets/ipywidgets/pull/2616))
* Tagsinput widget ([#2591](https://github.com/jupyter-widgets/ipywidgets/pull/2591))
* Drop notebook dependency from widgetsnbextension ([#2590](https://github.com/jupyter-widgets/ipywidgets/pull/2590))
* Replace print statement with output widget ([#2566](https://github.com/jupyter-widgets/ipywidgets/pull/2566))
* Drop support for legacy python 2.7 and eol 3.4 ([#2558](https://github.com/jupyter-widgets/ipywidgets/pull/2558))
* Fix documentation and add more helpful error message for interact usage ([#2544](https://github.com/jupyter-widgets/ipywidgets/pull/2544))
* Labmanager refactor ([#2532](https://github.com/jupyter-widgets/ipywidgets/pull/2532))
* Make more of lab manager dependencies optional ([#2528](https://github.com/jupyter-widgets/ipywidgets/pull/2528))
* Remove class `jupyter-widgets` from jp-outputarea-output node ([#2500](https://github.com/jupyter-widgets/ipywidgets/pull/2500))
* Cast 'value' in range sliders to a tuple ([#2441](https://github.com/jupyter-widgets/ipywidgets/pull/2441))
* Added a layout widget for 'stacked' layout ([#2376](https://github.com/jupyter-widgets/ipywidgets/pull/2376))
* Play widget: expose playing and repeat  ([#2283](https://github.com/jupyter-widgets/ipywidgets/pull/2283), [#1897](https://github.com/jupyter-widgets/ipywidgets/issues/1897))
* Fixed checkbox docs, issue #1758 ([#2267](https://github.com/jupyter-widgets/ipywidgets/pull/2267))
*  issue  #1979: add generation of json for widget specs which is then used to create md. ([#2193](https://github.com/jupyter-widgets/ipywidgets/pull/2193))
* Use _repr_mimebundle_ and require ipython 6.1 or later. ([#2021](https://github.com/jupyter-widgets/ipywidgets/pull/2021), [#1811](https://github.com/jupyter-widgets/ipywidgets/issues/1811))
* Fix selection container default index ([#1823](https://github.com/jupyter-widgets/ipywidgets/pull/1823))
* Typings improvement ([#1734](https://github.com/jupyter-widgets/ipywidgets/pull/1734))


```
</details>