### PR TITLE
Pin the upper version of jupyterlab_widgets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install node
       uses: actions/setup-node@v1
       with:
-       node-version: '12.x'
+       node-version: '14.x'
     - name: Install Python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,6 @@ jobs:
         python -m pip install jupyter_packaging
     - name: Build the extension
       run: |
-        pip install .
         jlpm install
         jlpm run build
         cd jupyterlab_widgets
@@ -55,5 +54,7 @@ jobs:
         pip install -e .
         jupyter labextension develop . --overwrite
         jupyter labextension list
+
+        pip install .
 
         python -m jupyterlab.browser_check

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ install_requires = setuptools_args['install_requires'] = [
 extras_require = setuptools_args['extras_require'] = {
     ':python_version<"3.3"' : ['ipython>=4.0.0,<6.0.0'],
     ':python_version>="3.3"': ['ipython>=4.0.0'],
-    ':python_version>="3.6"': ['jupyterlab_widgets>=1.0.0'],
+    ':python_version>="3.6"': ['jupyterlab_widgets>=1.0.0,<3'],
     'test:python_version=="2.7"': ['mock'],
     'test': ['pytest>=3.6.0', 'pytest-cov'],
 }


### PR DESCRIPTION
This makes sure we are getting an ipywidgets 7 compatible version of jupyterlab_widgets.

This backports the essential parts of #3551 and #3553 to 7.6.x from 7.7.x.