### PR TITLE
Backport PR #3367: Fix downward arrow misalignment for combobox

### DIFF
--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -408,7 +408,6 @@
 
 .widget-text input[type="text"], .widget-text input[type="number"], .widget-text input[type="password"] {
     height: var(--jp-widgets-inline-height);
-    line-height: var(--jp-widgets-inline-height);
 }
 
 .widget-text input[type="text"]:disabled, .widget-text input[type="number"]:disabled, .widget-text input[type="password"]:disabled, .widget-textarea textarea:disabled {


### PR DESCRIPTION
Backport PR https://github.com/jupyter-widgets/ipywidgets/pull/3367 on branch 7.x (Fix downward arrow misalignment for combobox)