### PR TITLE
Added sklearn and skimage dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,5 @@ recommonmark
 sphinx>=1.4.6
 sphinx_rtd_theme
 packaging
+scikit-image
+scikit-learn


### PR DESCRIPTION
I found in the examples that the Image Processing.ipynb requires skimage and Image Browser.ipynb requires sklearn. The binder is not installing these dependencies.