### PR TITLE
fix: make .widget and .widget_types deprecated

### DIFF
--- a/docs/source/user_migration_guides.md
+++ b/docs/source/user_migration_guides.md
@@ -78,6 +78,10 @@ The previously deprecated traits `overflow_x` and `overflow_y`
 [have been removed](https://github.com/jupyter-widgets/ipywidgets/pull/2688). Please
 use the `overflow` trait instead.
 
+#### `Widget.widgets` and `Widget.widget_types` attributes
+
+The `Widget` class attributes `.widgets` and `.widget_types` are now deprecated and relocated to internal module-level private variables, opening up these attribute names on the `Widget` class for future uses.
+
 ### Deployments
 
 #### Embedded CDN

--- a/python/ipywidgets/ipywidgets/embed.py
+++ b/python/ipywidgets/ipywidgets/embed.py
@@ -12,6 +12,7 @@ Functions for generating embeddable HTML/javascript of a widget.
 
 import json
 import re
+import ipywidgets.widgets.widget
 from .widgets import Widget, DOMWidget
 from .widgets.widget_link import Link
 from .widgets.docutils import doc_subst
@@ -129,7 +130,7 @@ def _get_recursive_state(widget, store=None, drop_defaults=False):
 
 def add_resolved_links(store, drop_defaults):
     """Adds the state of any link models between two models in store"""
-    for widget_id, widget in Widget._active_widgets.items(): # go over all widgets
+    for widget_id, widget in ipywidgets.widgets.widget.instances.items(): # go over all widgets
         if isinstance(widget, Link) and widget_id not in store:
             if widget.source[0].model_id in store and widget.target[0].model_id in store:
                 store[widget.model_id] = widget._get_embed_state(drop_defaults=drop_defaults)
@@ -207,7 +208,7 @@ def embed_data(views, drop_defaults=True, state=None):
         view_specs: a list of widget view specs
     """
     if views is None:
-        views = [w for w in Widget._active_widgets.values() if isinstance(w, DOMWidget)]
+        views = [w for w in ipywidgets.widgets.widget.instances.values() if isinstance(w, DOMWidget)]
     else:
         try:
             views[0]

--- a/python/ipywidgets/ipywidgets/embed.py
+++ b/python/ipywidgets/ipywidgets/embed.py
@@ -12,8 +12,7 @@ Functions for generating embeddable HTML/javascript of a widget.
 
 import json
 import re
-import ipywidgets.widgets.widget
-from .widgets import Widget, DOMWidget
+from .widgets import Widget, DOMWidget, widget as widget_module
 from .widgets.widget_link import Link
 from .widgets.docutils import doc_subst
 from ._version import __html_manager_version__
@@ -130,7 +129,7 @@ def _get_recursive_state(widget, store=None, drop_defaults=False):
 
 def add_resolved_links(store, drop_defaults):
     """Adds the state of any link models between two models in store"""
-    for widget_id, widget in ipywidgets.widgets.widget._instances.items(): # go over all widgets
+    for widget_id, widget in widget_module._instances.items(): # go over all widgets
         if isinstance(widget, Link) and widget_id not in store:
             if widget.source[0].model_id in store and widget.target[0].model_id in store:
                 store[widget.model_id] = widget._get_embed_state(drop_defaults=drop_defaults)
@@ -208,7 +207,7 @@ def embed_data(views, drop_defaults=True, state=None):
         view_specs: a list of widget view specs
     """
     if views is None:
-        views = [w for w in ipywidgets.widgets.widget._instances.values() if isinstance(w, DOMWidget)]
+        views = [w for w in widget_module._instances.values() if isinstance(w, DOMWidget)]
     else:
         try:
             views[0]

--- a/python/ipywidgets/ipywidgets/embed.py
+++ b/python/ipywidgets/ipywidgets/embed.py
@@ -130,7 +130,7 @@ def _get_recursive_state(widget, store=None, drop_defaults=False):
 
 def add_resolved_links(store, drop_defaults):
     """Adds the state of any link models between two models in store"""
-    for widget_id, widget in ipywidgets.widgets.widget.instances.items(): # go over all widgets
+    for widget_id, widget in ipywidgets.widgets.widget._instances.items(): # go over all widgets
         if isinstance(widget, Link) and widget_id not in store:
             if widget.source[0].model_id in store and widget.target[0].model_id in store:
                 store[widget.model_id] = widget._get_embed_state(drop_defaults=drop_defaults)
@@ -208,7 +208,7 @@ def embed_data(views, drop_defaults=True, state=None):
         view_specs: a list of widget view specs
     """
     if views is None:
-        views = [w for w in ipywidgets.widgets.widget.instances.values() if isinstance(w, DOMWidget)]
+        views = [w for w in ipywidgets.widgets.widget._instances.values() if isinstance(w, DOMWidget)]
     else:
         try:
             views[0]

--- a/python/ipywidgets/ipywidgets/tests/test_embed.py
+++ b/python/ipywidgets/ipywidgets/tests/test_embed.py
@@ -30,7 +30,7 @@ class CaseWidget(Widget):
 class TestEmbed:
 
     def teardown(self):
-        for w in tuple(ipywidgets.widgets.widget.instances.values()):
+        for w in tuple(ipywidgets.widgets.widget._instances.values()):
             w.close()
 
     def test_embed_data_simple(self):

--- a/python/ipywidgets/ipywidgets/tests/test_embed.py
+++ b/python/ipywidgets/ipywidgets/tests/test_embed.py
@@ -9,6 +9,7 @@ import shutil
 
 import traitlets
 
+import ipywidgets.widgets.widget
 from ..widgets import IntSlider, IntText, Text, Widget, jslink, HBox, widget_serialization
 from ..embed import embed_data, embed_snippet, embed_minimal_html, dependency_state
 
@@ -29,7 +30,7 @@ class CaseWidget(Widget):
 class TestEmbed:
 
     def teardown(self):
-        for w in tuple(Widget._active_widgets.values()):
+        for w in tuple(ipywidgets.widgets.widget.instances.values()):
             w.close()
 
     def test_embed_data_simple(self):

--- a/python/ipywidgets/ipywidgets/tests/test_embed.py
+++ b/python/ipywidgets/ipywidgets/tests/test_embed.py
@@ -9,8 +9,7 @@ import shutil
 
 import traitlets
 
-import ipywidgets.widgets.widget
-from ..widgets import IntSlider, IntText, Text, Widget, jslink, HBox, widget_serialization
+from ..widgets import IntSlider, IntText, Text, Widget, jslink, HBox, widget_serialization, widget as widget_module
 from ..embed import embed_data, embed_snippet, embed_minimal_html, dependency_state
 
 
@@ -30,7 +29,7 @@ class CaseWidget(Widget):
 class TestEmbed:
 
     def teardown(self):
-        for w in tuple(ipywidgets.widgets.widget._instances.values()):
+        for w in tuple(widget_module._instances.values()):
             w.close()
 
     def test_embed_data_simple(self):

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -67,5 +67,5 @@ def test_compatibility():
     assert not widget.Widget.widgets
     assert not widget.Widget._active_widgets
 
-    assert widget.Widget.widget_types is widget.registry
-    assert widget.Widget._widget_types is widget.registry
+    assert widget.Widget.widget_types is widget._registry
+    assert widget.Widget._widget_types is widget._registry

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -50,19 +50,19 @@ def test_close_all():
     # create a couple of widgets
     widgets = [Button() for i in range(10)]
 
-    assert len(widget.instances) > 0, "expect active widgets"
+    assert len(widget._instances) > 0, "expect active widgets"
 
     # close all the widgets
     Widget.close_all()
 
-    assert len(widget.instances) == 0, "active widgets should be cleared"
+    assert len(widget._instances) == 0, "active widgets should be cleared"
 
 
 def test_compatibility():
     button = Button()
     assert button in widget.Widget.widgets.values()
-    assert widget.instances is widget.Widget.widgets
-    assert widget.instances is widget.Widget._active_widgets
+    assert widget._instances is widget.Widget.widgets
+    assert widget._instances is widget.Widget._active_widgets
     Widget.close_all()
     assert not widget.Widget.widgets
     assert not widget.Widget._active_widgets

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -7,6 +7,7 @@ from IPython.core.interactiveshell import InteractiveShell
 from IPython.display import display
 from IPython.utils.capture import capture_output
 
+from .. import widget
 from ..widget import Widget
 from ..widget_button import Button
 
@@ -49,9 +50,22 @@ def test_close_all():
     # create a couple of widgets
     widgets = [Button() for i in range(10)]
 
-    assert len(Widget._active_widgets) > 0, "expect active widgets"
+    assert len(widget.instances) > 0, "expect active widgets"
 
     # close all the widgets
     Widget.close_all()
 
-    assert len(Widget._active_widgets) == 0, "active widgets should be cleared"
+    assert len(widget.instances) == 0, "active widgets should be cleared"
+
+
+def test_compatibility():
+    button = Button()
+    assert button in widget.Widget.widgets.values()
+    assert widget.instances is widget.Widget.widgets
+    assert widget.instances is widget.Widget._active_widgets
+    Widget.close_all()
+    assert not widget.Widget.widgets
+    assert not widget.Widget._active_widgets
+
+    assert widget.Widget.widget_types is widget.registry
+    assert widget.Widget._widget_types is widget.registry

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -317,7 +317,7 @@ class Widget(LoggingHasTraits):
 
     @_staticproperty
     def widget_types():
-        warnings.warn("Widget.widget_types is deprecated, use ipywidgets.widgets.widget.register", DeprecationWarning)
+        warnings.warn("Widget.widget_types is deprecated, use ipywidgets.widgets.widget.registry", DeprecationWarning)
         return registry
 
     @classmethod

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -268,12 +268,12 @@ class WidgetRegistry:
 
 # a registry of widgets by module, version, and name so we can create a Python model from widgets
 # that are constructed from the frontend.
-registry = WidgetRegistry()
+_registry = WidgetRegistry()
 
 def register(widget):
     """A decorator registering a widget class in the widget registry."""
     w = widget.class_traits()
-    registry.register(w['_model_module'].default_value,
+    _registry.register(w['_model_module'].default_value,
                                  w['_model_module_version'].default_value,
                                  w['_model_name'].default_value,
                                  w['_view_module'].default_value,
@@ -312,13 +312,13 @@ class Widget(LoggingHasTraits):
 
     @_staticproperty
     def _widget_types():
-        warnings.warn("Widget._widget_types is deprecated, use ipywidgets.widgets.widget.registry", DeprecationWarning)
-        return registry
+        warnings.warn("Widget._widget_types is deprecated, use ipywidgets.widgets.widget._registry", DeprecationWarning)
+        return _registry
 
     @_staticproperty
     def widget_types():
-        warnings.warn("Widget.widget_types is deprecated, use ipywidgets.widgets.widget.registry", DeprecationWarning)
-        return registry
+        warnings.warn("Widget.widget_types is deprecated, use ipywidgets.widgets.widget._registry", DeprecationWarning)
+        return _registry
 
     @classmethod
     def close_all(cls):

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -312,7 +312,7 @@ class Widget(LoggingHasTraits):
 
     @_staticproperty
     def _widget_types():
-        warnings.warn("Widget._widget_types is deprecated, use ipywidgets.widgets.widget.register", DeprecationWarning)
+        warnings.warn("Widget._widget_types is deprecated, use ipywidgets.widgets.widget.registry", DeprecationWarning)
         return registry
 
     @_staticproperty

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -302,22 +302,22 @@ class Widget(LoggingHasTraits):
 
     @_staticproperty
     def widgets():
-        warnings.warn("Widget.widgets is deprecated, use ipywidgets.widgets.widget._instances", DeprecationWarning)
+        warnings.warn("Widget.widgets is deprecated.", DeprecationWarning)
         return _instances
 
     @_staticproperty
     def _active_widgets():
-        warnings.warn("Widget._active_widgets is deprecated, use ipywidgets.widgets.widget._instances", DeprecationWarning)
+        warnings.warn("Widget._active_widgets is deprecated.", DeprecationWarning)
         return _instances
 
     @_staticproperty
     def _widget_types():
-        warnings.warn("Widget._widget_types is deprecated, use ipywidgets.widgets.widget._registry", DeprecationWarning)
+        warnings.warn("Widget._widget_types is deprecated.", DeprecationWarning)
         return _registry
 
     @_staticproperty
     def widget_types():
-        warnings.warn("Widget.widget_types is deprecated, use ipywidgets.widgets.widget._registry", DeprecationWarning)
+        warnings.warn("Widget.widget_types is deprecated.", DeprecationWarning)
         return _registry
 
     @classmethod


### PR DESCRIPTION
In #3122 we renamed .widget and .widget_types to ._active_widgets
and ._widget_types. That breaks code, and we did not have a deprecation
period.
This PR makes the dict and registry non-members of the Widget class
and puts in a backwards compatible way to deprecated these members.

Closes #3562