### PR TITLE
Add back set_title and get_title to selection containers

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
@@ -26,3 +26,17 @@ class TestAccordion(TestCase):
     def test_selected_index_out_of_bounds(self):
         with self.assertRaises(TraitError):
             Accordion(self.children, selected_index=-1)
+
+
+    def test_titles(self):
+        accordion = Accordion(self.children, selected_index=None)
+        assert accordion.get_state()['titles'] == (None, None)
+        assert accordion.titles == (None, None)
+        accordion.set_title(1, 'Title 1')
+        assert accordion.get_state()['titles'] == (None, 'Title 1')
+        assert accordion.titles[1] == 'Title 1'
+        assert accordion.get_title(1) == 'Title 1'
+        with self.assertRaises(IndexError):
+            accordion.set_title(2, 'out of bounds')
+        with self.assertRaises(IndexError):
+            accordion.get_title(2)

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
@@ -30,13 +30,19 @@ class TestAccordion(TestCase):
 
     def test_titles(self):
         accordion = Accordion(self.children, selected_index=None)
-        assert accordion.get_state()['titles'] == (None, None)
-        assert accordion.titles == (None, None)
+        assert accordion.get_state()['titles'] == ('', '')
+        assert accordion.titles == ('', '')
+
         accordion.set_title(1, 'Title 1')
-        assert accordion.get_state()['titles'] == (None, 'Title 1')
+        assert accordion.get_state()['titles'] == ('', 'Title 1')
         assert accordion.titles[1] == 'Title 1'
         assert accordion.get_title(1) == 'Title 1'
+
         with self.assertRaises(IndexError):
             accordion.set_title(2, 'out of bounds')
         with self.assertRaises(IndexError):
             accordion.get_title(2)
+
+        accordion.children = tuple(accordion.children[:1])
+        assert len(accordion.children) == 1
+        assert accordion.titles == ('',)

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
@@ -38,6 +38,12 @@ class TestAccordion(TestCase):
         assert accordion.titles[1] == 'Title 1'
         assert accordion.get_title(1) == 'Title 1'
 
+        # Backwards compatible with 7.x api
+        accordion.set_title(1, None)
+        assert accordion.get_state()['titles'] == ('', '')
+        assert accordion.titles[1] == ''
+        assert accordion.get_title(1) == ''
+
         with self.assertRaises(IndexError):
             accordion.set_title(2, 'out of bounds')
         with self.assertRaises(IndexError):

--- a/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
@@ -21,7 +21,7 @@ def pad(iterable, padding=None, length=None):
 
 class _SelectionContainer(Box, CoreWidget):
     """Base class used to display multiple child widgets."""
-    titles = TypedTuple(trait=Unicode(allow_none=True), help="Titles of the pages").tag(sync=True)
+    titles = TypedTuple(trait=Unicode(), help="Titles of the pages").tag(sync=True)
     selected_index = CInt(
         help="""The index of the selected page. This is either an integer selecting a particular sub-widget, or None to have no widgets selected.""",
         allow_none=True,
@@ -37,7 +37,7 @@ class _SelectionContainer(Box, CoreWidget):
 
     @validate('titles')
     def _validate_titles(self, proposal):
-        return tuple(pad(proposal.value, None, len(self.children)))
+        return tuple(pad(proposal.value, '', len(self.children)))
 
     @observe('children')
     def _observe_children(self, change):
@@ -61,7 +61,7 @@ class _SelectionContainer(Box, CoreWidget):
         self.titles = tuple(titles)
 
     def get_title(self, index):
-        """Gets the title of a container pages.
+        """Gets the title of a container page.
         Parameters
         ----------
         index : int

--- a/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
@@ -57,6 +57,9 @@ class _SelectionContainer(Box, CoreWidget):
             New title
         """
         titles = list(self.titles)
+        # for backwards compatibility with ipywidgets 7.x
+        if title is None:
+            title = ''
         titles[index]=title
         self.titles = tuple(titles)
 


### PR DESCRIPTION
Add back set_title and get_title to selection containers

Also, we eagerly compute a title list that updates when the children are updated, so that `.titles` is always reasonable.

This does change the api slightly from 7.x: a title is not allowed to be None, but instead should be an empty string. 

In order to better preserve the 7.x api, I also make it so that if you do `set_title(index, None)`, it actually sets the title to `''`. However, if you do `get_title(index)`, it won't return None then, so that is a small breakage from the 7.x api.

Fixes #3471.