### PR TITLE
feat: backward compatibility with 7.x

### DIFF
--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -1177,12 +1177,6 @@ export class DOMWidgetView extends WidgetView {
    * @deprecated Use {@link luminoWidget} instead (Since 8.0).
    */
   get pWidget(): Widget {
-    if (!DOMWidgetView.deprecationWarningDisplayed) {
-      console.warn(
-        'The use of pWidget is deprecated, use luminoWidget instead.'
-      );
-      DOMWidgetView.deprecationWarningDisplayed = true;
-    }
     return this.luminoWidget;
   }
 
@@ -1191,5 +1185,4 @@ export class DOMWidgetView extends WidgetView {
   luminoWidget: Widget;
   layoutPromise: Promise<any>;
   stylePromise: Promise<any>;
-  private static deprecationWarningDisplayed = false;
 }

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -885,6 +885,11 @@ export class JupyterLuminoWidget extends Widget {
   private _view: DOMWidgetView;
 }
 
+/**
+ * @deprecated Use {@link JupyterLuminoWidget} instead (Since 8.0).
+ */
+export const JupyterPhosphorWidget = JupyterLuminoWidget;
+
 export class JupyterLuminoPanelWidget extends Panel {
   constructor(options: JupyterLuminoWidget.IOptions & Panel.IOptions) {
     const view = options.view;
@@ -1167,9 +1172,24 @@ export class DOMWidgetView extends WidgetView {
       this.el.removeAttribute('tabIndex');
     }
   }
+
+  /**
+   * @deprecated Use {@link luminoWidget} instead (Since 8.0).
+   */
+  get pWidget(): Widget {
+    if (!DOMWidgetView.deprecationWarningDisplayed) {
+      console.warn(
+        'The use of pWidget is deprecated, use luminoWidget instead.'
+      );
+      DOMWidgetView.deprecationWarningDisplayed = true;
+    }
+    return this.luminoWidget;
+  }
+
   el: HTMLElement; // Override typing
   '$el': any;
   luminoWidget: Widget;
   layoutPromise: Promise<any>;
   stylePromise: Promise<any>;
+  private static deprecationWarningDisplayed = false;
 }


### PR DESCRIPTION
This way widget libraries accessing `JupyterPhosphorWidget` and/or `pWidget` can run with 8.x without making a 7.x incompatible build.

For example:
- https://github.com/bqplot/bqplot/search?q=pWidget
- https://github.com/jupyter-widgets/ipyleaflet/search?q=pWidget
- https://github.com/mariobuikhuizen/ipyvue/search?q=pWidget