### PR TITLE
7.x: Fix control comm channel test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install jupyter_packaging
     - name: Build the extension
       run: |
-        pip install .
+        pip install -e .[test]
         jlpm install
         jlpm run build
         cd jupyterlab_widgets
@@ -57,3 +57,5 @@ jobs:
         jupyter labextension list
 
         python -m jupyterlab.browser_check
+    - name: Run Python tests
+      run: pytest .

--- a/ipywidgets/widgets/tests/test_send_state.py
+++ b/ipywidgets/widgets/tests/test_send_state.py
@@ -7,6 +7,8 @@ from .utils import setup, teardown, DummyComm
 
 from ..widget import Widget
 
+from ..._version import __control_protocol_version__
+
 # A widget with simple traits
 class SimpleWidget(Widget):
     a = Bool().tag(sync=True)
@@ -29,6 +31,10 @@ def test_control():
     comm = DummyComm()
     Widget.close_all()
     w = SimpleWidget()
-    Widget.handle_control_comm_opened(comm, {})
-    Widget.handle_control_comm_msg({'type': 'models-request'})
+    Widget.handle_control_comm_opened(
+        comm, dict(metadata={'version': __control_protocol_version__})
+    )
+    Widget._handle_control_comm_msg(dict(content=dict(
+        data={'method': 'request_states'}
+    )))
     assert comm.messages

--- a/ipywidgets/widgets/widget.py
+++ b/ipywidgets/widgets/widget.py
@@ -361,7 +361,7 @@ class Widget(LoggingHasTraits):
             ), buffers=buffers)
 
         else:
-            self.log.error('Unknown front-end to back-end widget control msg with method "%s"' % method)
+            raise RuntimeError('Unknown front-end to back-end widget control msg with method "%s"' % method)
 
     @staticmethod
     def handle_comm_opened(comm, msg):


### PR DESCRIPTION
It's odd the CI didn't catch the test was not working after the latest reviews. We need to check that the CI runs the tests properly.