### PR TITLE
Add deprecated description_tooltip for backwards compatibility.

### DIFF
--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -1,7 +1,7 @@
 Migrating custom widget libraries
 =================================
 
-These are migration guides aimed specifically at developers of third-party
+These are migration guides specifically for developers of third-party
 widgets.
 
 Migrating from 7.x to 8.0

--- a/docs/source/user_migration_guides.md
+++ b/docs/source/user_migration_guides.md
@@ -1,7 +1,7 @@
 Migrating user code
 ===================
 
-These are migration guides aimed specifically at user of ipywidgets.
+These are migration guides specifically for ipywidgets users.
 
 Migrating from 7.x to 8.0
 -------------------------
@@ -85,6 +85,7 @@ attribute `data-jupyter-widgets-cdn` on the HTML manager script tag. See
 
 #### widgetsnbextension
 
-The `widgetsnbextension` package is no longer a dependency of `ipywidgets`. Consequently,
-neither is the `notebook` package. If you need to keep `notebook` and widget support for it
-you will need to ensure they are explicitly stated in any environment bootstrapping.
+The `notebook` package is no longer a dependency of the `widgetsnbextension`
+package (therefore `notebook` is no longer a dependency of `ipywidgets`). If you
+need to install `notebook` with `ipywidgets`, you will need to install
+`notebook` explicitly.

--- a/docs/source/user_migration_guides.md
+++ b/docs/source/user_migration_guides.md
@@ -30,12 +30,10 @@ to wrap reads from the widget.
 
 As part of an effort to make it possible to
 [set tooltips for all widgets](https://github.com/jupyter-widgets/ipywidgets/pull/2680),
-the old `description_tooltip` attribute for certain widgets was removed. Now all widgets
+the old `description_tooltip` attribute for certain widgets was deprecated. Now all widgets
 that inherit `DOMWidget` have the attribute `tooltip` instead.
 
 Suggested migration: Search and replace `description_tooltip` to `tooltip`.
-TBD: ipywidgets should add a `description_tooltip` keyword argument to `DescriptionWidget`s, with
-a deprecation warning.
 
 #### Selection Widgets
 

--- a/python/ipywidgets/ipywidgets/widgets/widget_description.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_description.py
@@ -9,6 +9,7 @@ from .trait_types import InstanceDict
 from .widget_style import Style
 from .widget_core import CoreWidget
 from .domwidget import DOMWidget
+import warnings
 
 @register
 class DescriptionStyle(Style, CoreWidget, Widget):
@@ -24,6 +25,13 @@ class DescriptionWidget(DOMWidget, CoreWidget):
     description_allow_html = Bool(False, help="Accept HTML in the description.").tag(sync=True)
     style = InstanceDict(DescriptionStyle, help="Styling customizations").tag(sync=True, **widget_serialization)
 
+    def __init__(self, *args, **kwargs):
+        if 'description_tooltip' in kwargs:
+            warnings.warn("the description_tooltip argument is deprecated, use tooltip instead", DeprecationWarning)
+            kwargs.setdefault('tooltip', kwargs['description_tooltip'])
+            del kwargs['description_tooltip']
+        super().__init__(*args, **kwargs)
+
     def _repr_keys(self):
         for key in super()._repr_keys():
             # Exclude style if it had the default value
@@ -32,3 +40,17 @@ class DescriptionWidget(DOMWidget, CoreWidget):
                 if repr(value) == '%s()' % value.__class__.__name__:
                     continue
             yield key
+
+    @property
+    def description_tooltip(self):
+        """The tooltip information.
+        .. deprecated :: 8.0.0
+           Use tooltip attribute instead.
+        """
+        warnings.warn(".description_tooltip is deprecated, use .tooltip instead", DeprecationWarning)
+        return self.tooltip
+
+    @description_tooltip.setter
+    def description_tooltip(self, tooltip):
+        warnings.warn(".description_tooltip is deprecated, use .tooltip instead", DeprecationWarning)
+        self.tooltip = tooltip


### PR DESCRIPTION
This follows up on #2680 to help users transition to this backwards-incompatible change.