### PR TITLE
Fix doc build

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,6 +2,5 @@ version: 2
 python:
     version: 3.7
     install:
-      - method: setuptools
-        path: .
+      - path: .
       - requirements: docs/requirements.txt


### PR DESCRIPTION
Rely on the default of readthedocs installing things with pip, rather than insisting on setuptools (which doesn't work anymore for us).