### PR TITLE
Handle `KernelWidgetManager` in the JupyterLab `OutputModel`

### DIFF
--- a/python/jupyterlab_widgets/src/output.ts
+++ b/python/jupyterlab_widgets/src/output.ts
@@ -7,7 +7,7 @@ import { JupyterLuminoPanelWidget } from '@jupyter-widgets/base';
 
 import { Panel } from '@lumino/widgets';
 
-import { KernelWidgetManager, WidgetManager } from './manager';
+import { LabWidgetManager, WidgetManager } from './manager';
 
 import { OutputAreaModel, OutputArea } from '@jupyterlab/outputarea';
 
@@ -63,12 +63,7 @@ export class OutputModel extends outputBase.OutputModel {
    * Reset the message id.
    */
   reset_msg_id(): void {
-    let kernel;
-    if (this.widget_manager instanceof WidgetManager) {
-      kernel = this.widget_manager.context.sessionContext?.session?.kernel;
-    } else if (this.widget_manager instanceof KernelWidgetManager) {
-      kernel = this.widget_manager.kernel;
-    }
+    const kernel = this.widget_manager.kernel;
     const msgId = this.get('msg_id');
     const oldMsgId = this.previous('msg_id');
 
@@ -122,7 +117,7 @@ export class OutputModel extends outputBase.OutputModel {
     }
   }
 
-  widget_manager: WidgetManager | KernelWidgetManager;
+  widget_manager: LabWidgetManager;
 
   private _msgHook: (msg: KernelMessage.IIOPubMessage) => boolean;
   private _outputs: OutputAreaModel;


### PR DESCRIPTION
Investigating an issue in https://github.com/voila-dashboards/voila/pull/846 where using an `interactive_output` would trigger the following error:

```
TypeError: Cannot read properties of undefined (reading 'sessionContext')
```

https://github.com/voila-dashboards/voila/pull/846 uses the JupyterLab packages but with a custom `KernelWidgetManager`, not a `WidgetManager` like in the JupyterLab extension. This is because it only has access to a kernel connection, not a document context.

However in its present state, the `OutputModel` assumes it can access the `context` from its `widget_manager` here: https://github.com/jupyter-widgets/ipywidgets/blob/58adde2cfbe2f78a8ec6756d38a7c637f5e599f8/python/jupyterlab_widgets/src/output.ts#L36 

Ideally it should be able to handle both a `WidgetManager` and `KernelWidgetManager` or even a `LabWidgetManager` directly.

---

For reference the `widget_manager` assigned to a `WidgetModel` is declared as `any` here:

https://github.com/jupyter-widgets/ipywidgets/blob/58adde2cfbe2f78a8ec6756d38a7c637f5e599f8/packages/base/src/widget.ts#L72

And assigned here:

https://github.com/jupyter-widgets/ipywidgets/blob/58adde2cfbe2f78a8ec6756d38a7c637f5e599f8/packages/base/src/widget.ts#L124

