### PR TITLE
Fix message throttle by making a copy of the callbacks dict

### DIFF
--- a/packages/base/test/src/widget_test.ts
+++ b/packages/base/test/src/widget_test.ts
@@ -643,7 +643,7 @@ describe('WidgetModel', function () {
       });
       expect(this.widget._msg_buffer_callbacks).to.not.equals(null);
       // have the comm send a status idle message
-      callbacks.iopub.status({
+      this.comm.send.lastCall.args[1].iopub.status({
         content: {
           execution_state: 'idle',
         },
@@ -662,7 +662,7 @@ describe('WidgetModel', function () {
         },
         buffer_paths: [],
       });
-      callbacks.iopub.status({
+      this.comm.send.lastCall.args[1].iopub.status({
         content: {
           execution_state: 'idle',
         },
@@ -687,7 +687,7 @@ describe('WidgetModel', function () {
         state: { a: 'sync test - 2' },
         buffer_paths: [],
       });
-      callbacks.iopub.status({
+      this.comm.send.lastCall.args[1].iopub.status({
         content: {
           execution_state: 'idle',
         },
@@ -703,7 +703,7 @@ describe('WidgetModel', function () {
         },
         buffer_paths: [],
       });
-      callbacks.iopub.status({
+      this.comm.send.lastCall.args[1].iopub.status({
         content: {
           execution_state: 'idle',
         },


### PR DESCRIPTION
Fixes #3469 in a different way from #3470.

This partially reverts code changes from #3470, but leaves the tests.

I think the underlying assumptions around send_sync_message and callbacks are:

1. send_sync_message is only ever called once per message. When the original sync happens, either we put the message on the queue or we send it immediately, and the callback modifications happen only when we actually send the message.
2. There was an implicit assumption in the send_sync_message code is that the callbacks object passed in is a new object unique to this message, i.e., we aren't modifying a global object, that then we'll modify again later.

I think assumption 2 is sometimes not true, so this guards against it by making a (2-deep) copy of the callbacks object before modifying and using it.