### PR TITLE
Add the ability to fully specify CDNs for loaded libraries

### DIFF
--- a/packages/html-manager/src/libembed-amd.ts
+++ b/packages/html-manager/src/libembed-amd.ts
@@ -96,12 +96,21 @@ export function requireLoader(
   if (onlyCDN) {
     return loadFromCDN();
   }
-  return requirePromise([`${moduleName}`]).catch((err) => {
+  return requirePromise([`${moduleName}`])
+  .then((ret) => {
+    // TODO: get current directory and print?
+    console.log(`Successfully loaded ${moduleName} from current directory`);
+    return ret;
+  })
+  .catch((err) => {
     const failedId = err.requireModules && err.requireModules[0];
     if (failedId) {
       require.undef(failedId);
       return loadFromCDN();
     }
+  })
+  .catch((err) => {
+    console.warn(`Unable to load module ${moduleName}.`, err)
   });
 }
 


### PR DESCRIPTION
This PR adds the ability to pass full URLs to resolve modules that we're loading in.

TODO: add documentation to say how to use the feature, e.g. add in html: <script data-jupyter-widgets-module-cdn="bqplot, XXX/share/jupyter/nbextensions/bqplot/index.js"></script>

TODO: figure out if we want to read `data-jupyter-widgets-module-cdn` first and if it can't be resolved check if the module is present locally (right now it does the opposite, i.e. checks if the module is present in the current directory first)