### PR TITLE
Add jsonschema to test dependencies of ipywidgets

### DIFF
--- a/python/ipywidgets/setup.cfg
+++ b/python/ipywidgets/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
 
 [options.extras_require]
 test =
+  jsonschema
   pytest>=3.6.0
   pytest-cov
   pytz


### PR DESCRIPTION
test_state_schema depends on jsonschema: https://github.com/jupyter-widgets/ipywidgets/blob/32f59acbc63c3ff0acf6afa86399cb563d3a9a86/python/ipywidgets/ipywidgets/widgets/tests/test_interaction.py#L606

If you don't want it there, I can prepare an automated skip of the test in the case when jsonschema is not installed.