### PR TITLE
Allow the 'class' attribute to pass the sanitizer

### DIFF
--- a/packages/base-manager/src/manager-base.ts
+++ b/packages/base-manager/src/manager-base.ts
@@ -70,7 +70,7 @@ function default_inline_sanitize(s: string): string {
     'ul',
   ];
   const allowedAttributes = {
-    '*': ['aria-*', 'style', 'title'],
+    '*': ['aria-*', 'class', 'style', 'title'],
     a: ['href'],
     img: ['src'],
     style: ['media', 'type'],


### PR DESCRIPTION
This allows the 'class' attribute in the default sanitizer.

Fixes #3564