### PR TITLE
Allow generate-spec to take optional output file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,7 @@ jobs:
         pip install file://$PWD#egg=ipywidgets
     - name: Compare spec with latest version
       run: |
-        python ./packages/schema/generate-spec.py -f markdown > spec.md
+        python ./packages/schema/generate-spec.py -f markdown spec.md
         diff -u ./packages/schema/jupyterwidgetmodels.latest.md ./spec.md
   ui-test:
     name: Visual Regression

--- a/docs/source/dev_install.md
+++ b/docs/source/dev_install.md
@@ -75,8 +75,8 @@ Updating widget model specification
 
 To update the widget model specification with changes, do something like this in the repo root:
 ```
-python ./packages/schema/generate-spec.py -f json-pretty > packages/schema/jupyterwidgetmodels.latest.json
-python ./packages/schema/generate-spec.py -f markdown > packages/schema/jupyterwidgetmodels.latest.md
+python ./packages/schema/generate-spec.py -f json-pretty packages/schema/jupyterwidgetmodels.latest.json
+python ./packages/schema/generate-spec.py -f markdown packages/schema/jupyterwidgetmodels.latest.md
 ```
 
 Releasing new versions

--- a/docs/source/dev_release.md
+++ b/docs/source/dev_release.md
@@ -28,8 +28,8 @@ First, update the relevant model specification versions. For example, the commit
 
 Next, regenerate the model spec with the new version numbers by doing something like this in the repository root directory:
 ```
-python ./packages/schema/generate-spec.py -f json-pretty > packages/schema/jupyterwidgetmodels.latest.json
-python ./packages/schema/generate-spec.py -f markdown > packages/schema/jupyterwidgetmodels.latest.md
+python ./packages/schema/generate-spec.py -f json-pretty packages/schema/jupyterwidgetmodels.latest.json
+python ./packages/schema/generate-spec.py -f markdown packages/schema/jupyterwidgetmodels.latest.md
 ```
 
 Copy `packages/schema/jupyterwidgetmodels.latest.md` to an appropriately-named

--- a/ipywidgets/widgets/widget_link.py
+++ b/ipywidgets/widgets/widget_link.py
@@ -19,6 +19,12 @@ class WidgetTraitTuple(Tuple):
 
     def __init__(self, **kwargs):
         super().__init__(Instance(Widget), Unicode(), **kwargs)
+        if "default_value" not in kwargs and not kwargs.get("allow_none", False):
+            # This is to keep consistent behavior for spec generation between traitlets 4 and 5
+            # Having a default empty container is explicitly not allowed in traitlets 5 when
+            # there are traits specified (as the default value will be invalid), but we do it
+            # anyway as there is no empty "default" that makes sense.
+            self.default_args = ()
 
     def validate_elements(self, obj, value):
         value = super().validate_elements(obj, value)

--- a/packages/schema/generate-spec.py
+++ b/packages/schema/generate-spec.py
@@ -237,14 +237,15 @@ if __name__ == '__main__':
     args = parser.parse_args()
     format = args.format
 
+    widgets_to_document = sorted(widgets.Widget._widget_types.items())
+    spec = create_spec(widgets_to_document)
+
     if args.output:
         args.output.parent.mkdir(exist_ok=True)
         output = open(args.output, mode='w', encoding='utf8')
     else:
         output = sys.stdout
 
-    widgets_to_document = sorted(widgets.Widget._widget_types.items())
-    spec = create_spec(widgets_to_document)
     try:
         if format == 'json':
             try:


### PR DESCRIPTION
When piping output from a command into a file on the terminal, you might end up with interesting encodings, e.g. in Powershell on Windows you get UTF16 (which git treats as binary files).

C.f. https://github.com/jupyter-widgets/ipywidgets/pull/2715#issuecomment-806940523