### PR TITLE
Fix selection container logic around setting titles.

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -23,7 +23,7 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}?urlpath=lab/tree/docs/source/examples/) :point_left: Launch a binder notebook on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_`
+            body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}?urlpath=lab/tree/docs/source/examples/) :point_left: Launch a binder notebook on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_. You can also try out changes using JupyterLite in the documentation that is built in the docs/readthedocs.org check below.`
           })
       env:
         PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from traitlets import TraitError
 
-from ipywidgets.widgets import Accordion, HTML
+from ipywidgets.widgets import Accordion, Tab, Stack, HTML
 
 
 class TestAccordion(TestCase):
@@ -26,6 +26,11 @@ class TestAccordion(TestCase):
     def test_selected_index_out_of_bounds(self):
         with self.assertRaises(TraitError):
             Accordion(self.children, selected_index=-1)
+
+    def test_children_position_argument(self):
+        Accordion(self.children)
+        Tab(self.children)
+        Stack(self.children)
 
 
     def test_titles(self):

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
@@ -5,55 +5,164 @@ from unittest import TestCase
 
 from traitlets import TraitError
 
-from ipywidgets.widgets import Accordion, Tab, Stack, HTML
+from ipywidgets.widgets import Accordion, Tab, Stacked, HTML
 
+class TestTab(TestCase):
+
+    def setUp(self):
+        self.children = [HTML('0'), HTML('1')]
+        self.widget = Tab
+
+    def test_selected_index_none(self):
+        widget = self.widget(self.children, selected_index=None)
+        state = widget.get_state()
+        assert state['selected_index'] == 0
+
+    def test_selected_index_default(self):
+        widget = self.widget(self.children)
+        state = widget.get_state()
+        assert state['selected_index'] == 0
+
+    def test_selected_index(self):
+        widget = self.widget(self.children, selected_index=1)
+        state = widget.get_state()
+        assert state['selected_index'] == 1
+
+    def test_selected_index_out_of_bounds(self):
+        with self.assertRaises(TraitError):
+            self.widget(self.children, selected_index=-1)
+
+    def test_children_position_argument(self):
+        self.widget(self.children)
+
+    def test_titles(self):
+        widget = self.widget(self.children, selected_index=None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles == ('', '')
+
+        widget.set_title(1, 'Title 1')
+        assert widget.get_state()['titles'] == ('', 'Title 1')
+        assert widget.titles[1] == 'Title 1'
+        assert widget.get_title(1) == 'Title 1'
+
+        # Backwards compatible with 7.x api
+        widget.set_title(1, None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles[1] == ''
+        assert widget.get_title(1) == ''
+
+        with self.assertRaises(IndexError):
+            widget.set_title(2, 'out of bounds')
+        with self.assertRaises(IndexError):
+            widget.get_title(2)
+
+        widget.children = tuple(widget.children[:1])
+        assert len(widget.children) == 1
+        assert widget.titles == ('',)
 
 class TestAccordion(TestCase):
 
     def setUp(self):
         self.children = [HTML('0'), HTML('1')]
+        self.widget = Accordion
 
     def test_selected_index_none(self):
-        accordion = Accordion(self.children, selected_index=None)
-        state = accordion.get_state()
+        widget = self.widget(self.children, selected_index=None)
+        state = widget.get_state()
+        assert state['selected_index'] is None
+
+    def test_selected_index_default(self):
+        widget = self.widget(self.children)
+        state = widget.get_state()
         assert state['selected_index'] is None
 
     def test_selected_index(self):
-        accordion = Accordion(self.children, selected_index=1)
-        state = accordion.get_state()
+        widget = self.widget(self.children, selected_index=1)
+        state = widget.get_state()
         assert state['selected_index'] == 1
 
     def test_selected_index_out_of_bounds(self):
         with self.assertRaises(TraitError):
-            Accordion(self.children, selected_index=-1)
+            self.widget(self.children, selected_index=-1)
 
     def test_children_position_argument(self):
-        Accordion(self.children)
-        Tab(self.children)
-        Stack(self.children)
-
+        self.widget(self.children)
 
     def test_titles(self):
-        accordion = Accordion(self.children, selected_index=None)
-        assert accordion.get_state()['titles'] == ('', '')
-        assert accordion.titles == ('', '')
+        widget = self.widget(self.children, selected_index=None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles == ('', '')
 
-        accordion.set_title(1, 'Title 1')
-        assert accordion.get_state()['titles'] == ('', 'Title 1')
-        assert accordion.titles[1] == 'Title 1'
-        assert accordion.get_title(1) == 'Title 1'
+        widget.set_title(1, 'Title 1')
+        assert widget.get_state()['titles'] == ('', 'Title 1')
+        assert widget.titles[1] == 'Title 1'
+        assert widget.get_title(1) == 'Title 1'
 
         # Backwards compatible with 7.x api
-        accordion.set_title(1, None)
-        assert accordion.get_state()['titles'] == ('', '')
-        assert accordion.titles[1] == ''
-        assert accordion.get_title(1) == ''
+        widget.set_title(1, None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles[1] == ''
+        assert widget.get_title(1) == ''
 
         with self.assertRaises(IndexError):
-            accordion.set_title(2, 'out of bounds')
+            widget.set_title(2, 'out of bounds')
         with self.assertRaises(IndexError):
-            accordion.get_title(2)
+            widget.get_title(2)
 
-        accordion.children = tuple(accordion.children[:1])
-        assert len(accordion.children) == 1
-        assert accordion.titles == ('',)
+        widget.children = tuple(widget.children[:1])
+        assert len(widget.children) == 1
+        assert widget.titles == ('',)
+
+class TestStacked(TestCase):
+
+    def setUp(self):
+        self.children = [HTML('0'), HTML('1')]
+        self.widget = Stacked
+
+    def test_selected_index_none(self):
+        widget = self.widget(self.children, selected_index=None)
+        state = widget.get_state()
+        assert state['selected_index'] is None
+
+    def test_selected_index_default(self):
+        widget = self.widget(self.children)
+        state = widget.get_state()
+        assert state['selected_index'] is None
+
+    def test_selected_index(self):
+        widget = self.widget(self.children, selected_index=1)
+        state = widget.get_state()
+        assert state['selected_index'] == 1
+
+    def test_selected_index_out_of_bounds(self):
+        with self.assertRaises(TraitError):
+            self.widget(self.children, selected_index=-1)
+
+    def test_children_position_argument(self):
+        self.widget(self.children)
+
+    def test_titles(self):
+        widget = self.widget(self.children, selected_index=None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles == ('', '')
+
+        widget.set_title(1, 'Title 1')
+        assert widget.get_state()['titles'] == ('', 'Title 1')
+        assert widget.titles[1] == 'Title 1'
+        assert widget.get_title(1) == 'Title 1'
+
+        # Backwards compatible with 7.x api
+        widget.set_title(1, None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles[1] == ''
+        assert widget.get_title(1) == ''
+
+        with self.assertRaises(IndexError):
+            widget.set_title(2, 'out of bounds')
+        with self.assertRaises(IndexError):
+            widget.get_title(2)
+
+        widget.children = tuple(widget.children[:1])
+        assert len(widget.children) == 1
+        assert widget.titles == ('',)
+

--- a/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
@@ -91,10 +91,10 @@ class Tab(_SelectionContainer):
     _view_name = Unicode('TabView').tag(sync=True)
     _model_name = Unicode('TabModel').tag(sync=True)
 
-    def __init__(self, **kwargs):
-        if 'children' in kwargs and 'selected_index' not in kwargs and len(kwargs['children']) > 0:
+    def __init__(self, children=(), **kwargs):
+        if len(children) > 0 and 'selected_index' not in kwargs:
             kwargs['selected_index'] = 0
-        super(Tab, self).__init__(**kwargs)
+        super().__init__(children=children, **kwargs)
 
     def _reset_selected_index(self):
         # if there are no tabs, then none should be selected

--- a/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
@@ -41,9 +41,15 @@ class _SelectionContainer(Box, CoreWidget):
 
     @observe('children')
     def _observe_children(self, change):
-        if self.selected_index is not None and len(change.new) < self.selected_index:
+        self._reset_selected_index()
+        self._reset_titles()
+
+    def _reset_selected_index(self):
+        if self.selected_index is not None and len(self.children) < self.selected_index:
             self.selected_index = None
-        if len(self.titles) != len(change.new):
+
+    def _reset_titles(self):
+        if len(self.titles) != len(self.children):
             # Run validation function
             self.titles = tuple(self.titles)
 
@@ -90,10 +96,10 @@ class Tab(_SelectionContainer):
             kwargs['selected_index'] = 0
         super(Tab, self).__init__(**kwargs)
 
-    @observe('children')
-    def _observe_children(self, change):
+    def _reset_selected_index(self):
         # if there are no tabs, then none should be selected
-        if len(change.new) == 0:
+        num_children = len(self.children)
+        if num_children == 0:
             self.selected_index = None
 
         # if there are tabs, but none is selected, select the first one
@@ -102,8 +108,9 @@ class Tab(_SelectionContainer):
 
         # if there are tabs and a selection, but the selection is no longer
         # valid, select the last tab.
-        elif len(change.new) < self.selected_index:
-            self.selected_index = len(change.new) - 1
+        elif num_children < self.selected_index:
+            self.selected_index = num_children - 1
+
 
 
 @register


### PR DESCRIPTION
Previously, the title logic was being overridden by Tab. This refactors the code so we can just override the selected index logic, without overriding the titles logic.

Fixes #3520