### PR TITLE
Export LabWidgetManager and KernelWidgetManager

### DIFF
--- a/jupyterlab_widgets/src/index.ts
+++ b/jupyterlab_widgets/src/index.ts
@@ -8,7 +8,11 @@ export default WidgetManagerProvider;
 
 export { registerWidgetManager } from './plugin';
 
-export { WidgetManager } from './manager';
+export {
+  KernelWidgetManager,
+  LabWidgetManager,
+  WidgetManager
+} from './manager';
 
 export { WidgetRenderer } from './renderer';
 


### PR DESCRIPTION
This is a proposal to export the `LabWidgetManager` and `KernelWidgetManager` from the `@jupyter-widgets/jupyterlab-manager` package.

This will let third-party packages and extensions import these managers with:

```typescript
import { KernelWidgetManager, LabWidgetManager } from '@jupyter-widgets/jupyterlab-manager';
```

Instead of:

```typescript
import { KernelWidgetManager, LabWidgetManager } from '@jupyter-widgets/jupyterlab-manager/lib/manager';
```

This would be useful to other applications that would like to reuse the widget managers as is, or extend their functionalities by subclassing them. See https://github.com/voila-dashboards/voila/pull/846 for a work-in-progress example. 

Opening this PR as a way to discuss whether or not we should do this, since exposing new classes increases the API surface.