### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install node
       uses: actions/setup-node@v1
       with:
-       node-version: '14.x'
+       node-version: '16.x'
     - name: Install Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.10'
         architecture: 'x64'
 
     - uses: actions/cache@v2
@@ -87,16 +87,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows]
-        python: ['3.6', '3.9']
+        python: ['3.7', '3.10']
         dist: ['ipywidgets*.tar.gz']
         include:
-          - python: '3.9'
+          - python: '3.10'
             dist: 'jupyterlab_widgets*.tar.gz'
             os: 'ubuntu'
-          - python: '3.9'
+          - python: '3.10'
             dist: 'widgetsnbextension*.tar.gz'
             os: 'ubuntu'
-          - python: '3.9'
+          - python: '3.10'
             dist: 'ipywidgets*.whl'
             os: 'ubuntu'
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,7 +169,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: '16.x'
 
     - name: Get yarn cache
       id: yarn-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -129,7 +129,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip
@@ -153,7 +153,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pip

--- a/python/ipywidgets/setup.cfg
+++ b/python/ipywidgets/setup.cfg
@@ -18,15 +18,15 @@ classifiers =
   License :: OSI Approved :: BSD License
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3 :: Only
   Framework :: Jupyter
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 
 zip_safe = False
 # include_package_data = True

--- a/python/jupyterlab_widgets/setup.cfg
+++ b/python/jupyterlab_widgets/setup.cfg
@@ -18,10 +18,10 @@ classifiers =
   License :: OSI Approved :: BSD License
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3 :: Only
   Framework :: Jupyter
   Framework :: Jupyter :: JupyterLab
@@ -30,7 +30,7 @@ classifiers =
   Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 zip_safe=False
 include_package_data = True
 packages = find:

--- a/python/widgetsnbextension/setup.cfg
+++ b/python/widgetsnbextension/setup.cfg
@@ -18,15 +18,15 @@ classifiers =
   License :: OSI Approved :: BSD License
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3 :: Only
   Framework :: Jupyter
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 zip_safe=False
 include_package_data = True
 packages = find:


### PR DESCRIPTION
Python 3.6 hits end-of-life in a few days. This drops support for Python 3.6.

It also upgrades our testing to use the current NodeJS LTS, version 16.