### PR TITLE
Fix installation on Python 3.10: Remove obsolete reference to ensure_python

### DIFF
--- a/jupyterlab_widgets/setup.py
+++ b/jupyterlab_widgets/setup.py
@@ -5,7 +5,7 @@ import os
 
 from jupyter_packaging import (
     create_cmdclass, install_npm, ensure_targets,
-    combine_commands, ensure_python, get_version,
+    combine_commands, get_version,
 )
 import setuptools
 
@@ -13,9 +13,6 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 # The name of the project
 name = "jupyterlab_widgets"
-
-# Ensure a valid python version
-ensure_python(">=3.6")
 
 # Get our version
 version = get_version(os.path.join(name, "_version.py"))


### PR DESCRIPTION
jupyter_packaging deprecates ensure_python and recommends using python_requres.
We already use python_requires, so there is no need to also use ensure_python.
Apparently, this issue prevents installing on Python 3.10.

Fixes #3364

Note that we don't use ensure_python on master, so this is just a bugfix on 7.x