### PR TITLE
Echo state updates in a backwards-compatible way

### DIFF
--- a/packages/base-manager/test/src/manager_test.ts
+++ b/packages/base-manager/test/src/manager_test.ts
@@ -180,7 +180,7 @@ describe('ManagerBase', function () {
           },
         },
         metadata: {
-          version: '3.0.0',
+          version: '2.1.0',
         },
       });
       expect(model.comm).to.equal(comm);
@@ -243,7 +243,7 @@ describe('ManagerBase', function () {
         },
         buffers: [new DataView(new Uint8Array([1, 2, 3]).buffer)],
         metadata: {
-          version: '3.0.0',
+          version: '2.1.0',
         },
       });
       expect(model.comm).to.equal(comm);

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -26,6 +26,7 @@
     "test:coverage": "npm run build:test && webpack --config test/webpack-cov.conf.js && karma start test/karma-cov.conf.js",
     "test:unit": "npm run test:unit:firefox && npm run test:unit:chrome",
     "test:unit:chrome": "npm run test:unit:default -- --browsers=Chrome",
+    "test:unit:chrome:debug": "npm run test:unit:default -- --browsers=Chrome --single-run=false",
     "test:unit:default": "npm run build:test && karma start test/karma.conf.js --log-level debug",
     "test:unit:firefox": "npm run test:unit:default -- --browsers=Firefox",
     "test:unit:firefox:headless": "npm run test:unit:default -- --browsers=FirefoxHeadless",

--- a/packages/base/src/version.ts
+++ b/packages/base/src/version.ts
@@ -3,4 +3,4 @@
 
 export const JUPYTER_WIDGETS_VERSION = '2.0.0';
 
-export const PROTOCOL_VERSION = '3.0.0';
+export const PROTOCOL_VERSION = '2.1.0';

--- a/packages/schema/messages.md
+++ b/packages/schema/messages.md
@@ -316,7 +316,7 @@ The `echo_update` messages enable a frontend to optimistically update its widget
 
 Since the `echo_update` update messages are optional, and not all attribute updates may be echoed, it is important that only `echo_update` updates are ignored in the last step above, and `update` message updates are always applied.
 
-For attributes where sending back an `echo_update` is considered too expensive or unnecessary, we have implemented an opt-out mechanism in the ipywidgets package. A model trait can have the `no_echo` metadata attribute to flag that the kernel should not send an `echo_update` update for that attribute to the frontends. We suggest other implementations implement a similar opt-out mechanism.
+Implementation note: For attributes where sending back an `echo_update` is considered too expensive or unnecessary, we have implemented an opt-out mechanism in the ipywidgets package. A model trait can have the `echo_update` metadata attribute set to `False` to flag that the kernel should never send an `echo_update` update for that attribute to the frontends. Additionally, we have a system-wide flag to disable echoing for all attributes via the environment variable `JUPYTER_WIDGETS_ECHO`. For ipywdgets 7.7, we default `JUPYTER_WIDGETS_ECHO` to off (disabling all echo messages) and in ipywidgets 8.0 we default `JUPYTER_WIDGETS_ECHO` to on (enabling echo messages).
 
 #### State requests: `request_state`
 

--- a/packages/schema/messages.md
+++ b/packages/schema/messages.md
@@ -292,35 +292,31 @@ The `data.state` and `data.buffer_paths` values are the same as in the `comm_ope
 
 See the [Model state](jupyterwidgetmodels.latest.md) documentation for the attributes of core Jupyter widgets.
 
-#### Synchronizing multiple frontends: `update` with `echo_state`
+#### Synchronizing multiple frontends: `echo_update`
 
-Starting with protocol version `2.1.0`, `update` messages from the kernel to the frontend can have optional `echo_state` and `echo_buffer_paths` attributes. These are analogous to `state` and `buffer_paths` attributes, but are for echoing state in messages from a frontend to the kernel back out to all the frontends.
+Starting with protocol version `2.1.0`, `echo_update` messages from the kernel to the frontend are optional update messages for echoing state in messages from a frontend to the kernel back out to all the frontends.
 
 ```
 {
   'comm_id' : 'u-u-i-d',
   'data' : {
-    'method': 'update',
+    'method': 'echo_update',
     'state': { <dictionary of widget state> },
     'buffer_paths': [ <list with paths corresponding to the binary buffers> ]
-    'echo_state': { <dictionary of widget state> },
-    'echo_buffer_paths': [ <list with paths corresponding to the binary buffers> ]
   }
 }
 ```
 
-The Jupyter comm protocol is asymmetric in how messages flow: messages flow from a single frontend to a single kernel, but messages are broadcast from the kernel to *all* frontends. In the widget protocol, if a frontend updates the value of a widget, the frontend does not have a way to directly notify other frontends about the state update. The `echo_state` and `echo_buffer_paths` optional attributes enable a kernel to broadcast out frontend updates to all frontends. This can also help resolve the race condition where the kernel and a frontend simultaneously send updates to each other since the frontend now knows the order of kernel updates.
+The Jupyter comm protocol is asymmetric in how messages flow: messages flow from a single frontend to a single kernel, but messages are broadcast from the kernel to *all* frontends. In the widget protocol, if a frontend updates the value of a widget, the frontend does not have a way to directly notify other frontends about the state update. The `echo_update` optional messages enable a kernel to broadcast out frontend updates to all frontends. This can also help resolve the race condition where the kernel and a frontend simultaneously send updates to each other since the frontend now knows the order of kernel updates.
 
-These attributes are intended to be used as follows:
+The `echo_update` messages enable a frontend to optimistically update its widget views to reflect its own changes that it knows the kernel will yet process. These messages are intended to be used as follows:
 1. A frontend model attribute is updated, and the frontend views are optimistically updated to reflect the attribute.
 2. The frontend queues an update message to the kernel and records the message id for the attribute.
-3. The frontend ignores updates to the attribute from the kernel contained in `echo_state` fields, until it gets an `echo_state` update corresponding to its own update (i.e., the [parent_header](https://jupyter-client.readthedocs.io/en/latest/messaging.html#parent-header) id matches the stored message id for the attribute). It also ignores `echo_state` updates if it has a pending attribute update to send to the kernel.
+3. The frontend ignores updates to the attribute from the kernel contained in `echo_update` messages until it gets an `echo_update` message corresponding to its own update of the attribute (i.e., the [parent_header](https://jupyter-client.readthedocs.io/en/latest/messaging.html#parent-header) id matches the stored message id for the attribute). It also ignores `echo_update` updates if it has a pending attribute update to send to the kernel. Once the frontend receives its own `echo_update` and does not have any more pending attribute updates to send to the kernel, it starts applying attribute updates from `echo_update` messages.
 
-Since the `echo_state` attributes are optional, and not all attributes may be echoed, it is important that only `echo_state` updates are ignored in the last step above, and `state` updates are always applied.
+Since the `echo_update` update messages are optional, and not all attribute updates may be echoed, it is important that only `echo_update` updates are ignored in the last step above, and `update` message updates are always applied.
 
-For situations where sending back an echo update for an attribute is considered too expensive, we have implemented an opt-out mechanism in ipywidgets. A trait can have the `no_echo` metadata attribute to flag that the kernel should not send back an update to the frontends. We suggest other implementations implement a similar opt-out mechanism.
-
-TODO: at this point, should we just make this an `'method': 'echo_update'` message. Then the entire message is ignored by older implementations, and processing is almost exactly the same for implementations that do implement it - they just have one or two small changes based on the message type.
+For attributes where sending back an `echo_update` is considered too expensive or unnecessary, we have implemented an opt-out mechanism in the ipywidgets package. A model trait can have the `no_echo` metadata attribute to flag that the kernel should not send an `echo_update` update for that attribute to the frontends. We suggest other implementations implement a similar opt-out mechanism.
 
 #### State requests: `request_state`
 

--- a/python/ipywidgets/ipywidgets/_version.py
+++ b/python/ipywidgets/ipywidgets/_version.py
@@ -3,7 +3,7 @@
 
 __version__ = '8.0.0b1'
 
-__protocol_version__ = '3.0.0'
+__protocol_version__ = '2.1.0'
 __control_protocol_version__ = '1.0.0'
 
 # These are *protocol* versions for each package, *not* npm versions. To check, look at each package's src/version.ts file for the protocol version the package implements.

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_set_state.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_set_state.py
@@ -345,7 +345,7 @@ def test_echo_single():
 def test_no_echo():
     # in cases where values coming from the frontend are 'heavy', we might want to opt out
     class ValueWidget(Widget):
-        value = Float().tag(sync=True, no_echo=True)
+        value = Float().tag(sync=True, echo_update=False)
 
     widget = ValueWidget(value=1)
     assert widget.value == 1

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -567,7 +567,7 @@ class Widget(LoggingHasTraits):
         if JUPYTER_WIDGETS_ECHO:
             echo_state = {}
             for attr,value in sync_data.items():
-                if not self.trait_metadata(attr, 'no_echo'):
+                if self.trait_metadata(attr, 'echo_update', default=True):
                     echo_state[attr] = value
             if echo_state:
                 echo_state, echo_buffer_paths, echo_buffers = _remove_buffers(echo_state)

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -572,11 +572,9 @@ class Widget(LoggingHasTraits):
             if echo_state:
                 echo_state, echo_buffer_paths, echo_buffers = _remove_buffers(echo_state)
                 msg = {
-                    'method': 'update',
-                    'state': {},
-                    'buffer_paths': [],
-                    'echo_state': echo_state,
-                    'echo_buffer_paths': echo_buffer_paths
+                    'method': 'echo_update',
+                    'state': echo_state,
+                    'buffer_paths': echo_buffer_paths,
                 }
                 self._send(msg, buffers=echo_buffers)
 

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -512,34 +512,47 @@ class Widget(LoggingHasTraits):
             A single property's name or iterable of property names to sync with the front-end.
         """
         state = self.get_state(key=key)
-        if len(state) > 0:
-            if JUPYTER_WIDGETS_ECHO:
-                echo_state = {}
-                if self._updated_attrs_from_frontend:
-                    for attr in self._updated_attrs_from_frontend:
-                        echo_state[attr] = state[attr]
-                        del state[attr]
-                    self._updated_attrs_from_frontend = None
-                state, buffer_paths, buffers = _remove_buffers(state)
-                echo_state, echo_buffer_paths, echo_buffers = _remove_buffers(echo_state)
-                msg = {'method': 'update', 'state': state, 'buffer_paths': buffer_paths}
-                if echo_state or echo_buffer_paths:
-                    msg['echo_state'] = echo_state
-                    msg['echo_buffer_paths'] = echo_buffer_paths
-                    buffers += echo_buffers
-                self._send(msg, buffers=buffers)
-                return
+        if len(state) == 0:
+            return
 
-            # TODO: _property_lock is our understanding of what the frontend thinks values are
-            # TODO: it is based on what we've sent the frontend
-            if self._property_lock:  # we need to keep this dict up to date with the front-end values
-                for name, value in state.items():
-                    if name in self._property_lock:
-                        self._property_lock[name] = value
-            state, buffer_paths, buffers = _remove_buffers(state)
-            msg = {'method': 'update', 'state': state, 'buffer_paths': buffer_paths}
-            self._send(msg, buffers=buffers)
+        # For any values that are currently locked (i.e., we are not echoing,
+        # and we are currently processing an update for), we need to update our
+        # notion of what the frontend value is.
 
+        # TODO: does this handle the case where we get an update from the
+        # frontend, in the middle of this we update the value *and send it*, and
+        # then at the end we have to evaluate whether to send an echo message.
+        # We need to send an echo message at some point so the originator can unblock
+        # other echo messages, and we don't want to send the same data twice. So probably
+        # the first time we send an update for an attribute back, we need to send it as an
+        # echo, and record that we've already sent it. So perhaps we just need to keep
+        # track of what echos we need to send, and we send at the end whatever echos still
+        # need to be sent.
+
+        # Sending echos at the end may send updates out of order, i.e., we may send
+        # some updates in the middle, then send echos at the end. perhaps we should immediately
+        # send echos just as we start processing the message?
+        if self._property_lock:
+            for name, value in state.items():
+                if name in self._property_lock:
+                    self._property_lock[name] = value
+
+
+        echo_state = {}
+        if self._updated_attrs_from_frontend:
+            for attr in self._updated_attrs_from_frontend:
+                echo_state[attr] = state[attr]
+                del state[attr]
+            self._updated_attrs_from_frontend = None
+        state, buffer_paths, buffers = _remove_buffers(state)
+        echo_state, echo_buffer_paths, echo_buffers = _remove_buffers(echo_state)
+        msg = {'method': 'update', 'state': state, 'buffer_paths': buffer_paths}
+        if echo_state or echo_buffer_paths:
+            msg['echo_state'] = echo_state
+            msg['echo_buffer_paths'] = echo_buffer_paths
+            buffers += echo_buffers
+        self._send(msg, buffers=buffers)
+        return
 
     def get_state(self, key=None, drop_defaults=False):
         """Gets the widget state, or a piece of it.

--- a/python/ipywidgets/ipywidgets/widgets/widget_upload.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_upload.py
@@ -133,7 +133,7 @@ class FileUpload(DescriptionWidget, ValueWidget, CoreWidget):
     style = InstanceDict(ButtonStyle).tag(sync=True, **widget_serialization)
     error = Unicode(help='Error message').tag(sync=True)
     value = TypedTuple(Dict(), help='The file upload value').tag(
-        sync=True, no_echo=True, **_value_serialization)
+        sync=True, echo_update=False, **_value_serialization)
 
     @default('description')
     def _default_description(self):


### PR DESCRIPTION
This updates the update echo implementation to be backwards compatible with 7.x.

Fixes #3392 

From the new docs in `messages.md`:

Starting with protocol version `2.1.0`, `echo_update` messages from the kernel to the frontend are optional update messages for echoing state in messages from a frontend to the kernel back out to all the frontends.

```
{
  'comm_id' : 'u-u-i-d',
  'data' : {
    'method': 'echo_update',
    'state': { <dictionary of widget state> },
    'buffer_paths': [ <list with paths corresponding to the binary buffers> ]
  }
}
```

The Jupyter comm protocol is asymmetric in how messages flow: messages flow from a single frontend to a single kernel, but messages are broadcast from the kernel to *all* frontends. In the widget protocol, if a frontend updates the value of a widget, the frontend does not have a way to directly notify other frontends about the state update. The `echo_update` optional messages enable a kernel to broadcast out frontend updates to all frontends. This can also help resolve the race condition where the kernel and a frontend simultaneously send updates to each other since the frontend now knows the order of kernel updates.

The `echo_update` messages enable a frontend to optimistically update its widget views to reflect its own changes that it knows the kernel will yet process. These messages are intended to be used as follows:
1. A frontend model attribute is updated, and the frontend views are optimistically updated to reflect the attribute.
2. The frontend queues an update message to the kernel and records the message id for the attribute.
3. The frontend ignores updates to the attribute from the kernel contained in `echo_update` messages until it gets an `echo_update` message corresponding to its own update of the attribute (i.e., the [parent_header](https://jupyter-client.readthedocs.io/en/latest/messaging.html#parent-header) id matches the stored message id for the attribute). It also ignores `echo_update` updates if it has a pending attribute update to send to the kernel. Once the frontend receives its own `echo_update` and does not have any more pending attribute updates to send to the kernel, it starts applying attribute updates from `echo_update` messages.

Since the `echo_update` update messages are optional, and not all attribute updates may be echoed, it is important that only `echo_update` updates are ignored in the last step above, and `update` message updates are always applied.

Implementation note: For attributes where sending back an `echo_update` is considered too expensive or unnecessary, we have implemented an opt-out mechanism in the ipywidgets package. A model trait can have the `echo_update` metadata attribute set to `False` to flag that the kernel should never send an `echo_update` update for that attribute to the frontends. Additionally, we have a system-wide flag to disable echoing for all attributes via the environment variable `JUPYTER_WIDGETS_ECHO`. For ipywdgets 7.7, we default `JUPYTER_WIDGETS_ECHO` to off (disabling all echo messages) and in ipywidgets 8.0 we default `JUPYTER_WIDGETS_ECHO` to on (enabling echo messages).
