### PR TITLE
Flush figures with new backend name

### DIFF
--- a/ipywidgets/widgets/interaction.py
+++ b/ipywidgets/widgets/interaction.py
@@ -44,7 +44,8 @@ def show_inline_matplotlib_plots():
     except ImportError:
         return
 
-    if mpl.get_backend() == 'module://ipykernel.pylab.backend_inline':
+    if (mpl.get_backend() == 'module://ipykernel.pylab.backend_inline' or
+        mpl.get_backend() == 'module://matplotlib_inline.backend_inline'):
         flush_figures()
 
 


### PR DESCRIPTION
Earlier this year, the name of the backend used by `matplotlib` changed. See the change at [ipykernel](https://github.com/ipython/ipykernel/pull/591/commits/f0d35275100c017fbe24b84a45ed0574b0ce71ef) and [ipython](https://github.com/ipython/ipython/pull/12817/commits/a7d4c74a81181b880932d9b34a5934f9c34a869e). This effectively makes `ipywidgets` not call `flush_figures` anymore and so interactives with plots stopped working (see [this old issue](https://github.com/ipython/ipython/issues/10376)).

This change fixes that so `flush_figures` is called again.