### PR TITLE
Add handle_color style key to SelectionSlider

### DIFF
--- a/ipywidgets/widgets/widget_selection.py
+++ b/ipywidgets/widgets/widget_selection.py
@@ -15,6 +15,7 @@ from .widget_core import CoreWidget
 from .widget_style import Style
 from .trait_types import InstanceDict, TypedTuple
 from .widget import register, widget_serialization
+from .widget_int import SliderStyle
 from .docutils import doc_subst
 from traitlets import (Unicode, Bool, Int, Any, Dict, TraitError, CaselessStrEnum,
                        Tuple, Union, observe, validate)
@@ -573,6 +574,9 @@ class SelectionSlider(_SelectionNonempty):
     continuous_update = Bool(True,
         help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
 
+    style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)
+
+
 @register
 @doc_subst(_doc_snippets)
 class SelectionRangeSlider(_MultipleSelectionNonempty):
@@ -621,3 +625,5 @@ class SelectionRangeSlider(_MultipleSelectionNonempty):
         help="Display the current selected label next to the slider").tag(sync=True)
     continuous_update = Bool(True,
         help="Update the value of the widget as the user is holding the slider.").tag(sync=True)
+
+    style = InstanceDict(SliderStyle).tag(sync=True, **widget_serialization)

--- a/packages/schema/jupyterwidgetmodels.latest.json
+++ b/packages/schema/jupyterwidgetmodels.latest.json
@@ -5068,7 +5068,7 @@
         "help": "Styling customizations",
         "name": "style",
         "type": "reference",
-        "widget": "DescriptionStyle"
+        "widget": "SliderStyle"
       },
       {
         "allow_none": true,
@@ -5201,7 +5201,7 @@
         "help": "Styling customizations",
         "name": "style",
         "type": "reference",
-        "widget": "DescriptionStyle"
+        "widget": "SliderStyle"
       },
       {
         "allow_none": true,

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -972,7 +972,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `readout`        | boolean          | `true`           | Display the current selected label next to the slider
-`style`          | reference to SliderStyle widget | reference to new instance | 
+`style`          | reference to SliderStyle widget | reference to new instance | Styling customizations
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
 
@@ -995,7 +995,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `readout`        | boolean          | `true`           | Display the current selected label next to the slider
-`style`          | reference to SliderStyle widget | reference to new instance | 
+`style`          | reference to SliderStyle widget | reference to new instance | Styling customizations
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
 

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -972,7 +972,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `readout`        | boolean          | `true`           | Display the current selected label next to the slider
-`style`          | reference to SliderStyle widget | reference to new instance | Styling customizations
+`style`          | reference to SliderStyle widget | reference to new instance | 
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
 
@@ -995,7 +995,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `readout`        | boolean          | `true`           | Display the current selected label next to the slider
-`style`          | reference to SliderStyle widget | reference to new instance | Styling customizations
+`style`          | reference to SliderStyle widget | reference to new instance | 
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
 

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -972,7 +972,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `readout`        | boolean          | `true`           | Display the current selected label next to the slider
-`style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`style`          | reference to SliderStyle widget | reference to new instance | 
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
 
@@ -995,7 +995,7 @@ Attribute        | Type             | Default          | Help
 `layout`         | reference to Layout widget | reference to new instance | 
 `orientation`    | string (one of `'horizontal'`, `'vertical'`) | `'horizontal'`   | Vertical or horizontal.
 `readout`        | boolean          | `true`           | Display the current selected label next to the slider
-`style`          | reference to DescriptionStyle widget | reference to new instance | Styling customizations
+`style`          | reference to SliderStyle widget | reference to new instance | 
 `tabbable`       | `null` or boolean | `null`           | Is widget tabbable?
 `tooltip`        | `null` or string | `null`           | A tooltip caption.
 


### PR DESCRIPTION
The SelectionSlider widget has a very similar interface to the FloatSlider and IntSlider, but is missing the handle_color style.  This adds it.  Seems to work for me, but I'm not super familiar with UI coding and don't know how to write tests for this.  I don't see tests for this feature implemented similarly on the FloatSlider.  If this needs a test, please point me to a test for something similar and I can probably figure it out.  Thanks!