### PR TITLE
Remove process.cwd polyfill

### DIFF
--- a/examples/web1/webpack.config.js
+++ b/examples/web1/webpack.config.js
@@ -20,8 +20,6 @@ module.exports = {
     new webpack.DefinePlugin({
       // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
       'process.env': '{}',
-      // Needed for various packages using cwd(), like the path polyfill
-      'process.cwd': '() => "/"',
     }),
   ],
 };

--- a/examples/web2/webpack.config.js
+++ b/examples/web2/webpack.config.js
@@ -63,8 +63,6 @@ module.exports = {
     new webpack.DefinePlugin({
       // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
       'process.env': '{}',
-      // Needed for various packages using cwd(), like the path polyfill
-      'process.cwd': '() => "/"',
     }),
   ],
 };

--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -94,8 +94,6 @@ module.exports = {
     new webpack.DefinePlugin({
       // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
       'process.env': '{}',
-      // Needed for various packages using cwd(), like the path polyfill
-      'process.cwd': '() => "/"',
     }),
   ],
 };

--- a/examples/web4/webpack.config.js
+++ b/examples/web4/webpack.config.js
@@ -62,8 +62,6 @@ module.exports = {
     new webpack.DefinePlugin({
       // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
       'process.env': '{}',
-      // Needed for various packages using cwd(), like the path polyfill
-      'process.cwd': '() => "/"',
     }),
   ],
 };

--- a/packages/html-manager/test/webpack.conf.js
+++ b/packages/html-manager/test/webpack.conf.js
@@ -95,8 +95,6 @@ module.exports = {
     new webpack.DefinePlugin({
       // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
       'process.env': '{}',
-      // Needed for various packages using cwd(), like the path polyfill
-      'process.cwd': '() => "/"',
     }),
   ],
 };

--- a/packages/html-manager/webpack.config.js
+++ b/packages/html-manager/webpack.config.js
@@ -65,8 +65,6 @@ var plugins = [
   new webpack.DefinePlugin({
     // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393
     'process.env': '{}',
-    // Needed for various packages using cwd(), like the path polyfill
-    'process.cwd': '() => "/"',
   }),
 ];
 


### PR DESCRIPTION
Fix https://github.com/jupyter-widgets/ipywidgets/issues/3312

I could not reproduce the HTML Manager issue there was when the polyfill was not around.

How I tested it:

```
jupyter nbconvert --to html --HTMLExporter.widget_renderer_url=./packages/html-manager/dist/embed-amd.js Notebook.ipynb
```