### PR TITLE
Add write permissions to the Binder badge workflow

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  pull-requests:
+    write
+
 jobs:
   binder:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix the permission of the Binder badge workflow so it can post the PR comment. Related to the recent GitHub changes on permission workflows. 

Example PR where it failed: https://github.com/jupyter-widgets/ipywidgets/pull/3211