### PR TITLE
Limit dependabot to run-time dependencies only.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+# PR limit is set to zero to get only security updates
+# Ref https://github.com/dependabot/dependabot-core/issues/2521#issuecomment-863261500
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0 # in case you don't want to enable version updates
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
Make dependabot only make PRs for versions that affect runtime dependencies. This would mean that we would not be getting security updates pushed automatically for dev dependencies. However, developers should still be able to receive a notice about security updates by running `yarn audit` locally (npm does this by default on `install` command, and yarn may change to that in the future as well).