### PR TITLE
Lazy load the JupyterLite example on the docs front page.

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -26,4 +26,4 @@ dependencies:
   - sympy
   - pip:
     - jupyterlite==0.1.0b11
-    - jupyterlite-sphinx>=0.6.0
+    - jupyterlite-sphinx>=0.7.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,4 +15,4 @@ scikit-image
 scikit-learn
 sympy
 jupyterlite==0.1.0b11
-jupyterlite-sphinx>=0.6.0
+jupyterlite-sphinx>=0.7.0

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,9 @@ tab with the `JupyterLab <lite/lab/?path=Widget%20List.ipynb>`_ or `Jupyter
 Notebook <./lite/retro/tree>`_ interfaces (provided by JupyterLite).
 
 .. retrolite:: examples/Widget List.ipynb
+   :width: 100%
+   :height: 600px
+   :prompt: Try ipywidgets!
 
 Learning widgets
 ----------------


### PR DESCRIPTION
Jupyterlite-sphinx now has an option to lazily load the heavy jlite bundle.