### PR TITLE
Backport #2975 to 7.x: fix return key submission of IntText widgets

### DIFF
--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -567,7 +567,7 @@ class IntTextView extends DescriptionView {
      * Handles key press
      */
     handleKeypress(e: KeyboardEvent) {
-        if (/[e,.\s]/.test(String.fromCharCode(e.keyCode))) {
+        if (/[e,. ]/.test(String.fromCharCode(e.keyCode))) {
             e.preventDefault();
         }
     }


### PR DESCRIPTION
Backport #2975 to 7.x: fix return key submission of IntText widgets