### PR TITLE
Backport PR #3478 on branch 7.x (Use dict instead of print to test callable without signature)

### DIFF
--- a/ipywidgets/widgets/tests/test_interaction.py
+++ b/ipywidgets/widgets/tests/test_interaction.py
@@ -703,7 +703,7 @@ def test_multiple_selection():
 
 def test_interact_noinspect():
     a = u'hello'
-    c = interactive(print, a=a)
+    c = interactive(dict, a=a)
     w = c.children[0]
     check_widget(w,
         cls=widgets.Text,


### PR DESCRIPTION
I have backported only the change for the test because in 7.x there is no testing matrix in Github Actions and no individual setup.{py,cfg} files – there is one in the root of the project but the Python versions there are outdated.