### PR TITLE
Unpin ipykernel<6 for the docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 bqplot
-ipykernel<6
+ipykernel
 jupyter_client
 matplotlib
 nbsphinx>=0.5


### PR DESCRIPTION
Follow-up to https://github.com/jupyter-widgets/ipywidgets/pull/3155 to see if the new `6.0.0a1` release would fix the issue reported in https://github.com/jupyter-widgets/ipywidgets/issues/3154.

Reverts back to how it was before the pin added in https://github.com/jupyter-widgets/ipywidgets/pull/3155