### PR TITLE
Update broken link icon to work in FontAwesome 4 and 5

### DIFF
--- a/packages/base/css/index.css
+++ b/packages/base/css/index.css
@@ -5,8 +5,7 @@
 .jupyter-widgets-disconnected::before {
   content: '\f127'; /* chain-broken */
   display: inline-block;
-  font: normal normal 900 14px/1px 'Font Awesome 5 Free';
-  font-size: inherit;
+  font: normal normal 900 14px/1 'Font Awesome 5 Free', 'FontAwesome';
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -68,11 +68,6 @@
   overflow: visible;
 }
 
-.jupyter-widgets.jupyter-widgets-disconnected::before {
-  line-height: var(--jp-widgets-inline-height);
-  height: var(--jp-widgets-inline-height);
-}
-
 .jp-Output-result > .jupyter-widgets {
   margin-left: 0;
   margin-right: 0;


### PR DESCRIPTION
#3475 fixed the broken link icon for FontAwesome 5, but unfortunately things broke for FontAwesome 4 (i.e., classic Notebook). This uses CSS that works for both FontAwesome 4 and FontAwesome 5, so the broken link works in classic notebook and JupyterLab.