### PR TITLE
Add a binder link to the top of notebooks in the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,6 +29,27 @@ intersphinx_mapping = {
     'jupyter': ('https://jupyter.readthedocs.io/en/latest/', None),
 }
 
+
+# prolog taken nearly verbatim from https://github.com/spatialaudio/nbsphinx/blob/98005a9d6b331b7d6d14221539154df69f7ae51a/doc/conf.py#L38
+nbsphinx_prolog = r"""
+{% set docname = env.doc2path(env.docname, base=None) %}
+
+.. raw:: html
+
+    <div class="admonition note">
+      This page was generated from
+      <a class="reference external" href="https://github.com/jupyter-widgets/ipywidgets/blob/{{ env.config.release|e }}/{{ docname|e }}">{{ docname|e }}</a>.
+      Interactive online version:
+      <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/{{ env.config.release|e }}?filepath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.</span>
+    </div>
+
+.. raw:: latex
+
+    \nbsphinxstartnotebook{\scriptsize\noindent\strut
+    \textcolor{gray}{The following section was generated from
+    \sphinxcode{\sphinxupquote{\strut {{ docname | escape_latex }}}} \dotfill}}
+"""
+
 nbsphinx_execute = 'always'
 
 # -- General information -------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ intersphinx_mapping = {
 }
 
 
-# prolog taken based on https://github.com/spatialaudio/nbsphinx/blob/98005a9d6b331b7d6d14221539154df69f7ae51a/doc/conf.py#L38
+# prolog based on https://github.com/spatialaudio/nbsphinx/blob/98005a9d6b331b7d6d14221539154df69f7ae51a/doc/conf.py#L38
 nbsphinx_prolog = r"""
 {% set docname_link = env.doc2path(env.docname, base=None).replace(' ', '%20') %}
 {% set docname_display = env.doc2path(env.docname, base=None) %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,17 +30,18 @@ intersphinx_mapping = {
 }
 
 
-# prolog taken nearly verbatim from https://github.com/spatialaudio/nbsphinx/blob/98005a9d6b331b7d6d14221539154df69f7ae51a/doc/conf.py#L38
+# prolog taken based on https://github.com/spatialaudio/nbsphinx/blob/98005a9d6b331b7d6d14221539154df69f7ae51a/doc/conf.py#L38
 nbsphinx_prolog = r"""
-{% set docname = env.doc2path(env.docname, base=None) %}
+{% set docname_link = env.doc2path(env.docname, base=None).replace(' ', '%20') %}
+{% set docname_display = env.doc2path(env.docname, base=None) %}
 
 .. raw:: html
 
     <div class="admonition note">
       This page was generated from
-      <a class="reference external" href="https://github.com/jupyter-widgets/ipywidgets/blob/{{ env.config.release|e }}/{{ docname|e }}">{{ docname|e }}</a>.
+      <a class="reference external" href="https://github.com/jupyter-widgets/ipywidgets/blob/{{ env.config.release|e }}/docs/source/{{ docname_link|e }}">{{ docname_display|e }}</a>.<br>
       Interactive online version:
-      <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/{{ env.config.release|e }}?filepath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.</span>
+      <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/{{ env.config.release|e }}?urlpath=lab/tree/docs/source/{{ docname_link|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.</span>
     </div>
 
 .. raw:: latex


### PR DESCRIPTION
Closes: https://github.com/jupyter-widgets/ipywidgets/issues/3083


Following: https://github.com/spatialaudio/nbsphinx/blob/98005a9d6b331b7d6d14221539154df69f7ae51a/doc/conf.py#L38

Example on this page:
https://nbsphinx.readthedocs.io/en/0.8.2/prolog-and-epilog.html