### PR TITLE
Create and upload reference screenshots on CI failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,9 +213,21 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: ui-test-output
+        name: ipywidgets-ui-test-output
         path: |
           ui-tests/test-output
+    - name: Run UI Tests
+      if: ${{ failure() }}
+      run: |
+        cd ui-tests
+        jlpm run test:create-references
+    - name: Upload UI Test new reference artifacts
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: ipywidgets-ui-test-new-reference
+        path: |
+          ui-tests/test-output/test/screenshots/*.png
 
       env:
         CI: true

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start-jlab": "jupyter lab --config ./jupyter_server_config.py",
     "start-jlab:detached": "yarn run start-jlab&",
+    "test:create-references": "galata --skip-visual-regression --skip-html-regression",
     "test": "galata"
   },
   "author": "Project Jupyter",

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -12,6 +12,6 @@
   "author": "Project Jupyter",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@jupyterlab/galata": "3.0.3-3"
+    "@jupyterlab/galata": "3.0.11-2"
   }
 }

--- a/ui-tests/yarn.lock
+++ b/ui-tests/yarn.lock
@@ -473,10 +473,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@jupyterlab/galata@3.0.3-3":
-  version "3.0.3-3"
-  resolved "https://registry.npmjs.org/@jupyterlab/galata/-/galata-3.0.3-3.tgz#02bc90897e139eff0773dbab2689c621f4a5b8da"
-  integrity sha512-g334GMDQdSlIOngfWLW9GR8ENc9Kegu3OkCrYPdheE2lYJJsgeiO+3n7lg4Iar5b8LtQTu9P0by3IhEFRtEATA==
+"@jupyterlab/galata@3.0.11-2":
+  version "3.0.11-2"
+  resolved "https://registry.npmjs.org/@jupyterlab/galata/-/galata-3.0.11-2.tgz#eeaf1a571a744718d664df7a3decc40907405bdc"
+  integrity sha512-i8jBhL0JUezAZ0Apa56Gy7lH6K0uuYhlkVwY0AYfrMJJw8ILLnd8yunt7QXAPto0m+QC3ud4VZ82KYck4W9+3w==
   dependencies:
     "@types/dateformat" "^3.0.1"
     "@types/jest" "^25.1.2"
@@ -484,7 +484,8 @@
     "@types/node" "^13.1.1"
     "@types/pixelmatch" "^5.0.0"
     "@types/pngjs" "^3.4.1"
-    ansi_up "^4.0.4"
+    "@yarnpkg/lockfile" "^1.1.0"
+    ansi_up "^5.0.0"
     axios "^0.21.1"
     chalk "^4.0.0"
     cross-spawn "^6.0.5"
@@ -654,6 +655,11 @@
   dependencies:
     "@types/node" "*"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.0:
   version "2.0.5"
   resolved "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -735,10 +741,10 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi_up@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.npmjs.org/ansi_up/-/ansi_up-4.0.4.tgz#5b8c35f0b02e4476f3f18cf89c3bf48d15d054f6"
-  integrity sha512-vRxC8q6QY918MbehO869biJW4tiunJdjOhi5fpY6NLOliBQlZhOkKgABJKJqH+JZfb/WfjvjN1chLWI6tODerw==
+ansi_up@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/ansi_up/-/ansi_up-5.0.1.tgz#b66839dba408d3d2f8548904f1ae6fc62d6917ef"
+  integrity sha512-HGOTjFQECRKZM9fIlGhJfR2pcK8PMUWzFOqcPwqBEnNIa4P2r0Di+g2hxCX0hL0n1NUtAHGRA+fUyA/OajZYFw==
 
 anymatch@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
So the new reference screenshots can be retrieved from the GitHub Actions artifacts and updated if needed.