### PR TITLE
Update to `jupyterlite==0.1.0b11` in the documentation

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -25,5 +25,5 @@ dependencies:
   - sphinx_rtd_theme
   - sympy
   - pip:
-    - jupyterlite==0.1.0b10
+    - jupyterlite==0.1.0b11
     - jupyterlite-sphinx>=0.6.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,5 +14,5 @@ packaging
 scikit-image
 scikit-learn
 sympy
-jupyterlite==0.1.0b10
+jupyterlite==0.1.0b11
 jupyterlite-sphinx>=0.6.0


### PR DESCRIPTION
Update to the latest `jupyterlite` released a couple of days ago, which contains a fix for reading and writing JSON files.