### PR TITLE
Rename Stacked widget to Stack

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -27,7 +27,7 @@ See also the
 - Tagsinput widget ([#2591](https://github.com/jupyter-widgets/ipywidgets/pull/2591), [#3272](https://github.com/jupyter-widgets/ipywidgets/pull/3272))
 - Drop notebook dependency from widgetsnbextension ([#2590](https://github.com/jupyter-widgets/ipywidgets/pull/2590))
 - Cast 'value' in range sliders to a tuple ([#2441](https://github.com/jupyter-widgets/ipywidgets/pull/2441))
-- Added a layout widget for 'stacked' layout ([#2376](https://github.com/jupyter-widgets/ipywidgets/pull/2376))
+- Added a layout widget for 'stack' layout ([#2376](https://github.com/jupyter-widgets/ipywidgets/pull/2376))
 - Play widget: expose playing and repeat ([#2283](https://github.com/jupyter-widgets/ipywidgets/pull/2283), [#1897](https://github.com/jupyter-widgets/ipywidgets/issues/1897))
 - Fix debouncing and throttling code ([#3060](https://github.com/jupyter-widgets/ipywidgets/pull/3060))
 - Fix regression on spinning icons ([#2685](https://github.com/jupyter-widgets/ipywidgets/pull/2685), [#2477](https://github.com/jupyter-widgets/ipywidgets/issues/2477))

--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -1388,9 +1388,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Stacked\n",
+    "### Stack\n",
     "\n",
-    "The `Stacked` widget can have multiple children widgets as for `Tab` and `Accordion`, but only shows one at a time depending on the value of ``selected_index``:"
+    "The `Stack` widget can have multiple children widgets as for `Tab` and `Accordion`, but only shows one at a time depending on the value of ``selected_index``:"
    ]
   },
   {
@@ -1401,8 +1401,8 @@
    "source": [
     "button = widgets.Button(description='Click here')\n",
     "slider = widgets.IntSlider()\n",
-    "stacked = widgets.Stacked([button, slider], selected_index=0)\n",
-    "stacked  # will show only the button"
+    "stack = widgets.Stack([button, slider], selected_index=0)\n",
+    "stack  # will show only the button"
    ]
   },
   {
@@ -1419,15 +1419,15 @@
    "outputs": [],
    "source": [
     "dropdown = widgets.Dropdown(options=['button', 'slider'])\n",
-    "widgets.jslink((dropdown, 'index'), (stacked, 'selected_index'))\n",
-    "widgets.VBox([dropdown, stacked])"
+    "widgets.jslink((dropdown, 'index'), (stack, 'selected_index'))\n",
+    "widgets.VBox([dropdown, stack])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Accordion,  Tab, and Stacked use `selected_index`, not value\n",
+    "### Accordion,  Tab, and Stack use `selected_index`, not value\n",
     "\n",
     "Unlike the rest of the widgets discussed earlier, the container widgets `Accordion` and `Tab` update their `selected_index` attribute when the user changes which accordion or tab is selected. That means that you can both see what the user is doing *and* programmatically set what the user sees by setting the value of `selected_index`.\n",
     "\n",

--- a/packages/controls/src/widget_selectioncontainer.ts
+++ b/packages/controls/src/widget_selectioncontainer.ts
@@ -422,17 +422,17 @@ export class TabView extends DOMWidgetView {
   luminoWidget: JupyterLuminoTabPanelWidget;
 }
 
-export class StackedModel extends SelectionContainerModel {
+export class StackModel extends SelectionContainerModel {
   defaults(): Backbone.ObjectHash {
     return {
       ...super.defaults(),
-      _model_name: 'StackedModel',
-      _view_name: 'StackedView',
+      _model_name: 'StackModel',
+      _view_name: 'StackView',
     };
   }
 }
 
-export class StackedView extends BoxView {
+export class StackView extends BoxView {
   initialize(parameters: WidgetView.IInitializeParameters): void {
     super.initialize(parameters);
     this.listenTo(this.model, 'change:selected_index', this.update_children);

--- a/packages/schema/jupyterwidgetmodels.latest.json
+++ b/packages/schema/jupyterwidgetmodels.latest.json
@@ -6554,7 +6554,7 @@
         "type": "string"
       },
       {
-        "default": "StackedModel",
+        "default": "StackModel",
         "help": "",
         "name": "_model_name",
         "type": "string"
@@ -6572,7 +6572,7 @@
         "type": "string"
       },
       {
-        "default": "StackedView",
+        "default": "StackView",
         "help": "",
         "name": "_view_name",
         "type": "string"
@@ -6634,12 +6634,12 @@
     ],
     "model": {
       "module": "@jupyter-widgets/controls",
-      "name": "StackedModel",
+      "name": "StackModel",
       "version": "2.0.0"
     },
     "view": {
       "module": "@jupyter-widgets/controls",
-      "name": "StackedView",
+      "name": "StackView",
       "version": "2.0.0"
     }
   },

--- a/packages/schema/jupyterwidgetmodels.latest.md
+++ b/packages/schema/jupyterwidgetmodels.latest.md
@@ -1168,17 +1168,17 @@ Attribute        | Type             | Default          | Help
 `description_width` | string           | `''`             | Width of the description to the side of the control.
 `handle_color`   | `null` or string | `null`           | Color of the slider handle.
 
-### StackedModel (@jupyter-widgets/controls, 2.0.0); StackedView (@jupyter-widgets/controls, 2.0.0)
+### StackModel (@jupyter-widgets/controls, 2.0.0); StackView (@jupyter-widgets/controls, 2.0.0)
 
 Attribute        | Type             | Default          | Help
 -----------------|------------------|------------------|----
 `_dom_classes`   | array of string  | `[]`             | CSS classes applied to widget DOM element
 `_model_module`  | string           | `'@jupyter-widgets/controls'` | 
 `_model_module_version` | string           | `'2.0.0'`        | 
-`_model_name`    | string           | `'StackedModel'` | 
+`_model_name`    | string           | `'StackModel'`   | 
 `_view_module`   | string           | `'@jupyter-widgets/controls'` | 
 `_view_module_version` | string           | `'2.0.0'`        | 
-`_view_name`     | string           | `'StackedView'`  | 
+`_view_name`     | string           | `'StackView'`    | 
 `box_style`      | string (one of `'success'`, `'info'`, `'warning'`, `'danger'`, `''`) | `''`             | Use a predefined styling for the box.
 `children`       | array of reference to Widget widget | `[]`             | List of widget children
 `layout`         | reference to Layout widget | reference to new instance | 

--- a/python/ipywidgets/ipywidgets/widgets/__init__.py
+++ b/python/ipywidgets/ipywidgets/widgets/__init__.py
@@ -19,7 +19,7 @@ from .widget_datetime import DatetimePicker
 from .widget_time import TimePicker
 from .widget_output import Output
 from .widget_selection import RadioButtons, ToggleButtons, ToggleButtonsStyle, Dropdown, Select, SelectionSlider, SelectMultiple, SelectionRangeSlider
-from .widget_selectioncontainer import Tab, Accordion, Stacked
+from .widget_selectioncontainer import Tab, Accordion, Stack
 from .widget_string import HTML, HTMLMath, Label, Text, Textarea, Password, Combobox
 from .widget_controller import Controller
 from .interaction import interact, interactive, fixed, interact_manual, interactive_output

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from traitlets import TraitError
 
-from ipywidgets.widgets import Accordion, HTML
+from ipywidgets.widgets import Accordion, Tab, Stack, HTML
 
 
 class TestAccordion(TestCase):
@@ -26,6 +26,11 @@ class TestAccordion(TestCase):
     def test_selected_index_out_of_bounds(self):
         with self.assertRaises(TraitError):
             Accordion(self.children, selected_index=-1)
+
+    def test_children_position_argument(self):
+        Accordion(self.children)
+        Tab(self.children)
+        Stack(self.children)
 
 
     def test_titles(self):

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
@@ -5,55 +5,164 @@ from unittest import TestCase
 
 from traitlets import TraitError
 
-from ipywidgets.widgets import Accordion, Tab, Stack, HTML
+from ipywidgets.widgets import Accordion, Tab, Stacked, HTML
 
+class TestTab(TestCase):
+
+    def setUp(self):
+        self.children = [HTML('0'), HTML('1')]
+        self.widget = Tab
+
+    def test_selected_index_none(self):
+        widget = self.widget(self.children, selected_index=None)
+        state = widget.get_state()
+        assert state['selected_index'] == 0
+
+    def test_selected_index_default(self):
+        widget = self.widget(self.children)
+        state = widget.get_state()
+        assert state['selected_index'] == 0
+
+    def test_selected_index(self):
+        widget = self.widget(self.children, selected_index=1)
+        state = widget.get_state()
+        assert state['selected_index'] == 1
+
+    def test_selected_index_out_of_bounds(self):
+        with self.assertRaises(TraitError):
+            self.widget(self.children, selected_index=-1)
+
+    def test_children_position_argument(self):
+        self.widget(self.children)
+
+    def test_titles(self):
+        widget = self.widget(self.children, selected_index=None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles == ('', '')
+
+        widget.set_title(1, 'Title 1')
+        assert widget.get_state()['titles'] == ('', 'Title 1')
+        assert widget.titles[1] == 'Title 1'
+        assert widget.get_title(1) == 'Title 1'
+
+        # Backwards compatible with 7.x api
+        widget.set_title(1, None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles[1] == ''
+        assert widget.get_title(1) == ''
+
+        with self.assertRaises(IndexError):
+            widget.set_title(2, 'out of bounds')
+        with self.assertRaises(IndexError):
+            widget.get_title(2)
+
+        widget.children = tuple(widget.children[:1])
+        assert len(widget.children) == 1
+        assert widget.titles == ('',)
 
 class TestAccordion(TestCase):
 
     def setUp(self):
         self.children = [HTML('0'), HTML('1')]
+        self.widget = Accordion
 
     def test_selected_index_none(self):
-        accordion = Accordion(self.children, selected_index=None)
-        state = accordion.get_state()
+        widget = self.widget(self.children, selected_index=None)
+        state = widget.get_state()
+        assert state['selected_index'] is None
+
+    def test_selected_index_default(self):
+        widget = self.widget(self.children)
+        state = widget.get_state()
         assert state['selected_index'] is None
 
     def test_selected_index(self):
-        accordion = Accordion(self.children, selected_index=1)
-        state = accordion.get_state()
+        widget = self.widget(self.children, selected_index=1)
+        state = widget.get_state()
         assert state['selected_index'] == 1
 
     def test_selected_index_out_of_bounds(self):
         with self.assertRaises(TraitError):
-            Accordion(self.children, selected_index=-1)
+            self.widget(self.children, selected_index=-1)
 
     def test_children_position_argument(self):
-        Accordion(self.children)
-        Tab(self.children)
-        Stack(self.children)
-
+        self.widget(self.children)
 
     def test_titles(self):
-        accordion = Accordion(self.children, selected_index=None)
-        assert accordion.get_state()['titles'] == ('', '')
-        assert accordion.titles == ('', '')
+        widget = self.widget(self.children, selected_index=None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles == ('', '')
 
-        accordion.set_title(1, 'Title 1')
-        assert accordion.get_state()['titles'] == ('', 'Title 1')
-        assert accordion.titles[1] == 'Title 1'
-        assert accordion.get_title(1) == 'Title 1'
+        widget.set_title(1, 'Title 1')
+        assert widget.get_state()['titles'] == ('', 'Title 1')
+        assert widget.titles[1] == 'Title 1'
+        assert widget.get_title(1) == 'Title 1'
 
         # Backwards compatible with 7.x api
-        accordion.set_title(1, None)
-        assert accordion.get_state()['titles'] == ('', '')
-        assert accordion.titles[1] == ''
-        assert accordion.get_title(1) == ''
+        widget.set_title(1, None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles[1] == ''
+        assert widget.get_title(1) == ''
 
         with self.assertRaises(IndexError):
-            accordion.set_title(2, 'out of bounds')
+            widget.set_title(2, 'out of bounds')
         with self.assertRaises(IndexError):
-            accordion.get_title(2)
+            widget.get_title(2)
 
-        accordion.children = tuple(accordion.children[:1])
-        assert len(accordion.children) == 1
-        assert accordion.titles == ('',)
+        widget.children = tuple(widget.children[:1])
+        assert len(widget.children) == 1
+        assert widget.titles == ('',)
+
+class TestStacked(TestCase):
+
+    def setUp(self):
+        self.children = [HTML('0'), HTML('1')]
+        self.widget = Stacked
+
+    def test_selected_index_none(self):
+        widget = self.widget(self.children, selected_index=None)
+        state = widget.get_state()
+        assert state['selected_index'] is None
+
+    def test_selected_index_default(self):
+        widget = self.widget(self.children)
+        state = widget.get_state()
+        assert state['selected_index'] is None
+
+    def test_selected_index(self):
+        widget = self.widget(self.children, selected_index=1)
+        state = widget.get_state()
+        assert state['selected_index'] == 1
+
+    def test_selected_index_out_of_bounds(self):
+        with self.assertRaises(TraitError):
+            self.widget(self.children, selected_index=-1)
+
+    def test_children_position_argument(self):
+        self.widget(self.children)
+
+    def test_titles(self):
+        widget = self.widget(self.children, selected_index=None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles == ('', '')
+
+        widget.set_title(1, 'Title 1')
+        assert widget.get_state()['titles'] == ('', 'Title 1')
+        assert widget.titles[1] == 'Title 1'
+        assert widget.get_title(1) == 'Title 1'
+
+        # Backwards compatible with 7.x api
+        widget.set_title(1, None)
+        assert widget.get_state()['titles'] == ('', '')
+        assert widget.titles[1] == ''
+        assert widget.get_title(1) == ''
+
+        with self.assertRaises(IndexError):
+            widget.set_title(2, 'out of bounds')
+        with self.assertRaises(IndexError):
+            widget.get_title(2)
+
+        widget.children = tuple(widget.children[:1])
+        assert len(widget.children) == 1
+        assert widget.titles == ('',)
+

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_selectioncontainer.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from traitlets import TraitError
 
-from ipywidgets.widgets import Accordion, Tab, Stacked, HTML
+from ipywidgets.widgets import Accordion, Tab, Stack, HTML
 
 class TestTab(TestCase):
 
@@ -113,11 +113,11 @@ class TestAccordion(TestCase):
         assert len(widget.children) == 1
         assert widget.titles == ('',)
 
-class TestStacked(TestCase):
+class TestStack(TestCase):
 
     def setUp(self):
         self.children = [HTML('0'), HTML('1')]
-        self.widget = Stacked
+        self.widget = Stack
 
     def test_selected_index_none(self):
         widget = self.widget(self.children, selected_index=None)

--- a/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
@@ -91,10 +91,10 @@ class Tab(_SelectionContainer):
     _view_name = Unicode('TabView').tag(sync=True)
     _model_name = Unicode('TabModel').tag(sync=True)
 
-    def __init__(self, **kwargs):
-        if 'children' in kwargs and 'selected_index' not in kwargs and len(kwargs['children']) > 0:
+    def __init__(self, children=(), **kwargs):
+        if len(children) > 0 and 'selected_index' not in kwargs:
             kwargs['selected_index'] = 0
-        super(Tab, self).__init__(**kwargs)
+        super().__init__(children=children, **kwargs)
 
     def _reset_selected_index(self):
         # if there are no tabs, then none should be selected

--- a/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
@@ -41,9 +41,15 @@ class _SelectionContainer(Box, CoreWidget):
 
     @observe('children')
     def _observe_children(self, change):
-        if self.selected_index is not None and len(change.new) < self.selected_index:
+        self._reset_selected_index()
+        self._reset_titles()
+
+    def _reset_selected_index(self):
+        if self.selected_index is not None and len(self.children) < self.selected_index:
             self.selected_index = None
-        if len(self.titles) != len(change.new):
+
+    def _reset_titles(self):
+        if len(self.titles) != len(self.children):
             # Run validation function
             self.titles = tuple(self.titles)
 
@@ -90,10 +96,10 @@ class Tab(_SelectionContainer):
             kwargs['selected_index'] = 0
         super(Tab, self).__init__(**kwargs)
 
-    @observe('children')
-    def _observe_children(self, change):
+    def _reset_selected_index(self):
         # if there are no tabs, then none should be selected
-        if len(change.new) == 0:
+        num_children = len(self.children)
+        if num_children == 0:
             self.selected_index = None
 
         # if there are tabs, but none is selected, select the first one
@@ -102,8 +108,9 @@ class Tab(_SelectionContainer):
 
         # if there are tabs and a selection, but the selection is no longer
         # valid, select the last tab.
-        elif len(change.new) < self.selected_index:
-            self.selected_index = len(change.new) - 1
+        elif num_children < self.selected_index:
+            self.selected_index = num_children - 1
+
 
 
 @register

--- a/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_selectioncontainer.py
@@ -114,7 +114,7 @@ class Tab(_SelectionContainer):
 
 
 @register
-class Stacked(_SelectionContainer):
+class Stack(_SelectionContainer):
     """Displays only the selected child."""
-    _view_name = Unicode('StackedView').tag(sync=True)
-    _model_name = Unicode('StackedModel').tag(sync=True)
+    _view_name = Unicode('StackView').tag(sync=True)
+    _model_name = Unicode('StackModel').tag(sync=True)


### PR DESCRIPTION
The Stacked widget was added in #2376. Considering the name, all of our other widgets are present tense, like Accordion, Tab, Box, etc, so the grammar of "Stack" feels like it fits better than "Stacked". As a survey:

Toolkits that use "Stack":

* flutter: https://api.flutter.dev/flutter/widgets/Stack-class.html
* GTK: https://docs.gtk.org/gtk4/class.Stack.html
* MUI: https://mui.com/material-ui/react-stack/
* Kivy: https://kivy.org/doc/stable/api-kivy.uix.stacklayout.html?highlight=stack

Toolkits that use "Stacked":

* QT: https://doc.qt.io/qt-6/qstackedwidget.html
* Lumino (which in general follows QT closely)

This builds on #3522, so that should be merged first.
