### PR TITLE
Validate selection slider values

### DIFF
--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -219,7 +219,7 @@ export abstract class BaseIntSliderView extends DescriptionView {
       direction: orientation === 'horizontal' ? 'ltr' : 'rtl',
       format: {
         from: (value: string): number => Number(value),
-        to: (value: number): number => value,
+        to: (value: number): number => this._validate_slide_value(value),
       },
     });
 
@@ -285,7 +285,7 @@ export abstract class BaseIntSliderView extends DescriptionView {
    * and applying it to the other views on the page.
    */
   _validate_slide_value(x: number): number {
-    return Math.floor(x);
+    return Math.round(x);
   }
 
   $slider: any;

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -765,7 +765,7 @@ export class SelectionSliderView extends DescriptionView {
       direction: orientation === 'horizontal' ? 'ltr' : 'rtl',
       format: {
         from: (value: string): number => Number(value),
-        to: (value: number): number => value,
+        to: (value: number): number => Math.round(value),
       },
     });
 


### PR DESCRIPTION
Ensure the slider values are valid. For the selection slider, this makes sure they are integer indices.

Fixes #3363 