### PR TITLE
Backport #3265 to 7.x (Add new trove classifiers for JLab extensions)

### DIFF
--- a/jupyterlab_widgets/setup.py
+++ b/jupyterlab_widgets/setup.py
@@ -84,6 +84,10 @@ setup_args = dict(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Framework :: Jupyter",
+        "Framework :: Jupyter :: JupyterLab",
+        "Framework :: Jupyter :: JupyterLab :: 3",
+        "Framework :: Jupyter :: JupyterLab :: Extensions",
+        "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
     ],
 )
 


### PR DESCRIPTION
Manual backport of #3265 to `7.x`.