### PR TITLE
Fix the use of _active_widgets in Widget.close_all()

### DIFF
--- a/ipywidgets/widgets/tests/test_widget.py
+++ b/ipywidgets/widgets/tests/test_widget.py
@@ -49,6 +49,8 @@ def test_close_all():
     # create a couple of widgets
     widgets = [Button() for i in range(10)]
 
+    assert len(Widget._active_widgets) > 0, "expect active widgets"
+
     # close all the widgets
     Widget.close_all()
 

--- a/ipywidgets/widgets/tests/test_widget.py
+++ b/ipywidgets/widgets/tests/test_widget.py
@@ -43,3 +43,13 @@ def test_widget_view():
     assert 'application/vnd.jupyter.widget-view+json' in mime_bundle, "widget should have have a view"
     assert cap.stdout == '', repr(cap.stdout)
     assert cap.stderr == '', repr(cap.stderr)
+
+
+def test_close_all():
+    # create a couple of widgets
+    widgets = [Button() for i in range(10)]
+
+    # close all the widgets
+    Widget.close_all()
+
+    assert len(Widget._active_widgets) == 0, "active widgets should be cleared"

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -271,7 +271,7 @@ class Widget(LoggingHasTraits):
 
     @classmethod
     def close_all(cls):
-        for widget in list(cls.widgets.values()):
+        for widget in list(cls._active_widgets.values()):
             widget.close()
 
 


### PR DESCRIPTION
This was spotted while rebasing https://github.com/jupyter-widgets/ipywidgets/pull/2765, and is a follow-up to https://github.com/jupyter-widgets/ipywidgets/pull/3122.

![image](https://user-images.githubusercontent.com/591645/112676449-ba673100-8e68-11eb-8a90-bfe36a39f245.png)

