### PR TITLE
[7.x] Add the explicit dependency on ipython_genutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'ipykernel>=4.5.1',
+    'ipython_genutils~=0.2.0',
     'traitlets>=4.3.1',
     # Requiring nbformat to specify bugfix version which is not required by
     # notebook.


### PR DESCRIPTION
This was first noticed in https://github.com/jupyterlite/jupyterlite/issues/311 when installing `ipywidgets` in JupyterLite with `micropip`.

Since we use `ipython_genutils` in several places on the `7.x` branch like here:

https://github.com/jupyter-widgets/ipywidgets/blob/08093b0c5db3e10ce1b91389fcbee39a49b2e66e/ipywidgets/widgets/widget.py#L22

We should add it as an explicit dependency.

Similar to:

- https://github.com/ipython/ipykernel/issues/755
- https://github.com/ipython/ipykernel/pull/756

cc @martinRenou 