### PR TITLE
Automatically close answered issues

### DIFF
--- a/.github/workflows/answered.yml
+++ b/.github/workflows/answered.yml
@@ -1,0 +1,20 @@
+# This action automatically schedules issues to be closed that have been
+# labeled as answered if there is no activity on them for 30 days. This takes
+# care of the common usecase of an issue being answered to the best of our
+# ability and no other follow-up from the submitter.
+name: 'Close answered issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          skip-stale-issue-message: true
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: 'closing as answered'
+          only-issue-labels: 'answered'


### PR DESCRIPTION
Often we’ll have a question which we answer to the best of our ability, and doesn’t look like it needs further follow-up. Sometimes the original author does not close the issue and also never responds. This builds up a lot of open issues that essentially have been answered or resolved. This workflow gives us a way to signal that a question is answered and will be automatically closed as answered unless there is further followup.

The configuration here is, for any issue with the ‘answered’ label, wait until there are 30 days of no activity, then apply the ‘closing as answered’ label for 7 days, then close the issue if there is still no further activity. A triage person can also directly assign the ‘closing as answered’ label to shortcut directly to the 7-day waiting period before closing.