### PR TITLE
Drop python 3.5 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -128,7 +128,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.6
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip

--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,10 @@ setup_args = dict(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Framework :: Jupyter'
     ],
@@ -88,7 +89,7 @@ setup_args = dict(
         'build_py': build_py,
         'sdist': sdist,
     },
-    python_requires = '>=3.5',
+    python_requires = '>=3.6',
 )
 
 if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
@@ -107,10 +108,10 @@ install_requires = setuptools_args['install_requires'] = [
     # interpreter, to allow ipywidgets to be
     # installed on bare kernels.
     'widgetsnbextension~=4.0a0',
+    'jupyterlab_widgets~=2.0a0'
 ]
 
 extras_require = setuptools_args['extras_require'] = {
-    ':python_version>="3.6"': ['jupyterlab_widgets~=2.0a0'],
     'test': ['pytest>=3.6.0', 'pytest-cov'],
 }
 

--- a/widgetsnbextension/setup.py
+++ b/widgetsnbextension/setup.py
@@ -34,12 +34,6 @@ instructions.
 
 import sys
 
-v = sys.version_info
-if v[:2] < (3, 5):
-    error = "ERROR: %s requires Python version 3.5 or above." % name
-    print(error, file=sys.stderr)
-    sys.exit(1)
-
 #-----------------------------------------------------------------------------
 # get on with it
 #-----------------------------------------------------------------------------
@@ -204,6 +198,7 @@ setup_args = dict(
     ],
     zip_safe=False,
     include_package_data = True,
+    python_requires = '>=3.6'
 )
 
 if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):


### PR DESCRIPTION
As @willingc said in https://github.com/jupyter-widgets/ipywidgets/pull/3120#issuecomment-779353535: “Version 8.0 of widgets should drop 3.5 as it has reached [End-of-Life](https://devguide.python.org/#status-of-python-branches) and lacks good support for async and does not have f-strings.”