### PR TITLE
fix: Issue 3466 - Disconnect broken link problems

### DIFF
--- a/packages/base/css/index.css
+++ b/packages/base/css/index.css
@@ -3,13 +3,13 @@
  */
 
 .jupyter-widgets-disconnected::before {
-  content: '\f127'; /* chain-broken */
+  content: "\f127"; /* chain-broken */
   display: inline-block;
-  font: normal normal normal 14px/1 FontAwesome;
+  font: normal normal 900 14px/1px "Font Awesome 5 Free";
   font-size: inherit;
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  -moz-osx-font-smoothing: grayscale; 
   color: #d9534f;
   padding: 3px;
   align-self: flex-start;

--- a/packages/base/css/index.css
+++ b/packages/base/css/index.css
@@ -3,13 +3,13 @@
  */
 
 .jupyter-widgets-disconnected::before {
-  content: "\f127"; /* chain-broken */
+  content: '\f127'; /* chain-broken */
   display: inline-block;
-  font: normal normal 900 14px/1px "Font Awesome 5 Free";
+  font: normal normal 900 14px/1px 'Font Awesome 5 Free';
   font-size: inherit;
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; 
+  -moz-osx-font-smoothing: grayscale;
   color: #d9534f;
   padding: 3px;
   align-self: flex-start;


### PR DESCRIPTION
PR Summary:
Issue #3466 mentions 2 issues. This PR specifically only fixes issue 1 - "When restarting, the broken link icon is, well, broken in jupyterlab."

Fix Description:
- updated font-weight to 900 as FontAwesome now only allows font-weight 900 as part of its free plans.