### PR TITLE
Add new trove classifiers for JLab extensions

### DIFF
--- a/jupyterlab_widgets/setup.cfg
+++ b/jupyterlab_widgets/setup.cfg
@@ -24,6 +24,10 @@ classifiers =
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3 :: Only
   Framework :: Jupyter
+  Framework :: Jupyter :: JupyterLab
+  Framework :: Jupyter :: JupyterLab :: 3
+  Framework :: Jupyter :: JupyterLab :: Extensions
+  Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt
 
 [options]
 python_requires = >=3.6


### PR DESCRIPTION
This should be backported to 7.x as well.

See https://pypi.org/classifiers/ to see the new classifiers.