### PR TITLE
fix: [Widget Image] Remove oldurl string check since it's always a string and prevent the ObjectURL cleaning resulting in a memory leak.

### DIFF
--- a/packages/controls/src/widget_audio.ts
+++ b/packages/controls/src/widget_audio.ts
@@ -62,8 +62,9 @@ export class AudioView extends DOMWidgetView {
     // Clean up the old objectURL
     const oldurl = this.el.src;
     this.el.src = url;
-
-    URL.revokeObjectURL(oldurl);
+    if (oldurl) {
+      URL.revokeObjectURL(oldurl);
+    }
 
     // Audio attributes
     this.el.loop = this.model.get('loop');

--- a/packages/controls/src/widget_audio.ts
+++ b/packages/controls/src/widget_audio.ts
@@ -62,9 +62,8 @@ export class AudioView extends DOMWidgetView {
     // Clean up the old objectURL
     const oldurl = this.el.src;
     this.el.src = url;
-    if (oldurl && typeof oldurl !== 'string') {
-      URL.revokeObjectURL(oldurl);
-    }
+
+    URL.revokeObjectURL(oldurl);
 
     // Audio attributes
     this.el.loop = this.model.get('loop');

--- a/packages/controls/src/widget_image.ts
+++ b/packages/controls/src/widget_image.ts
@@ -62,8 +62,9 @@ export class ImageView extends DOMWidgetView {
     // Clean up the old objectURL
     const oldurl = this.el.src;
     this.el.src = url;
-
-    URL.revokeObjectURL(oldurl);
+    if (oldurl) {
+      URL.revokeObjectURL(oldurl);
+    }
 
     const width = this.model.get('width');
     if (width !== undefined && width.length > 0) {

--- a/packages/controls/src/widget_image.ts
+++ b/packages/controls/src/widget_image.ts
@@ -62,9 +62,9 @@ export class ImageView extends DOMWidgetView {
     // Clean up the old objectURL
     const oldurl = this.el.src;
     this.el.src = url;
-    if (oldurl) {
-      URL.revokeObjectURL(oldurl);
-    }
+
+    URL.revokeObjectURL(oldurl);
+
     const width = this.model.get('width');
     if (width !== undefined && width.length > 0) {
       this.el.setAttribute('width', width);

--- a/packages/controls/src/widget_image.ts
+++ b/packages/controls/src/widget_image.ts
@@ -62,7 +62,7 @@ export class ImageView extends DOMWidgetView {
     // Clean up the old objectURL
     const oldurl = this.el.src;
     this.el.src = url;
-    if (oldurl && typeof oldurl !== 'string') {
+    if (oldurl) {
       URL.revokeObjectURL(oldurl);
     }
     const width = this.model.get('width');

--- a/packages/controls/src/widget_video.ts
+++ b/packages/controls/src/widget_video.ts
@@ -65,9 +65,8 @@ export class VideoView extends DOMWidgetView {
     // Clean up the old objectURL
     const oldurl = this.el.src;
     this.el.src = url;
-    if (oldurl && typeof oldurl !== 'string') {
-      URL.revokeObjectURL(oldurl);
-    }
+
+    URL.revokeObjectURL(oldurl);
 
     // Height and width
     const width = this.model.get('width');

--- a/packages/controls/src/widget_video.ts
+++ b/packages/controls/src/widget_video.ts
@@ -65,8 +65,9 @@ export class VideoView extends DOMWidgetView {
     // Clean up the old objectURL
     const oldurl = this.el.src;
     this.el.src = url;
-
-    URL.revokeObjectURL(oldurl);
+    if (oldurl) {
+      URL.revokeObjectURL(oldurl);
+    }
 
     // Height and width
     const width = this.model.get('width');


### PR DESCRIPTION
See #3170 