### PR TITLE
Variable Inspector example used a wrong callback argument signature

### DIFF
--- a/docs/source/examples/Variable Inspector.ipynb
+++ b/docs/source/examples/Variable Inspector.ipynb
@@ -73,7 +73,7 @@
     "            self.closed = True\n",
     "            VariableInspectorWindow.instance = None\n",
     "\n",
-    "    def _fill(self):\n",
+    "    def _fill(self, _result):\n",
     "        \"\"\"Fill self with variable information.\"\"\"\n",
     "        values = self.namespace.who_ls()\n",
     "        self._table.value = '<div class=\"rendered_html jp-RenderedHTMLCommon\"><table><thead><tr><th>Name</th><th>Type</th><th>Value</th></tr></thead><tr><td>' + \\\n",


### PR DESCRIPTION
I ran into an issue described here https://github.com/ipython/ipython/issues/12214 for the Variable Inspector example.

The `inspector.close()` line would crash with the slightly cryptic message:

```
ValueError: Function <bound method VariableInspectorWindow._fill of <__main__.VariableInspectorWindow object at 0x2b7148c38a58>> is not registered as a post_run_cell callback
```

... despite the callback clearly being registered.

The fix is to a accept a second argument in the callback.