### PR TITLE
Use `dict` instead of `print` to test callable without signature

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,12 +88,12 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v1

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_interaction.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_interaction.py
@@ -578,7 +578,7 @@ def test_multiple_selection():
 
 def test_interact_noinspect():
     a = 'hello'
-    c = interactive(print, a=a)
+    c = interactive(dict, a=a)
     w = c.children[0]
     check_widget(w,
         cls=widgets.Text,

--- a/python/ipywidgets/setup.cfg
+++ b/python/ipywidgets/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3 :: Only
   Framework :: Jupyter
 

--- a/python/jupyterlab_widgets/setup.cfg
+++ b/python/jupyterlab_widgets/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3 :: Only
   Framework :: Jupyter
   Framework :: Jupyter :: JupyterLab

--- a/python/widgetsnbextension/setup.cfg
+++ b/python/widgetsnbextension/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3 :: Only
   Framework :: Jupyter
 


### PR DESCRIPTION
In Python 3.11, `inspect.signature(print)` no longer raises
ValueError.

Fixes: https://github.com/jupyter-widgets/ipywidgets/issues/3459