### PR TITLE
Deserialize state before setting it, as is done elsewhere set_state is used

### DIFF
--- a/packages/base-manager/src/manager-base.ts
+++ b/packages/base-manager/src/manager-base.ts
@@ -487,7 +487,10 @@ export abstract class ManagerBase implements IWidgetManager {
           } else {
             // model already exists here
             const model = await this.get_model(widget_id);
-            model!.set_state(state.state);
+            const deserializedState = await (
+              model.constructor as typeof WidgetModel
+            )._deserialize_state(state.state, this);
+            model!.set_state(deserializedState);
           }
         } catch (error) {
           // Failed to create a widget model, we continue creating other models so that


### PR DESCRIPTION
This is causing at least one problem in the ipyleaflet 8.0 upgrade tests, as seen in https://github.com/jupyter-widgets/ipyleaflet/pull/968

This code is similar to code from another place in this file that has similar logic: https://github.com/jupyter-widgets/ipywidgets/blob/bf6816912f7015ac6a8da0b5db26274da15be48d/packages/base-manager/src/manager-base.ts#L703-L715