### PR TITLE
Update public path to auto, and update example configs

### DIFF
--- a/examples/web1/package.json
+++ b/examples/web1/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "chai": "^4.0.0",
     "css-loader": "^6.5.1",
-    "file-loader": "^6.2.0",
     "karma": "^6.3.3",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",

--- a/examples/web1/webpack.config.js
+++ b/examples/web1/webpack.config.js
@@ -7,12 +7,10 @@ module.exports = {
   entry: './index.js',
   output: {
     filename: 'index.built.js',
-    path: path.resolve(__dirname, 'built')
+    path: path.resolve(__dirname, 'built'),
   },
   module: {
-    rules: [
-      { test: /\.css$/i, use: ['style-loader', 'css-loader'] },
-    ],
+    rules: [{ test: /\.css$/i, use: ['style-loader', 'css-loader'] }],
   },
   plugins: [
     new webpack.DefinePlugin({

--- a/examples/web1/webpack.config.js
+++ b/examples/web1/webpack.config.js
@@ -3,6 +3,7 @@ var webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
+  devtool: 'source-map',
   entry: './index.js',
   output: {
     filename: 'index.built.js',
@@ -10,9 +11,7 @@ module.exports = {
   },
   module: {
     rules: [
-      { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-      // jquery-ui loads some images
-      { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
+      { test: /\.css$/i, use: ['style-loader', 'css-loader'] },
     ],
   },
   plugins: [

--- a/examples/web1/webpack.config.js
+++ b/examples/web1/webpack.config.js
@@ -6,8 +6,7 @@ module.exports = {
   entry: './index.js',
   output: {
     filename: 'index.built.js',
-    path: path.resolve(__dirname, 'built'),
-    publicPath: 'built/',
+    path: path.resolve(__dirname, 'built')
   },
   module: {
     rules: [

--- a/examples/web2/index.js
+++ b/examples/web2/index.js
@@ -7,7 +7,7 @@ require('@jupyter-widgets/controls/css/widgets.css');
 require('font-awesome/css/font-awesome.css');
 
 document.addEventListener('DOMContentLoaded', function (event) {
-  var code = require('./widget_code.py').default;
+  var code = require('./widget_code.py');
   var inputarea = document.getElementsByClassName('inputarea')[0];
   new CodeMirror(inputarea, {
     value: code,

--- a/examples/web2/package.json
+++ b/examples/web2/package.json
@@ -21,10 +21,7 @@
   },
   "devDependencies": {
     "css-loader": "^6.5.1",
-    "file-loader": "^6.2.0",
-    "raw-loader": "^4.0.2",
     "style-loader": "^3.3.1",
-    "url-loader": "^4.1.1",
     "webpack": "^5.65.0"
   }
 }

--- a/examples/web2/webpack.config.js
+++ b/examples/web2/webpack.config.js
@@ -3,59 +3,19 @@ var webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
+  devtool: 'source-map',
   entry: './index.js',
   output: {
     filename: 'index.built.js',
-    path: path.resolve(__dirname, 'built')
+    path: path.resolve(__dirname, 'built'),
   },
   module: {
     rules: [
-      { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-      { test: /\.py$/, use: 'raw-loader' },
-      // jquery-ui loads some images
-      { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
+      { test: /\.css$/i, use: ['style-loader', 'css-loader'] },
+      { test: /\.py$/i, type: 'asset/source' },
       // required to load font-awesome
-      {
-        test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'application/font-woff',
-          },
-        },
-      },
-      {
-        test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'application/font-woff',
-          },
-        },
-      },
-      {
-        test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'application/octet-stream',
-          },
-        },
-      },
-      { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
-      {
-        test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'image/svg+xml',
-          },
-        },
-      },
+      { test: /\.(woff|woff2|eot|ttf|otf)$/i, type: 'asset/resource' },
+      { test: /\.svg$/i, type: 'asset' },
     ],
   },
   plugins: [

--- a/examples/web2/webpack.config.js
+++ b/examples/web2/webpack.config.js
@@ -6,8 +6,7 @@ module.exports = {
   entry: './index.js',
   output: {
     filename: 'index.built.js',
-    path: path.resolve(__dirname, 'built'),
-    publicPath: 'built/',
+    path: path.resolve(__dirname, 'built')
   },
   module: {
     rules: [

--- a/examples/web3/package.json
+++ b/examples/web3/package.json
@@ -26,12 +26,10 @@
     "@types/codemirror": "^5.60.0",
     "@types/node": "^17.0.2",
     "css-loader": "^6.5.1",
-    "file-loader": "^6.2.0",
     "fs-extra": "^10.0.0",
     "rimraf": "^3.0.2",
     "style-loader": "^3.3.1",
     "typescript": "~4.3.2",
-    "url-loader": "^4.1.1",
     "webpack": "^5.65.0"
   }
 }

--- a/examples/web3/package.json
+++ b/examples/web3/package.json
@@ -28,17 +28,10 @@
     "css-loader": "^6.5.1",
     "file-loader": "^6.2.0",
     "fs-extra": "^10.0.0",
-    "postcss": "^8.3.2",
-    "postcss-cssnext": "^3.1.0",
-    "postcss-import": "^14.0.2",
-    "postcss-loader": "^6.1.0",
     "rimraf": "^3.0.2",
     "style-loader": "^3.3.1",
     "typescript": "~4.3.2",
     "url-loader": "^4.1.1",
     "webpack": "^5.65.0"
-  },
-  "peerDependencies": {
-    "postcss": "^8.0.0"
   }
 }

--- a/examples/web3/package.json
+++ b/examples/web3/package.json
@@ -37,5 +37,8 @@
     "typescript": "~4.3.2",
     "url-loader": "^4.1.1",
     "webpack": "^5.65.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.0"
   }
 }

--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -22,20 +22,22 @@ module.exports = {
             options: {
               postcssOptions: {
                 plugins: [
-                  postcss.plugin('delete-tilde', function () {
-                    return function (css) {
-                      css.walkAtRules('import', function (rule) {
-                        rule.params = rule.params.replace('~', '');
-                      });
-                    };
-                  }),
-                  postcss.plugin('prepend', function () {
-                    return function (css) {
+                  {
+                    postcssPlugin: 'delete-tilde',
+                    AtRule: {
+                      import: (atRule) => {
+                        atRule.params = atRule.params.replace('~', '');
+                      },
+                    },
+                  },
+                  {
+                    postcssPlugin: 'prepend',
+                    Once(css) {
                       css.prepend(
                         "@import '@jupyter-widgets/controls/css/labvariables.css';"
                       );
-                    };
-                  }),
+                    },
+                  },
                   require('postcss-import')(),
                   require('postcss-cssnext')(),
                 ],

--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -12,40 +12,7 @@ module.exports = {
   },
   module: {
     rules: [
-      {
-        test: /\.css$/,
-        use: [
-          'style-loader',
-          'css-loader',
-          {
-            loader: 'postcss-loader',
-            options: {
-              postcssOptions: {
-                plugins: [
-                  {
-                    postcssPlugin: 'delete-tilde',
-                    AtRule: {
-                      import: (atRule) => {
-                        atRule.params = atRule.params.replace('~', '');
-                      },
-                    },
-                  },
-                  {
-                    postcssPlugin: 'prepend',
-                    Once(css) {
-                      css.prepend(
-                        "@import '@jupyter-widgets/controls/css/labvariables.css';"
-                      );
-                    },
-                  },
-                  require('postcss-import')(),
-                  require('postcss-cssnext')(),
-                ],
-              },
-            },
-          },
-        ],
-      },
+      { test: /\.css$/i, use: ['style-loader', 'css-loader'] },
       // required to load font-awesome
       { test: /\.(woff|woff2|eot|ttf|otf)$/i, type: 'asset/resource' },
       { test: /\.svg$/i, type: 'asset' },

--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -4,6 +4,7 @@ const webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
+  devtool: 'source-map',
   entry: './lib/index.js',
   output: {
     filename: 'index.built.js',
@@ -43,50 +44,9 @@ module.exports = {
           },
         ],
       },
-      // jquery-ui loads some images
-      { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
       // required to load font-awesome
-      {
-        test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'application/font-woff',
-          },
-        },
-      },
-      {
-        test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'application/font-woff',
-          },
-        },
-      },
-      {
-        test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'application/octet-stream',
-          },
-        },
-      },
-      { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
-      {
-        test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'image/svg+xml',
-          },
-        },
-      },
+      { test: /\.(woff|woff2|eot|ttf|otf)$/i, type: 'asset/resource' },
+      { test: /\.svg$/i, type: 'asset' },
     ],
   },
   plugins: [

--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
   entry: './lib/index.js',
   output: {
     filename: 'index.built.js',
-    path: path.resolve(__dirname, 'built')
+    path: path.resolve(__dirname, 'built'),
   },
   module: {
     rules: [

--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -7,8 +7,7 @@ module.exports = {
   entry: './lib/index.js',
   output: {
     filename: 'index.built.js',
-    path: path.resolve(__dirname, 'built'),
-    publicPath: 'built/',
+    path: path.resolve(__dirname, 'built')
   },
   module: {
     rules: [

--- a/examples/web4/README.md
+++ b/examples/web4/README.md
@@ -20,6 +20,17 @@ semver range. For example:
 
 `<script src="https://cdn.jsdelivr.net/npm/@jupyter-widgets/html-manager@^0.8.0/dist/embed.js" crossorigin="anonymous"></script>`
 
+The widget data in this example was generated from the following code:
+
+```python
+from ipywidgets import VBox, jsdlink, IntSlider, Button
+
+s1, s2 = IntSlider(max=200, value=100), IntSlider(value=40)
+b = Button(icon='legal')
+jsdlink((s1, 'value'), (s2, 'max'))
+VBox([s1, s2, b])
+```
+
 ## Try it
 
 1. Start with a repository checkout, and run `yarn install` in the root directory.

--- a/examples/web4/index.html
+++ b/examples/web4/index.html
@@ -13,91 +13,135 @@
     <body>
         <script src="./built/index.built.js"></script>
         <script type="application/vnd.jupyter.widget-state+json">
-        {
-            "version_major": 1,
-            "version_minor": 0,
-            "state": {
-                "79c5cde32c044e4d95cfa27a54982bde": {
-                    "model_name": "LayoutModel",
-                    "model_module": "@jupyter-widgets/base",
-                    "state": {}
-                },
-                "7687c2dd3f344143ae1e87ee9704c774": {
-                    "model_name": "IntSliderModel",
-                    "model_module": "@jupyter-widgets/controls",
-                    "state": {
-                        "layout": "IPY_MODEL_79c5cde32c044e4d95cfa27a54982bde",
-                        "max": 200,
-                        "value": 100
-                    }
-                },
-                "06ad7ea9cf7b4029b312e8fc012c3294": {
-                    "model_name": "LayoutModel",
-                    "model_module": "@jupyter-widgets/base",
-                    "state": {}
-                },
-                "0c3957dbb4734762a84ad924f77197b3": {
-                    "model_name": "IntSliderModel",
-                    "model_module": "@jupyter-widgets/controls",
-                    "state": {
-                        "layout": "IPY_MODEL_06ad7ea9cf7b4029b312e8fc012c3294",
-                        "value": 40
-                    }
-                },
-                "f326c34c26034acdbab8ca4610d49bae": {
-                    "model_name": "LayoutModel",
-                    "model_module": "@jupyter-widgets/base",
-                    "state": {}
-                },
-                "2e4ca159b05a4f3295c8b59695359428": {
-                    "model_name": "ButtonModel",
-                    "model_module": "@jupyter-widgets/controls",
-                    "state": {
-                        "layout": "IPY_MODEL_f326c34c26034acdbab8ca4610d49bae",
-                        "icon": "legal"
-                    }
-                },
-                "e7c5849fbfe7415ab5896fc749d71164": {
-                    "model_name": "DirectionalLinkModel",
-                    "model_module": "@jupyter-widgets/controls",
-                    "state": {
-                        "target": [
-                            "IPY_MODEL_0c3957dbb4734762a84ad924f77197b3",
-                            "max"
-                        ],
-                        "source": [
-                            "IPY_MODEL_7687c2dd3f344143ae1e87ee9704c774",
-                            "value"
-                        ]
-                    }
-                },
-                "4e6ee45ef7c64f0f953c79150d4ae0ca": {
-                    "model_name": "LayoutModel",
-                    "model_module": "@jupyter-widgets/base",
-                    "state": {
-                        "flex_flow": "column",
-                        "display": "flex"
-                    }
-                },
-                "4c5a49e52ae54ad5bdbe973353a58931": {
-                    "model_name": "BoxModel",
-                    "model_module": "@jupyter-widgets/controls",
-                    "state": {
-                        "children": [
-                            "IPY_MODEL_7687c2dd3f344143ae1e87ee9704c774",
-                            "IPY_MODEL_0c3957dbb4734762a84ad924f77197b3",
-                            "IPY_MODEL_2e4ca159b05a4f3295c8b59695359428"
-                        ],
-                        "layout": "IPY_MODEL_4e6ee45ef7c64f0f953c79150d4ae0ca"
+            {
+                "version_major": 2,
+                "version_minor": 0,
+                "state": {
+                    "1d915e54eff54fd89e505a46ccabdabd": {
+                        "model_name": "LayoutModel",
+                        "model_module": "@jupyter-widgets/base",
+                        "model_module_version": "2.0.0",
+                        "state": {}
+                    },
+                    "48a42260652f4b7eb7851c65cd155604": {
+                        "model_name": "SliderStyleModel",
+                        "model_module": "@jupyter-widgets/controls",
+                        "model_module_version": "2.0.0",
+                        "state": {
+                            "description_width": ""
+                        }
+                    },
+                    "105655a5e8dc4b7bb19d824cc3ff7770": {
+                        "model_name": "IntSliderModel",
+                        "model_module": "@jupyter-widgets/controls",
+                        "model_module_version": "2.0.0",
+                        "state": {
+                            "value": 100,
+                            "max": 200,
+                            "style": "IPY_MODEL_48a42260652f4b7eb7851c65cd155604",
+                            "behavior": "drag-tap",
+                            "layout": "IPY_MODEL_1d915e54eff54fd89e505a46ccabdabd"
+                        }
+                    },
+                    "cb13b25cf84542ba882ab2a9c6e57c6d": {
+                        "model_name": "LayoutModel",
+                        "model_module": "@jupyter-widgets/base",
+                        "model_module_version": "2.0.0",
+                        "state": {}
+                    },
+                    "f0479b348e2441cd87e1bd856fac5c22": {
+                        "model_name": "SliderStyleModel",
+                        "model_module": "@jupyter-widgets/controls",
+                        "model_module_version": "2.0.0",
+                        "state": {
+                            "description_width": ""
+                        }
+                    },
+                    "2182c1a3fe4a410f9b0a5306ae05c530": {
+                        "model_name": "IntSliderModel",
+                        "model_module": "@jupyter-widgets/controls",
+                        "model_module_version": "2.0.0",
+                        "state": {
+                            "value": 40,
+                            "style": "IPY_MODEL_f0479b348e2441cd87e1bd856fac5c22",
+                            "behavior": "drag-tap",
+                            "layout": "IPY_MODEL_cb13b25cf84542ba882ab2a9c6e57c6d"
+                        }
+                    },
+                    "5f2da4ad981b467cb2d4f07efe5141f4": {
+                        "model_name": "LayoutModel",
+                        "model_module": "@jupyter-widgets/base",
+                        "model_module_version": "2.0.0",
+                        "state": {}
+                    },
+                    "e5f63e1e06af400aac8135ff3394b856": {
+                        "model_name": "ButtonStyleModel",
+                        "model_module": "@jupyter-widgets/controls",
+                        "model_module_version": "2.0.0",
+                        "state": {
+                            "font_family": null,
+                            "font_size": null,
+                            "font_style": null,
+                            "font_variant": null,
+                            "font_weight": null,
+                            "text_color": null,
+                            "text_decoration": null
+                        }
+                    },
+                    "891a12a9856949b4be2e520f732dcca9": {
+                        "model_name": "ButtonModel",
+                        "model_module": "@jupyter-widgets/controls",
+                        "model_module_version": "2.0.0",
+                        "state": {
+                            "tooltip": null,
+                            "icon": "legal",
+                            "style": "IPY_MODEL_e5f63e1e06af400aac8135ff3394b856",
+                            "layout": "IPY_MODEL_5f2da4ad981b467cb2d4f07efe5141f4"
+                        }
+                    },
+                    "e8a6db8ff7bd4645b5b23ccb797dee9c": {
+                        "model_name": "DirectionalLinkModel",
+                        "model_module": "@jupyter-widgets/controls",
+                        "model_module_version": "2.0.0",
+                        "state": {
+                            "target": [
+                                "IPY_MODEL_2182c1a3fe4a410f9b0a5306ae05c530",
+                                "max"
+                            ],
+                            "source": [
+                                "IPY_MODEL_105655a5e8dc4b7bb19d824cc3ff7770",
+                                "value"
+                            ]
+                        }
+                    },
+                    "b9445ea442bc4a5aae73c1e2241c3922": {
+                        "model_name": "LayoutModel",
+                        "model_module": "@jupyter-widgets/base",
+                        "model_module_version": "2.0.0",
+                        "state": {}
+                    },
+                    "a08a1974ba01461c8d9b91b8bfa0f6ce": {
+                        "model_name": "VBoxModel",
+                        "model_module": "@jupyter-widgets/controls",
+                        "model_module_version": "2.0.0",
+                        "state": {
+                            "children": [
+                                "IPY_MODEL_105655a5e8dc4b7bb19d824cc3ff7770",
+                                "IPY_MODEL_2182c1a3fe4a410f9b0a5306ae05c530",
+                                "IPY_MODEL_891a12a9856949b4be2e520f732dcca9"
+                            ],
+                            "layout": "IPY_MODEL_b9445ea442bc4a5aae73c1e2241c3922"
+                        }
                     }
                 }
             }
-        }
-        </script>
-        <script type="application/vnd.jupyter.widget-view+json">
-        {
-            "model_id": "4c5a49e52ae54ad5bdbe973353a58931"
-        }
-        </script>
+            </script>
+            <script type="application/vnd.jupyter.widget-view+json">
+            {
+                "version_major": 2,
+                "version_minor": 0,
+                "model_id": "a08a1974ba01461c8d9b91b8bfa0f6ce"
+            }
+            </script>
     </body>
 </html>

--- a/examples/web4/index.js
+++ b/examples/web4/index.js
@@ -1,1 +1,1 @@
-require('@jupyter-widgets/html-manager/dist/embed');
+require('@jupyter-widgets/html-manager/lib/embed');

--- a/examples/web4/package.json
+++ b/examples/web4/package.json
@@ -18,9 +18,7 @@
   },
   "devDependencies": {
     "css-loader": "^6.5.1",
-    "file-loader": "^6.2.0",
     "style-loader": "^3.3.1",
-    "url-loader": "^4.1.1",
     "webpack": "^5.65.0"
   }
 }

--- a/examples/web4/webpack.config.js
+++ b/examples/web4/webpack.config.js
@@ -3,6 +3,7 @@ var webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
+  devtool: 'source-map',
   entry: './index.js',
   output: {
     filename: 'index.built.js',
@@ -11,50 +12,9 @@ module.exports = {
   module: {
     rules: [
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-      // jquery-ui loads some images
-      { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
       // required to load font-awesome
-      {
-        test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'application/font-woff',
-          },
-        },
-      },
-      {
-        test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'application/font-woff',
-          },
-        },
-      },
-      {
-        test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'application/octet-stream',
-          },
-        },
-      },
-      { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
-      {
-        test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-        use: {
-          loader: 'url-loader',
-          options: {
-            limit: 10000,
-            mimetype: 'image/svg+xml',
-          },
-        },
-      },
+      { test: /\.(woff|woff2|eot|ttf|otf)$/i, type: 'asset/resource' },
+      { test: /\.svg$/i, type: 'asset' },
     ],
   },
   plugins: [

--- a/examples/web4/webpack.config.js
+++ b/examples/web4/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   entry: './index.js',
   output: {
     filename: 'index.built.js',
-    path: path.resolve(__dirname, 'built')
+    path: path.resolve(__dirname, 'built'),
   },
   module: {
     rules: [

--- a/examples/web4/webpack.config.js
+++ b/examples/web4/webpack.config.js
@@ -6,8 +6,7 @@ module.exports = {
   entry: './index.js',
   output: {
     filename: 'index.built.js',
-    path: path.resolve(__dirname, 'built'),
-    publicPath: 'built/',
+    path: path.resolve(__dirname, 'built')
   },
   module: {
     rules: [

--- a/packages/base-manager/test/webpack-cov.conf.js
+++ b/packages/base-manager/test/webpack-cov.conf.js
@@ -4,8 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'coverage.js',
-    publicPath: './build/',
+    filename: 'coverage.js'
   },
   bail: true,
   module: {

--- a/packages/base-manager/test/webpack-cov.conf.js
+++ b/packages/base-manager/test/webpack-cov.conf.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'coverage.js'
+    filename: 'coverage.js',
   },
   bail: true,
   module: {

--- a/packages/base-manager/test/webpack.conf.js
+++ b/packages/base-manager/test/webpack.conf.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'bundle.js'
+    filename: 'bundle.js',
   },
   bail: true,
   module: {

--- a/packages/base-manager/test/webpack.conf.js
+++ b/packages/base-manager/test/webpack.conf.js
@@ -4,8 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'bundle.js',
-    publicPath: './build/',
+    filename: 'bundle.js'
   },
   bail: true,
   module: {

--- a/packages/base/test/webpack-cov.conf.js
+++ b/packages/base/test/webpack-cov.conf.js
@@ -4,8 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'coverage.js',
-    publicPath: './build/',
+    filename: 'coverage.js'
   },
   bail: true,
   module: {

--- a/packages/base/test/webpack-cov.conf.js
+++ b/packages/base/test/webpack-cov.conf.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'coverage.js'
+    filename: 'coverage.js',
   },
   bail: true,
   module: {

--- a/packages/base/test/webpack.conf.js
+++ b/packages/base/test/webpack.conf.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'bundle.js'
+    filename: 'bundle.js',
   },
   bail: true,
   module: {

--- a/packages/base/test/webpack.conf.js
+++ b/packages/base/test/webpack.conf.js
@@ -4,8 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'bundle.js',
-    publicPath: './build/',
+    filename: 'bundle.js'
   },
   bail: true,
   module: {

--- a/packages/controls/test/webpack-cov.conf.js
+++ b/packages/controls/test/webpack-cov.conf.js
@@ -4,8 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'coverage.js',
-    publicPath: './build/',
+    filename: 'coverage.js'
   },
   bail: true,
   module: {

--- a/packages/controls/test/webpack-cov.conf.js
+++ b/packages/controls/test/webpack-cov.conf.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'coverage.js'
+    filename: 'coverage.js',
   },
   bail: true,
   module: {

--- a/packages/controls/test/webpack.conf.js
+++ b/packages/controls/test/webpack.conf.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'bundle.js'
+    filename: 'bundle.js',
   },
   bail: true,
   module: {

--- a/packages/controls/test/webpack.conf.js
+++ b/packages/controls/test/webpack.conf.js
@@ -4,8 +4,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: __dirname + '/build',
-    filename: 'bundle.js',
-    publicPath: './build/',
+    filename: 'bundle.js'
   },
   bail: true,
   module: {

--- a/packages/html-manager/test/webpack.conf.js
+++ b/packages/html-manager/test/webpack.conf.js
@@ -7,8 +7,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: path.resolve(__dirname, 'build'),
-    filename: 'bundle.js',
-    publicPath: './build/',
+    filename: 'bundle.js'
   },
   bail: true,
   module: {

--- a/packages/html-manager/test/webpack.conf.js
+++ b/packages/html-manager/test/webpack.conf.js
@@ -7,7 +7,7 @@ module.exports = {
   entry: './test/build/index.js',
   output: {
     path: path.resolve(__dirname, 'build'),
-    filename: 'bundle.js'
+    filename: 'bundle.js',
   },
   bail: true,
   module: {

--- a/packages/html-manager/webpack.config.js
+++ b/packages/html-manager/webpack.config.js
@@ -56,10 +56,6 @@ var rules = [
   },
 ];
 
-var publicPath =
-  'https://cdn.jsdelivr.net/npm/@jupyter-widgets/html-manager@' +
-  version +
-  '/dist/';
 
 var plugins = [
   new webpack.DefinePlugin({
@@ -75,7 +71,6 @@ module.exports = [
     output: {
       filename: 'embed.js',
       path: path.resolve(__dirname, 'dist'),
-      publicPath: publicPath,
     },
     devtool: 'source-map',
     module: { rules: rules },
@@ -88,7 +83,6 @@ module.exports = [
     output: {
       filename: 'embed-amd-render.js',
       path: path.resolve(__dirname, 'dist', 'amd'),
-      publicPath: publicPath,
     },
     module: { rules: rules },
     mode: 'production',
@@ -101,7 +95,6 @@ module.exports = [
       library: '@jupyter-widgets/html-manager/dist/libembed-amd',
       filename: 'libembed-amd.js',
       path: path.resolve(__dirname, 'dist', 'amd'),
-      publicPath: publicPath,
       libraryTarget: 'amd',
     },
     module: { rules: rules },
@@ -115,7 +108,6 @@ module.exports = [
       library: '@jupyter-widgets/html-manager',
       filename: 'index.js',
       path: path.resolve(__dirname, 'dist', 'amd'),
-      publicPath: publicPath,
       libraryTarget: 'amd',
     },
     module: { rules: rules },
@@ -130,7 +122,6 @@ module.exports = [
       library: '@jupyter-widgets/base',
       filename: 'base.js',
       path: path.resolve(__dirname, 'dist', 'amd'),
-      publicPath: publicPath,
       libraryTarget: 'amd',
     },
     module: { rules: rules },
@@ -144,7 +135,6 @@ module.exports = [
       library: '@jupyter-widgets/controls',
       filename: 'controls.js',
       path: path.resolve(__dirname, 'dist', 'amd'),
-      publicPath: publicPath,
       libraryTarget: 'amd',
     },
     module: { rules: rules },

--- a/packages/html-manager/webpack.config.js
+++ b/packages/html-manager/webpack.config.js
@@ -56,7 +56,6 @@ var rules = [
   },
 ];
 
-
 var plugins = [
   new webpack.DefinePlugin({
     // Needed for Blueprint. See https://github.com/palantir/blueprint/issues/4393

--- a/yarn.lock
+++ b/yarn.lock
@@ -8684,7 +8684,7 @@ raw-body@2.4.2:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-loader@^4.0.2, raw-loader@~4.0.0:
+raw-loader@~4.0.0:
   version "4.0.2"
   resolved "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
   integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==


### PR DESCRIPTION
I started by updating the public path to 'auto' so that we don't have to hardcode jsdelivr in the html manager. This broke examples, so I updated the examples' webpack config as well.