### PR TITLE
Update information for custom widget authors

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,7 +104,6 @@ some custom widget packages built on top of the Jupyter Widgets framework.
     examples/Widget Layout.ipynb
     examples/Layout Templates.ipynb
     examples/Using Interact.ipynb
-    examples/Widget Custom.ipynb
     examples/Widget Low Level.ipynb
     examples/Widget Asynchronous.ipynb
     embedding.md

--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -7,6 +7,15 @@ widgets.
 Migrating from 7.x to 8.0
 -------------------------
 
+In this section, we discuss migrating a custom widget from ipywidgets 7 to
+ipywidgets 8 or supporting both ipywidgets 7 and ipywidgets 8 with the same
+codebase.
+
+For a summarized list of changes affecting custom widget authors, please see the "Developers" section of the
+[changelog](./changelog) for 8.0.
+
+Please consider updating your widget by generating a new widget from the cookiecutter at https://github.com/jupyter-widgets/widget-cookiecutter and adapting the changes to your widget. The widget cookiecutter has been updated to use best practices in Python packaging and Jupyter Widget infrastructure.
+
 For example migrations, see these PRs:
 
 - [ts-cookiecutter](https://github.com/jupyter-widgets/widget-ts-cookiecutter/pull/115)
@@ -16,18 +25,6 @@ For example migrations, see these PRs:
 - [bqscales](https://github.com/bqplot/bqscales/pull/49)
 - [sidecar](https://github.com/jupyter-widgets/jupyterlab-sidecar/pull/86)
 - [pythreejs](https://github.com/jupyter-widgets/pythreejs/pull/378)
-
-To avoid tying your development cycle to ipywidgets, we recommend starting
-the migration on a branch and keeping that branch open until ipywidgets 8.0
-is released.
-
-We also recommend testing the migration in a completely new notebook, rather
-than one that contains widgets that you instantiated with ipywidgets 7.x.
-
-For a summarized list of relevant changes, please consult the "Developers" section of the
-[changelog](./changelog).
-
-You may consider updating your widget by generating a new widget from the cookiecutter at https://github.com/jupyter-widgets/widget-cookiecutter and adapting the changes to your widget. The widget cookiecutter has been updated to use best practices in Python packaging and Jupyter Widget infrastructure.
 
 ### Updating setup.py
 
@@ -70,11 +67,11 @@ The ``ManagerBase`` class has been split into an interface type `IWidgetManager`
 + "@jupyter-widgets/base-manager": "^1",
 ```
 
-### Updating the AMD module logic
+### Updating the webpack `publicPath` configuration
 
-We highly encourage you to update your widget's logic around generating AMD modules for the CDN with changes similar to those at https://github.com/jupyter-widgets/widget-cookiecutter/pull/103/files. These changes allow your AMD module to be hosted anywhere, rather than hardcoding the `unpkg.com` CDN, and they remove the differences between the AMD module generated for the notebook extension and the AMD module generated for the CDN.
+We highly encourage you to update your widget's webpack configuration for `publicPath`, which is used in generating AMD modules, with changes similar to those at https://github.com/jupyter-widgets/widget-cookiecutter/pull/103/files. These changes allow your AMD module to be hosted anywhere, rather than hardcoding the a particular CDN like `unpkg.com`, and they simplify things by removing the differences between the AMD module generated for the notebook extension and the AMD module generated for the CDN.
 
-### Updating the client-side code
+### Updating the browser code
 
 #### Phosphor -> Lumino
 

--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -14,7 +14,7 @@ codebase.
 For a summarized list of changes affecting custom widget authors, please see the "Developers" section of the
 [changelog](./changelog) for 8.0.
 
-Please consider updating your widget by generating a new widget from the cookiecutter at https://github.com/jupyter-widgets/widget-cookiecutter and adapting the changes to your widget. The widget cookiecutter has been updated to use best practices in Python packaging and Jupyter Widget infrastructure.
+Please consider updating your widget by generating a new widget from the [JavaScript widget cookiecutter](https://github.com/jupyter-widgets/widget-cookiecutter) and adapting the code to your widget, since the cookiecutter has been updated to use best practices in Python packaging and Jupyter Widget infrastructure.
 
 For example migrations, see these PRs:
 
@@ -69,13 +69,13 @@ The ``ManagerBase`` class has been split into an interface type `IWidgetManager`
 
 ### Updating the webpack `publicPath` configuration
 
-We highly encourage you to update your widget's webpack configuration for `publicPath`, which is used in generating AMD modules, with changes similar to those at https://github.com/jupyter-widgets/widget-cookiecutter/pull/103/files. These changes allow your AMD module to be hosted anywhere, rather than hardcoding the a particular CDN like `unpkg.com`, and they simplify things by removing the differences between the AMD module generated for the notebook extension and the AMD module generated for the CDN.
+We highly encourage you to update your widget's webpack configuration for `publicPath`, which is used in generating AMD modules, with changes similar to [these changes](https://github.com/jupyter-widgets/widget-cookiecutter/pull/103/files). These changes allow your AMD module to be hosted anywhere, rather than hardcoding the a particular CDN like `unpkg.com`, and they simplify things by removing the differences between the AMD module generated for the notebook extension and the AMD module generated for the CDN.
 
 ### Updating the browser code
 
 #### Phosphor -> Lumino
 
-The Phosphor library has been archived. It has been forked and renamed "Lumino", and the maintenance is now done under the JupyterLab governance: https://github.com/jupyterlab/lumino
+The Phosphor library has been archived. It has been forked and renamed [Lumino](https://github.com/jupyterlab/lumino), and the maintenance is now done under the JupyterLab governance.
 
 If you used to import classes like ``JupyterPhosphorPanelWidget`` and ``JupyterPhosphorWidget`` from the ``@jupyter-widgets/base`` library, you will need to update them:
 
@@ -169,7 +169,7 @@ The version of [Backbone.js](https://backbonejs.org/) that ipywidgets depends on
 
 #### Custom tag names
 
-If you were changing the base HTML tag for your widget by defining the `tagName` property, this can now be done in ipywidgets 8 in the `preinitialize` method (see https://github.com/jupyter-widgets/ipywidgets/commit/a342e0dbc7c779bb668e5a21c097d7cec9a6ac44 for example changes in core widgets):
+If you were changing the base HTML tag for your widget by defining the `tagName` property, this can now be done in ipywidgets 8 in the `preinitialize` method (see [here](https://github.com/jupyter-widgets/ipywidgets/commit/a342e0dbc7c779bb668e5a21c097d7cec9a6ac44) for example changes in core widgets):
 
 ```diff
 - get tagName() {


### PR DESCRIPTION
* Update text for migrating custom widgets from 7 to 8.
* Remove the custom widget authoring guide for now. (It is based on the typescript cookiecutter, which is out of date regarding 8.0. We don't want to delay the 8.0 release, so we'll remove this guide for now and later either update the ts one to 8.0 or change this guide to use the js cookiecutter.)
