### PR TITLE
Using the new Comm Python package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install file://$PWD/python/ipywidgets#egg=ipywidgets
+          pip install file://$PWD/python/ipywidgets#egg=ipywidgets[test]
       - name: Install JS dependencies
         run: |
           yarn

--- a/python/ipywidgets/ipywidgets/tests/test_embed.py
+++ b/python/ipywidgets/ipywidgets/tests/test_embed.py
@@ -9,6 +9,9 @@ import shutil
 
 import traitlets
 
+# This has a byproduct of setting up the comms
+import ipykernel.ipkernel
+
 from ..widgets import IntSlider, IntText, Text, Widget, jslink, HBox, widget_serialization, widget as widget_module
 from ..embed import embed_data, embed_snippet, embed_minimal_html, dependency_state
 

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_interaction.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_interaction.py
@@ -624,4 +624,3 @@ def test_state_schema():
     with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../', 'state.schema.json')) as f:
         schema = json.load(f)
     jsonschema.validate(state, schema)
-

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_templates.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_templates.py
@@ -229,7 +229,7 @@ class TestTwoByTwoLayout(TestCase):
         assert box.layout.grid_template_areas == ('"top-left top-right"\n' +
                                                   '"bottom-left bottom-right"')
         # check whether frontend was informed
-        send_state.assert_called_once_with(key="grid_template_areas")
+        send_state.assert_called_with(key="grid_template_areas")
 
         box = widgets.TwoByTwoLayout(top_left=button1, top_right=button3,
                                      bottom_left=None, bottom_right=button4)
@@ -240,7 +240,7 @@ class TestTwoByTwoLayout(TestCase):
         box.merge = False
         assert box.layout.grid_template_areas == ('"top-left top-right"\n' +
                                                   '"bottom-left bottom-right"')
-        send_state.assert_called_once_with(key="grid_template_areas")
+        send_state.assert_called_with(key="grid_template_areas")
 
 
 class TestAppLayout(TestCase):

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_upload.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_upload.py
@@ -76,8 +76,8 @@ class TestFileUpload(TestCase):
         from ipykernel.comm import Comm
         uploader = FileUpload()
         mock_comm = MagicMock(spec=Comm)
-        mock_comm.kernel = 'does not matter'
         mock_comm.send = MagicMock()
+        mock_comm.kernel = 'does not matter'
         uploader.comm = mock_comm
         message = {'value': [FILE_UPLOAD_FRONTEND_CONTENT]}
         uploader.set_state(message)

--- a/python/ipywidgets/ipywidgets/widgets/tests/utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/utils.py
@@ -4,8 +4,14 @@
 from ipywidgets import Widget
 import ipywidgets.widgets.widget
 
-import comm
-from ipykernel.comm import Comm
+# The new comm package is not available in our Python 3.7 CI (older ipykernel version)
+try:
+    import comm
+    NEW_COMM_PACKAGE = True
+except ImportError:
+    NEW_COMM_PACKAGE = False
+
+import ipykernel.comm
 
 
 class DummyComm():
@@ -13,7 +19,7 @@ class DummyComm():
     kernel = 'Truthy'
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__()
         self.messages = []
 
     def open(self, *args, **kwargs):
@@ -40,12 +46,24 @@ def dummy_get_comm_manager(**kwargs):
 _widget_attrs = {}
 undefined = object()
 
-orig_create_comm = comm.create_comm
-orig_get_comm_manager = comm.get_comm_manager
+if NEW_COMM_PACKAGE:
+    orig_comm = ipykernel.comm.comm.BaseComm
+else:
+    orig_comm = ipykernel.comm.Comm
+orig_create_comm = None
+orig_get_comm_manager = None
+
+if NEW_COMM_PACKAGE:
+    orig_create_comm = comm.create_comm
+    orig_get_comm_manager = comm.get_comm_manager
 
 def setup_test_comm():
-    comm.create_comm = dummy_create_comm
-    comm.get_comm_manager = dummy_get_comm_manager
+    if NEW_COMM_PACKAGE:
+        comm.create_comm = dummy_create_comm
+        comm.get_comm_manager = dummy_get_comm_manager
+        ipykernel.comm.comm.BaseComm = DummyComm
+    else:
+        ipykernel.comm.Comm = DummyComm
     Widget.comm.klass = DummyComm
     ipywidgets.widgets.widget.Comm = DummyComm
     _widget_attrs['_repr_mimebundle_'] = Widget._repr_mimebundle_
@@ -54,10 +72,14 @@ def setup_test_comm():
     Widget._repr_mimebundle_ = raise_not_implemented
 
 def teardown_test_comm():
-    comm.create_comm = orig_create_comm
-    comm.get_comm_manager = orig_get_comm_manager
-    Widget.comm.klass = Comm
-    ipywidgets.widgets.widget.Comm = Comm
+    if NEW_COMM_PACKAGE:
+        comm.create_comm = orig_create_comm
+        comm.get_comm_manager = orig_get_comm_manager
+        ipykernel.comm.comm.BaseComm = orig_comm
+    else:
+        ipykernel.comm.Comm = orig_comm
+    Widget.comm.klass = orig_comm
+    ipywidgets.widgets.widget.Comm = orig_comm
     for attr, value in _widget_attrs.items():
         if value is undefined:
             delattr(Widget, attr)

--- a/python/ipywidgets/ipywidgets/widgets/tests/utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/utils.py
@@ -1,11 +1,14 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ipykernel.comm import Comm
 from ipywidgets import Widget
 import ipywidgets.widgets.widget
 
-class DummyComm(Comm):
+import comm
+from ipykernel.comm import Comm
+
+
+class DummyComm():
     comm_id = 'a-b-c-d'
     kernel = 'Truthy'
 
@@ -16,16 +19,33 @@ class DummyComm(Comm):
     def open(self, *args, **kwargs):
         pass
 
+    def on_msg(self, *args, **kwargs):
+        pass
+
     def send(self, *args, **kwargs):
         self.messages.append((args, kwargs))
 
     def close(self, *args, **kwargs):
         pass
 
+
+def dummy_create_comm(**kwargs):
+    return DummyComm()
+
+
+def dummy_get_comm_manager(**kwargs):
+    return {}
+
+
 _widget_attrs = {}
 undefined = object()
 
+orig_create_comm = comm.create_comm
+orig_get_comm_manager = comm.get_comm_manager
+
 def setup_test_comm():
+    comm.create_comm = dummy_create_comm
+    comm.get_comm_manager = dummy_get_comm_manager
     Widget.comm.klass = DummyComm
     ipywidgets.widgets.widget.Comm = DummyComm
     _widget_attrs['_repr_mimebundle_'] = Widget._repr_mimebundle_
@@ -34,6 +54,8 @@ def setup_test_comm():
     Widget._repr_mimebundle_ = raise_not_implemented
 
 def teardown_test_comm():
+    comm.create_comm = orig_create_comm
+    comm.get_comm_manager = orig_get_comm_manager
     Widget.comm.klass = Comm
     ipywidgets.widgets.widget.Comm = Comm
     for attr, value in _widget_attrs.items():

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from collections.abc import Iterable
 from IPython import get_ipython
 from traitlets import (
-    HasTraits, Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default, Container,
+    Any, HasTraits, Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default, Container,
     Undefined)
 from json import loads as jsonloads, dumps as jsondumps
 
@@ -479,7 +479,7 @@ class Widget(LoggingHasTraits):
 
     _view_count = Int(None, allow_none=True,
         help="EXPERIMENTAL: The number of views of the model displayed in the frontend. This attribute is experimental and may change or be removed in the future. None signifies that views will not be tracked. Set this to 0 to start tracking view creation/deletion.").tag(sync=True)
-    comm = Instance(object, allow_none=True)
+    comm = Any(allow_none=True)
 
     keys = List(help="The traits which are synced.")
 

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from collections.abc import Iterable
 from IPython import get_ipython
 from traitlets import (
-    Any, HasTraits, Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default, Container,
+    HasTraits, Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default, Container,
     Undefined)
 from json import loads as jsonloads, dumps as jsondumps
 
@@ -479,7 +479,7 @@ class Widget(LoggingHasTraits):
 
     _view_count = Int(None, allow_none=True,
         help="EXPERIMENTAL: The number of views of the model displayed in the frontend. This attribute is experimental and may change or be removed in the future. None signifies that views will not be tracked. Set this to 0 to start tracking view creation/deletion.").tag(sync=True)
-    comm = Any(None, allow_none=True)
+    comm = Instance(object, allow_none=True)
 
     keys = List(help="The traits which are synced.")
 
@@ -693,7 +693,7 @@ class Widget(LoggingHasTraits):
         # Send the state to the frontend before the user-registered callbacks
         # are called.
         name = change['name']
-        if self.comm is not None:
+        if self.comm is not None and (self.comm.kernel is not None if hasattr(self.comm, "kernel") else True):
             # Make sure this isn't information that the front-end just sent us.
             if name in self.keys and self._should_send_property(name, getattr(self, name)):
                 # Send new state to front-end
@@ -821,7 +821,7 @@ class Widget(LoggingHasTraits):
 
     def _send(self, msg, buffers=None):
         """Sends a message to the model in the front-end."""
-        if self.comm is not None:
+        if self.comm is not None and (self.comm.kernel is not None if hasattr(self.comm, "kernel") else True):
             self.comm.send(data=msg, buffers=buffers)
 
     def _repr_keys(self):

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -693,7 +693,7 @@ class Widget(LoggingHasTraits):
         # Send the state to the frontend before the user-registered callbacks
         # are called.
         name = change['name']
-        if self.comm is not None and (self.comm.kernel is not None if hasattr(self.comm, "kernel") else True):
+        if self.comm is not None and getattr(self.comm, 'kernel', True) is not None:
             # Make sure this isn't information that the front-end just sent us.
             if name in self.keys and self._should_send_property(name, getattr(self, name)):
                 # Send new state to front-end

--- a/python/ipywidgets/ipywidgets/widgets/widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_output.py
@@ -136,6 +136,7 @@ class Output(DOMWidget):
                 ip.showtraceback((etype, evalue, tb), tb_offset=0)
             elif (self.comm is not None and
                     getattr(self.comm, "kernel", None) is not None and
+                    # Check if it's ipykernel
                     getattr(self.comm.kernel, "send_response", None) is not None):
                 kernel = self.comm.kernel
                 kernel.send_response(kernel.iopub_socket,

--- a/python/ipywidgets/ipywidgets/widgets/widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_output.py
@@ -111,7 +111,7 @@ class Output(DOMWidget):
         kernel = None
         if ip and getattr(ip, "kernel", None) is not None:
             kernel = ip.kernel
-        elif self.comm is not None and getattr(self.comm, "kernel", None) is not None:
+        elif self.comm is not None and getattr(self.comm, 'kernel', True) is not None:
             kernel = self.comm.kernel
 
         if kernel:

--- a/python/ipywidgets/ipywidgets/widgets/widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_output.py
@@ -111,9 +111,9 @@ class Output(DOMWidget):
         kernel = None
         if ip and getattr(ip, "kernel", None) is not None:
             kernel = ip.kernel
-        elif self.comm is not None and self.comm.kernel is not None:
+        elif self.comm is not None and getattr(self.comm, "kernel", None) is not None:
             kernel = self.comm.kernel
-        
+
         if kernel:
             parent = None
             if hasattr(kernel, "get_parent"):
@@ -134,7 +134,9 @@ class Output(DOMWidget):
             if ip:
                 kernel = ip
                 ip.showtraceback((etype, evalue, tb), tb_offset=0)
-            elif self.comm is not None and self.comm.kernel is not None:
+            elif (self.comm is not None and
+                    getattr(self.comm, "kernel", None) is not None and
+                    getattr(self.comm.kernel, "send_response", None) is not None):
                 kernel = self.comm.kernel
                 kernel.send_response(kernel.iopub_socket,
                                      u'error',

--- a/python/ipywidgets/setup.cfg
+++ b/python/ipywidgets/setup.cfg
@@ -34,7 +34,6 @@ zip_safe = False
 packages = find:
 
 install_requires =
-  ipykernel>=4.5.1
   ipython>=6.1.0
   traitlets>=4.3.1
   widgetsnbextension~=4.0
@@ -43,6 +42,7 @@ install_requires =
 [options.extras_require]
 test =
   jsonschema
+  ipykernel
   pytest>=3.6.0
   pytest-cov
   pytz


### PR DESCRIPTION
Related discussions:
- https://github.com/jupyter-xeus/xeus-python/issues/342 
- https://github.com/jupyter-widgets/ipywidgets/issues/3514

Currently working on a Python comm package on https://github.com/martinRenou/comm for now, but it should probably be moved in the IPython org

This has the benefit of being able to:
- remove the ipykernel dependency in ipywidgets https://github.com/jupyter-widgets/ipywidgets/pull/3533
- remove the ipykernel monkey patch in xeus-python https://github.com/jupyter-xeus/xeus-python/pull/548
- remove the ipykernel package mock in jupyterlite's pyolite 
- remove the ipykernel package mock in emscripten-forge