### PR TITLE
Fix jupyterlite_contents

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -26,4 +26,4 @@ dependencies:
   - sympy
   - pip:
     - jupyterlite==0.1.0b11
-    - jupyterlite-sphinx~=0.7.0
+    - jupyterlite-sphinx~=0.7.2

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -26,4 +26,4 @@ dependencies:
   - sympy
   - pip:
     - jupyterlite==0.1.0b11
-    - jupyterlite-sphinx>=0.7.0
+    - jupyterlite-sphinx~=0.7.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,4 +15,4 @@ scikit-image
 scikit-learn
 sympy
 jupyterlite==0.1.0b11
-jupyterlite-sphinx>=0.7.0
+jupyterlite-sphinx~=0.7.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,4 +15,4 @@ scikit-image
 scikit-learn
 sympy
 jupyterlite==0.1.0b11
-jupyterlite-sphinx~=0.7.0
+jupyterlite-sphinx~=0.7.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,7 @@ jupyterlite_dir = "."
 # "examples/Layout Example.ipynb", # bqplot/ipyleaflet dependencies require ipywidgets 7
 # "examples/Layout Templates.ipynb", # bqplot/ipyleaflet dependencies require ipywidgets 7
 # "examples/Variable Inspector.ipynb", # uses ipykernel-specific features
-jupyterlite_contents = "examples"
+jupyterlite_contents = ["examples"]
 
 # intersphinx_mapping = {
 #     'ipython': ('http://ipython.org/ipython-doc/dev/', None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -160,8 +160,12 @@ def on_config_inited(*args):
     IPYW = ROOT / "python/ipywidgets"
     subprocess.check_call([sys.executable, "-m", "build"], cwd=str(IPYW))
 
+    WIDG = ROOT / "python/widgetsnbextension"
+    subprocess.check_call([sys.executable, "-m", "build"], cwd=str(WIDG))
+
     JLW = ROOT / "python/jupyterlab_widgets"
     subprocess.check_call(["jupyter", "labextension", "build", "."], cwd=str(JLW))
+    subprocess.check_call([sys.executable, "-m", "build"], cwd=str(JLW))
 
 def setup(app):
     app.connect("config-inited", on_config_inited)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,7 @@ jupyterlite_dir = "."
 # "examples/Layout Example.ipynb", # bqplot/ipyleaflet dependencies require ipywidgets 7
 # "examples/Layout Templates.ipynb", # bqplot/ipyleaflet dependencies require ipywidgets 7
 # "examples/Variable Inspector.ipynb", # uses ipykernel-specific features
-jupyterlite_contents = ["examples"]
+jupyterlite_contents = "examples"
 
 # intersphinx_mapping = {
 #     'ipython': ('http://ipython.org/ipython-doc/dev/', None),

--- a/docs/source/jupyter_lite_config.json
+++ b/docs/source/jupyter_lite_config.json
@@ -15,6 +15,8 @@
     "ignore_sys_prefix": true,
     "piplite_urls": [
       "../../python/ipywidgets/dist",
+      "../../python/widgetsnbextension/dist",
+      "../../python/jupyterlab_widgets/dist",
       "https://files.pythonhosted.org/packages/py2.py3/a/asttokens/asttokens-2.0.5-py2.py3-none-any.whl",
       "https://files.pythonhosted.org/packages/py2.py3/b/backcall/backcall-0.2.0-py2.py3-none-any.whl",
       "https://files.pythonhosted.org/packages/py2.py3/b/bqplot/bqplot-0.12.33-py2.py3-none-any.whl",
@@ -68,7 +70,6 @@
       "https://files.pythonhosted.org/packages/py3/t/traitlets/traitlets-5.1.1-py3-none-any.whl",
       "https://files.pythonhosted.org/packages/py3/t/typing_extensions/typing_extensions-4.1.1-py3-none-any.whl",
       "https://files.pythonhosted.org/packages/py3/v/vega-datasets/vega_datasets-0.9.0-py3-none-any.whl",
-      "https://files.pythonhosted.org/packages/py3/w/widgetsnbextension/widgetsnbextension-4.0.0rc2-py3-none-any.whl",
       "https://files.pythonhosted.org/packages/py3/x/xyzservices/xyzservices-2022.2.0-py3-none-any.whl"
     ]
   }

--- a/docs/source/jupyter_lite_config.json
+++ b/docs/source/jupyter_lite_config.json
@@ -68,7 +68,7 @@
       "https://files.pythonhosted.org/packages/py3/t/traitlets/traitlets-5.1.1-py3-none-any.whl",
       "https://files.pythonhosted.org/packages/py3/t/typing_extensions/typing_extensions-4.1.1-py3-none-any.whl",
       "https://files.pythonhosted.org/packages/py3/v/vega-datasets/vega_datasets-0.9.0-py3-none-any.whl",
-      "https://files.pythonhosted.org/packages/py3/w/widgetsnbextension/widgetsnbextension-4.0.0rc1-py3-none-any.whl",
+      "https://files.pythonhosted.org/packages/py3/w/widgetsnbextension/widgetsnbextension-4.0.0rc2-py3-none-any.whl",
       "https://files.pythonhosted.org/packages/py3/x/xyzservices/xyzservices-2022.2.0-py3-none-any.whl"
     ]
   }


### PR DESCRIPTION
It seems we are only getting one file in the jlite contents these days, which started happening right around the time we switched to jupyterlite_sphinx 0.7.0.