### PR TITLE
[7.x] Pin to `jupyterlab_widgets>=1.0.0,<3`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install jupyterlab~=3.0
-        python -m pip install jupyter_packaging
+        python -m pip install jupyter_packaging~=0.7.9
     - name: Build the extension
       run: |
         pip install -e .[test]

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -52,7 +52,7 @@ echo -n "ipywidgets"
 pip install -v -e .
 
 if test "$skip_jupyter_lab" != yes; then
-    pip install jupyter_packaging
+    pip install jupyter_packaging~=0.7.9
     pip install -ve ./jupyterlab_widgets
     jupyter labextension develop ./jupyterlab_widgets --overwrite
 fi

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ install_requires = setuptools_args['install_requires'] = [
 extras_require = setuptools_args['extras_require'] = {
     ':python_version<"3.3"' : ['ipython>=4.0.0,<6.0.0'],
     ':python_version>="3.3"': ['ipython>=4.0.0'],
-    ':python_version>="3.6"': ['jupyterlab_widgets>=1.0.0,<2'],
+    ':python_version>="3.6"': ['jupyterlab_widgets>=1.0.0,<3'],
     'test:python_version=="2.7"': ['mock'],
     'test': ['pytest>=3.6.0', 'pytest-cov'],
 }

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ install_requires = setuptools_args['install_requires'] = [
 extras_require = setuptools_args['extras_require'] = {
     ':python_version<"3.3"' : ['ipython>=4.0.0,<6.0.0'],
     ':python_version>="3.3"': ['ipython>=4.0.0'],
-    ':python_version>="3.6"': ['jupyterlab_widgets>=1.0.0'],
+    ':python_version>="3.6"': ['jupyterlab_widgets>=1.0.0,<2'],
     'test:python_version=="2.7"': ['mock'],
     'test': ['pytest>=3.6.0', 'pytest-cov'],
 }


### PR DESCRIPTION
As noticed in https://github.com/jupyterlab/jupyterlab/issues/12962 and https://github.com/jupyterlab/jupyterlab/pull/12967, the JupyterLab UI tests were affected by the ipywidgets 8 release even though they pin on `ipywidgets==7.6.5`.

This had to do with `jupyterlab_widgets==3` being pulled when installing `ipywidgets==7.6.5`.

This PR proposes pinning the version of `jupyterlab_widgets` for the 7.x release series to avoid mismatches.