### PR TITLE
Backport PR #3476: Update broken link icon to work in FontAwesome 4 and 5

### DIFF
--- a/packages/base/css/index.css
+++ b/packages/base/css/index.css
@@ -5,7 +5,7 @@
  .jupyter-widgets-disconnected::before {
     content: "\f127"; /* chain-broken */
     display: inline-block;
-    font: normal normal normal 14px/1 FontAwesome;
+    font: normal normal 900 14px/1 'Font Awesome 5 Free', 'FontAwesome';
     font-size: inherit;
     text-rendering: auto;
     -webkit-font-smoothing: antialiased;

--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -60,11 +60,6 @@
     overflow: visible;
 }
 
-.jupyter-widgets.jupyter-widgets-disconnected::before {
-    line-height: var(--jp-widgets-inline-height);
-    height: var(--jp-widgets-inline-height);
-}
-
 .jp-Output-result > .jupyter-widgets {
     margin-left: 0;
     margin-right: 0;


### PR DESCRIPTION
Backport PR #3476: Update broken link icon to work in FontAwesome 4 and 5