### PR TITLE
Use control comm target in base Manager

### DIFF
--- a/python/jupyterlab_widgets/src/manager.ts
+++ b/python/jupyterlab_widgets/src/manager.ts
@@ -9,7 +9,6 @@ import {
   ExportData,
   WidgetModel,
   WidgetView,
-  put_buffers,
   ICallbacks,
 } from '@jupyter-widgets/base';
 
@@ -21,7 +20,7 @@ import {
 
 import { IDisposable } from '@lumino/disposable';
 
-import { PromiseDelegate, ReadonlyPartialJSONValue } from '@lumino/coreutils';
+import { ReadonlyPartialJSONValue } from '@lumino/coreutils';
 
 import { INotebookModel } from '@jupyterlab/notebook';
 
@@ -106,74 +105,8 @@ export abstract class LabWidgetManager
       // A "load" for a kernel that does not handle comms does nothing.
       return;
     }
-    const comm_ids = await this._get_comm_info();
 
-    // For each comm id that we do not know about, create the comm, and request the state.
-    const widgets_info = await Promise.all(
-      Object.keys(comm_ids).map(async (comm_id) => {
-        try {
-          await this.get_model(comm_id);
-          // If we successfully get the model, do no more.
-          return;
-        } catch (e) {
-          // If we have the widget model not found error, then we can create the
-          // widget. Otherwise, rethrow the error. We have to check the error
-          // message text explicitly because the get_model function in this
-          // class throws a generic error with this specific text.
-          if (e.message !== 'widget model not found') {
-            throw e;
-          }
-          const comm = await this._create_comm(this.comm_target_name, comm_id);
-
-          let msg_id = '';
-          const info = new PromiseDelegate<Private.ICommUpdateData>();
-          comm.on_msg((msg: KernelMessage.ICommMsgMsg) => {
-            if (
-              (msg.parent_header as any).msg_id === msg_id &&
-              msg.header.msg_type === 'comm_msg' &&
-              msg.content.data.method === 'update'
-            ) {
-              const data = msg.content.data as any;
-              const buffer_paths = data.buffer_paths || [];
-              const buffers = msg.buffers || [];
-              put_buffers(data.state, buffer_paths, buffers);
-              info.resolve({ comm, msg });
-            }
-          });
-          msg_id = comm.send(
-            {
-              method: 'request_state',
-            },
-            this.callbacks(undefined)
-          );
-
-          return info.promise;
-        }
-      })
-    );
-
-    // We put in a synchronization barrier here so that we don't have to
-    // topologically sort the restored widgets. `new_model` synchronously
-    // registers the widget ids before reconstructing their state
-    // asynchronously, so promises to every widget reference should be available
-    // by the time they are used.
-    await Promise.all(
-      widgets_info.map(async (widget_info) => {
-        if (!widget_info) {
-          return;
-        }
-        const content = widget_info.msg.content as any;
-        await this.new_model(
-          {
-            model_name: content.data.state._model_name,
-            model_module: content.data.state._model_module,
-            model_module_version: content.data.state._model_module_version,
-            comm: widget_info.comm,
-          },
-          content.data.state
-        );
-      })
-    );
+    return super._loadFromKernel();
   }
 
   /**
@@ -667,14 +600,4 @@ export namespace WidgetManager {
   export type Settings = {
     saveState: boolean;
   };
-}
-
-namespace Private {
-  /**
-   * Data promised when a comm info request resolves.
-   */
-  export interface ICommUpdateData {
-    comm: IClassicComm;
-    msg: KernelMessage.ICommMsgMsg;
-  }
 }

--- a/python/widgetsnbextension/src/manager.js
+++ b/python/widgetsnbextension/src/manager.js
@@ -99,93 +99,37 @@ export class WidgetManager extends ManagerBase {
       this.handle_comm_open.bind(this)
     );
 
-    // Attempt to reconstruct any live comms by requesting them from the back-end (2).
     var that = this;
-    this._get_comm_info().then(function (comm_ids) {
-      // Create comm class instances from comm ids (2).
-      var comm_promises = Object.keys(comm_ids).map(function (comm_id) {
-        return that._create_comm(that.comm_target_name, comm_id);
-      });
 
-      // Send a state request message out for each widget comm and wait
-      // for the responses (2).
-      return Promise.all(comm_promises)
-        .then(function (comms) {
-          return Promise.all(
-            comms.map(function (comm) {
-              var update_promise = new Promise(function (resolve, reject) {
-                comm.on_msg(function (msg) {
-                  base.put_buffers(
-                    msg.content.data.state,
-                    msg.content.data.buffer_paths,
-                    msg.buffers
-                  );
-                  // A suspected response was received, check to see if
-                  // it's a state update. If so, resolve.
-                  if (msg.content.data.method === 'update') {
-                    resolve({
-                      comm: comm,
-                      msg: msg,
-                    });
-                  }
-                });
-              });
-              comm.send(
-                {
-                  method: 'request_state',
-                },
-                that.callbacks()
-              );
-              return update_promise;
-            })
-          );
-        })
-        .then(function (widgets_info) {
-          return Promise.all(
-            widgets_info.map(function (widget_info) {
-              return that.new_model(
-                {
-                  model_name: widget_info.msg.content.data.state._model_name,
-                  model_module:
-                    widget_info.msg.content.data.state._model_module,
-                  model_module_version:
-                    widget_info.msg.content.data.state._model_module_version,
-                  comm: widget_info.comm,
-                },
-                widget_info.msg.content.data.state
-              );
-            })
-          );
-        })
-        .then(function () {
-          // Now that we have mirrored any widgets from the kernel...
-          // Restore any widgets from saved state that are not live (3)
-          if (
-            widget_md &&
-            widget_md['application/vnd.jupyter.widget-state+json']
-          ) {
-            var state =
-              notebook.metadata.widgets[
-                'application/vnd.jupyter.widget-state+json'
-              ];
-            state = that.filterExistingModelState(state);
-            return that.set_state(state);
+    this._loadFromKernel()
+      .then(function () {
+        // Now that we have mirrored any widgets from the kernel...
+        // Restore any widgets from saved state that are not live (3)
+        if (
+          widget_md &&
+          widget_md['application/vnd.jupyter.widget-state+json']
+        ) {
+          var state =
+            notebook.metadata.widgets[
+              'application/vnd.jupyter.widget-state+json'
+            ];
+          state = that.filterExistingModelState(state);
+          return that.set_state(state);
+        }
+      })
+      .then(function () {
+        // Rerender cells that have widget data
+        that.notebook.get_cells().forEach(function (cell) {
+          var rerender =
+            cell.output_area &&
+            cell.output_area.outputs.find(function (output) {
+              return output.data && output.data[MIME_TYPE];
+            });
+          if (rerender) {
+            that.notebook.render_cell_output(cell);
           }
-        })
-        .then(function () {
-          // Rerender cells that have widget data
-          that.notebook.get_cells().forEach(function (cell) {
-            var rerender =
-              cell.output_area &&
-              cell.output_area.outputs.find(function (output) {
-                return output.data && output.data[MIME_TYPE];
-              });
-            if (rerender) {
-              that.notebook.render_cell_output(cell);
-            }
-          });
         });
-    });
+      });
 
     // Create the actions and menu
     this._init_actions();


### PR DESCRIPTION
Port of https://github.com/voila-dashboards/voila/pull/766 for JupyterLab and classic Jupyter Notebook

Use the `jupyter.widget.control` comm target for fetching widget states in the JupyterLab manager and the widgetsnbextension, this is used *e.g.* when refreshing the JupyterLab page on an already running kernel that contains widgets.

It will also be used by Voila in https://github.com/voila-dashboards/voila/pull/846.

I would really like this to be considered for the coming 8.0.0 release. It would also be nice to backport it to the 7.x branch if we keep making releases from there.

User facing changes
---------------------

This improves the performances when refreshing the JupyterLab page or when connecting to an already existing kernel that contains widgets.