### PR TITLE
Check self.keys before accessing trait in set_state()

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/tests/test_set_state.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_set_state.py
@@ -304,8 +304,8 @@ def test_echo():
     assert widget.value == 1
 
     widget._send = mock.MagicMock()
-    # this mimics a value coming from the front end
-    widget.set_state({'value': 42})
+    # this mimics a state coming from the front end
+    widget.set_state({'value': 42, 'unexpected_field': 43})
     assert widget.value == 42
 
     # we expect this to be echoed

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -566,8 +566,8 @@ class Widget(LoggingHasTraits):
         # Send an echo update message immediately
         if JUPYTER_WIDGETS_ECHO:
             echo_state = {}
-            for attr,value in sync_data.items():
-                if self.trait_metadata(attr, 'echo_update', default=True):
+            for attr, value in sync_data.items():
+                if attr in self.keys and self.trait_metadata(attr, 'echo_update', default=True):
                     echo_state[attr] = value
             if echo_state:
                 echo_state, echo_buffer_paths, echo_buffers = _remove_buffers(echo_state)

--- a/python/jupyterlab_widgets/src/manager.ts
+++ b/python/jupyterlab_widgets/src/manager.ts
@@ -421,6 +421,7 @@ export class WidgetManager extends LabWidgetManager {
     this._context = context;
 
     context.sessionContext.kernelChanged.connect((sender, args) => {
+      console.log('kernel changed');
       this._handleKernelChanged(args);
     });
 

--- a/python/jupyterlab_widgets/src/manager.ts
+++ b/python/jupyterlab_widgets/src/manager.ts
@@ -421,7 +421,6 @@ export class WidgetManager extends LabWidgetManager {
     this._context = context;
 
     context.sessionContext.kernelChanged.connect((sender, args) => {
-      console.log('kernel changed');
       this._handleKernelChanged(args);
     });
 


### PR DESCRIPTION
When widgets echo mode is on (`JUPYTER_WIDGETS_ECHO == true`) and `sync_data` contains non-trait attribute, a `TraitError` will be thrown by `self.trait_metadata(attr, 'echo_update', default=True)`.

An example is from ipyleaflet where field `_dragging` can be [sent to kernel](https://github.com/jupyter-widgets/ipyleaflet/blob/3437521/js/src/Map.js#L272) while it's not a registered trait for class [Map](https://github.com/jupyter-widgets/ipyleaflet/blob/3437521c69514a965f7d8e5c559b82bd742a0dcc/ipyleaflet/leaflet.py#L2134)

We should check if attribute is inside `self.keys` before accessing it as a trait 