### PR TITLE
Run js tests on 7.x in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,34 @@ jobs:
     - name: Build the extension
       run: |
         pip install -e .[test]
-        jlpm install
-        jlpm run build
-        cd jupyterlab_widgets
+
+        yarn install --frozen-lockfile
+        yarn run build
+        yarn run build:examples
+
+        pushd jupyterlab_widgets
         pwd
         pip install -e .
         jupyter labextension develop . --overwrite
         jupyter labextension list
-
         python -m jupyterlab.browser_check
+        popd
     - name: Run Python tests
       run: pytest .
+    - name: Run JS tests
+      run: |
+        pushd packages/base
+        yarn run test:unit:firefox:headless
+        popd
+
+        pushd packages/controls
+        yarn run test:unit:firefox:headless
+        popd
+
+        pushd packages/html-manager
+        yarn run test:unit:firefox:headless
+        popd
+
+        pushd examples/web1
+        yarn run test:firefox:headless
+        popd

--- a/examples/web1/package.json
+++ b/examples/web1/package.json
@@ -12,7 +12,8 @@
     "test": "npm run test:firefox && npm run test:chrome",
     "test:chrome": "npm run test:default",
     "test:default": "karma start karma.config.js --log-level debug",
-    "test:firefox": "npm run test:default -- --browsers Firefox"
+    "test:firefox": "npm run test:default -- --browsers Firefox",
+    "test:firefox:headless": "npm run test:default -- --browsers FirefoxHeadless"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^4.0.0",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -29,6 +29,7 @@
     "test:unit:chrome": "npm run test:unit:default -- --browsers=Chrome",
     "test:unit:default": "npm run build:test && karma start test/karma.conf.js --log-level debug",
     "test:unit:firefox": "npm run test:unit:default -- --browsers=Firefox",
+    "test:unit:firefox:headless": "npm run test:unit:default -- --browsers=FirefoxHeadless",
     "test:unit:ie": "npm run test:unit:default -- --browsers=IE"
   },
   "dependencies": {

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -31,6 +31,7 @@
     "test:unit:chrome": "npm run test:unit:default -- --browsers=Chrome",
     "test:unit:default": "npm run build:test && karma start test/karma.conf.js --log-level debug",
     "test:unit:firefox": "npm run test:unit:default -- --browsers=Firefox",
+    "test:unit:firefox:headless": "npm run test:unit:default -- --browsers=FirefoxHeadless",
     "test:unit:ie": "npm run test:unit:default -- --browsers=IE"
   },
   "dependencies": {

--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -32,7 +32,8 @@
     "test:unit": "npm run test:unit:firefox && npm run test:unit:chrome",
     "test:unit:chrome": "npm run test:unit:default -- --browsers=Chrome",
     "test:unit:default": "npm run build:test && karma start test/karma.conf.js --log-level debug --browsers=Firefox",
-    "test:unit:firefox": "npm run test:unit:default -- --browsers=Firefox"
+    "test:unit:firefox": "npm run test:unit:default -- --browsers=Firefox",
+    "test:unit:firefox:headless": "npm run test:unit:default -- --browsers=FirefoxHeadless"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^4.0.0",


### PR DESCRIPTION
Apparently we don't run the javascript tests in CI for 7.x. This fixes this issue.