### PR TITLE
Enhancing the contributing.md document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,17 +15,20 @@ python -c "import IPython; print(IPython.sys_info())"
 
 Current developer information can be found in the latest docs [here](https://ipywidgets.readthedocs.io/en/latest/developer_docs.html).
 
-
-For a quick start:
-
+-------
+# Check these resources:
+Now that we went through the basics, Here are more detailed documentation on areas of contribution:
+## Installing
 [Developer install information](docs/source/dev_install.md) for installation steps.
-
+## Releasing
 [Release procedures](docs/source/dev_release.md)
-
+## Testing
 [Testing Contributions](docs/source/dev_testing.md)
-
+## Documenting
 [Documentation Contributions](docs/source/dev_docs.md)
 
 ---------
+# Good First Issues
+This is a link for issues that don't require deep knowledge of the project:
 
-[Good First Issues](https://github.com/jupyter-widgets/ipywidgets/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+Click here: [Good First Issues](https://github.com/jupyter-widgets/ipywidgets/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,20 @@
 # Contributing
 
-We appreciate contributions from the community. (See [Guidelines](docs/source/contributing.md) here).
+We appreciate contributions from the community.
+
+Click here to see the full [Guidelines](docs/source/contributing.md):
+- issues are managed by the `@meeseeksdev` bot
+- When opening an issue, make sure that it hasn't been solved
+  - Search on Google or Github.
+- Include your system information
+```
+python -c "import IPython; print(IPython.sys_info())"
+```
+- **All work is submitted through pull requests (PRs)**
+  - PRs are submitted as soon as there is code to be discussed
 
 Current developer information can be found in the latest docs [here](https://ipywidgets.readthedocs.io/en/latest/developer_docs.html).
+
 
 For a quick start:
 
@@ -13,3 +25,7 @@ For a quick start:
 [Testing Contributions](docs/source/dev_testing.md)
 
 [Documentation Contributions](docs/source/dev_docs.md)
+
+---------
+
+[Good First Issues](https://github.com/jupyter-widgets/ipywidgets/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)


### PR DESCRIPTION
Hello guys,

Here is my first PR. I am happy to work on better documentation for contributors!

Better Documentation=Easier Development
---------

I have a couple of suggestions
# Suggestions:
## Add a td;lr on each link
    - So that the new participant doesn't feel intimidated by the sheer amount of reading to do
## Add a "to reach out" section
    - with added contact info (if a contributor prefers a different messaging channel together with GitHub)

--------------
Here are some of my comments (having a fresh eye)
# Comments
## Community guidelines:
**Jupyter Guidelines link is broken**
- We can directly link to IPython Guidelines
    - This way, the new person has one link to click

## Current developer information
  - Give a more descriptive title
    - Example: "ipywidgets: what it is"

## Developer install information
  - steps are clear, concise and precise
  - Put the setup and [troubleshooting, updating] in the Main contribute file
    - "For more info refer to the guidelines"
    - **testing contributions is in the install information**
## release procedures
  - put the Header 2s as a td;lr
## testing
  - Concise
  - put Header 2s as td;lr
## Documentation
  - Also, Concise
  - put Header 2's as td'lr

