### PR TITLE
Fix slider update on readout text change

### DIFF
--- a/packages/controls/src/widget_float.ts
+++ b/packages/controls/src/widget_float.ts
@@ -215,7 +215,7 @@ export class FloatLogSliderView extends BaseIntSliderView {
 
       if (value !== this.model.get('value')) {
         this.readout.textContent = this.valueToString(value);
-        this.model.set('value', value, { updated_view: this });
+        this.model.set('value', value);
         this.touch();
       } else {
         this.readout.textContent = this.valueToString(this.model.get('value'));

--- a/packages/controls/src/widget_int.ts
+++ b/packages/controls/src/widget_int.ts
@@ -358,7 +358,7 @@ export class IntRangeSliderView extends BaseIntSliderView {
         value[1] !== this.model.get('value')[1]
       ) {
         this.readout.textContent = this.valueToString(value);
-        this.model.set('value', value, { updated_view: this });
+        this.model.set('value', value);
         this.touch();
       } else {
         this.readout.textContent = this.valueToString(this.model.get('value'));
@@ -452,7 +452,7 @@ export class IntSliderView extends BaseIntSliderView {
 
       if (value !== this.model.get('value')) {
         this.readout.textContent = this.valueToString(value);
-        this.model.set('value', value, { updated_view: this });
+        this.model.set('value', value);
         this.touch();
       } else {
         this.readout.textContent = this.valueToString(this.model.get('value'));


### PR DESCRIPTION
## Description

In ipywidgets 7 it was possible to edit the readout of a slider, press Enter and the position of the slider would be updated according to the new value:

https://user-images.githubusercontent.com/591645/186837698-817b9328-d6d1-484f-8304-92c07816fd8f.mp4

This does not seem possible anymore with the latest ipywidgets release (8.0.1 at the time of writing).

## Changes

Remove `{ updated_view: this }` from the options when the change comes from updating the text.

**Before**

https://user-images.githubusercontent.com/591645/186837747-a9db61aa-a56f-40cc-837c-acaec9273549.mp4

**After**

https://user-images.githubusercontent.com/591645/186838550-9d248dbd-fa35-417d-ada5-e709f265e003.mp4
