### PR TITLE
HTMLManager: Do not reset lab's CSS variables if they are defined

### DIFF
--- a/packages/html-manager/src/libembed.ts
+++ b/packages/html-manager/src/libembed.ts
@@ -10,7 +10,16 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 import '@fortawesome/fontawesome-free/css/v4-shims.min.css';
 
 import '@lumino/widgets/style/index.css';
-import '@jupyter-widgets/controls/css/widgets.css';
+import '@jupyter-widgets/controls/css/widgets-base.css';
+
+// If lab variables are not found, we set them (we don't want to reset the variables if they are already defined)
+if (
+  getComputedStyle(document.documentElement).getPropertyValue(
+    '--jp-layout-color0'
+  ) === ''
+) {
+  require('@jupyter-widgets/controls/css/labvariables.css');
+}
 
 // Used just for the typing. We must not import the javascript because we don't
 // want to include it in the require embedding.


### PR DESCRIPTION
Do not override the JupyterLab's CSS variables if they are already defined in the page.
This fixes the nbconvert's HTMLExporter when using a dark theme.

Testing it:

```
jupyter nbconvert --to html --HTMLExporter.theme=dark --HTMLExporter.template_name=lab --HTMLExporter.widget_renderer_url=/path/to/local/ipywidgets/packages/html-manager/dist/embed-amd.js NotebookWithWidgets.ipynb
```

Screenshot:
-----------

![dark](https://user-images.githubusercontent.com/21197331/148932614-e5a4eb89-5bd8-4017-80dd-4d348b50d074.png)

References:
-----------

Fix #3340 fix https://github.com/jupyter/nbconvert/issues/1506

