### PR TITLE
Calculate correct stack level for deprecation warnings to show them to the user

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/tests/test_button.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_button.py
@@ -1,0 +1,9 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import pytest
+from ipywidgets import Button
+
+def test_deprecation_fa_icons():
+    with pytest.deprecated_call():
+        Button(icon='fa-home')

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_utils.py
@@ -15,3 +15,8 @@ def test_deprecation():
         deprecation('Deprecated call', ['ipywidgets/widgets/tests'])
         # Make sure the deprecation pointed to the external function calling this test function
         assert w[0].filename.endswith('_pytest/python.py')
+
+    with pytest.deprecated_call() as w:
+        deprecation('Deprecated call', 'ipywidgets/widgets/tests')
+        # Make sure the deprecation pointed to the external function calling this test function
+        assert w[0].filename.endswith('_pytest/python.py')

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_utils.py
@@ -7,27 +7,27 @@ import pytest
 from ..utils import deprecation
 from .utils import call_method
 
-PYTEST_PATH = inspect.getfile(pytest.Function)
 CALL_PATH = inspect.getfile(call_method)
 
 def test_deprecation():
+    caller_path = inspect.stack(context=0)[1].filename
     with pytest.deprecated_call() as record:
         deprecation('Deprecated call')
     # Make sure the deprecation pointed to the external function calling this test function
     assert len(record) == 1
-    assert record[0].filename == PYTEST_PATH
+    assert record[0].filename == caller_path
 
     with pytest.deprecated_call() as record:
         deprecation('Deprecated call', ['ipywidgets/widgets/tests'])
     # Make sure the deprecation pointed to the external function calling this test function
     assert len(record) == 1
-    assert record[0].filename == PYTEST_PATH
+    assert record[0].filename == caller_path
 
     with pytest.deprecated_call() as record:
         deprecation('Deprecated call', 'ipywidgets/widgets/tests')
     # Make sure the deprecation pointed to the external function calling this test function
     assert len(record) == 1
-    assert record[0].filename == PYTEST_PATH
+    assert record[0].filename == caller_path
 
     with pytest.deprecated_call() as record:
         deprecation('Deprecated call', [])

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_utils.py
@@ -1,4 +1,5 @@
 
+import inspect
 from pathlib import Path
 from unittest.mock import patch
 
@@ -6,6 +7,9 @@ import pytest
 
 from ipywidgets.widgets.utils import deprecation
 from ipywidgets.widgets.tests.utils import call_method
+
+
+CALL_PATH = inspect.getfile(call_method)
 
 @patch("ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL", [])
 def test_deprecation_direct():
@@ -20,9 +24,9 @@ def test_deprecation_indirect():
     with pytest.warns(DeprecationWarning) as record:
         call_method(deprecation, "test message")
     assert len(record) == 1
-    assert Path(record[0].filename) == Path(__file__, '..', 'utils.py').resolve()
+    assert record[0].filename == CALL_PATH
 
-@patch("ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL", [str(Path(__file__, '..', 'utils.py').resolve())])
+@patch("ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL", [CALL_PATH])
 def test_deprecation_indirect_internal():
     # If the line that calls "deprecation" is internal, it is not considered the source:
     with pytest.warns(DeprecationWarning) as record:

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_utils.py
@@ -1,0 +1,56 @@
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ipywidgets.widgets.utils import deprecation
+from ipywidgets.widgets.tests.utils import call_method
+
+@patch("ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL", [])
+def test_deprecation_direct():
+    with pytest.warns(DeprecationWarning) as record:
+        deprecation("test message")
+    assert len(record) == 1
+    assert record[0].filename == __file__
+
+@patch("ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL", [])
+def test_deprecation_indirect():
+    # If the line that calls "deprecation" is not internal, it is considered the source:
+    with pytest.warns(DeprecationWarning) as record:
+        call_method(deprecation, "test message")
+    assert len(record) == 1
+    assert Path(record[0].filename) == Path(__file__, '..', 'utils.py').resolve()
+
+@patch("ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL", [str(Path(__file__, '..', 'utils.py').resolve())])
+def test_deprecation_indirect_internal():
+    # If the line that calls "deprecation" is internal, it is not considered the source:
+    with pytest.warns(DeprecationWarning) as record:
+        call_method(deprecation, "test message")
+    assert len(record) == 1
+    assert record[0].filename == __file__
+
+@patch("ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL", [])
+def test_deprecation_nested1():
+    def level1():
+        deprecation("test message")
+
+    with pytest.warns(DeprecationWarning) as record:
+        call_method(level1)
+
+    assert len(record) == 1
+    assert record[0].filename == __file__
+
+@patch("ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL", [])
+def test_deprecation_nested2():
+    def level2():
+        deprecation("test message")
+    def level1():
+        level2()
+
+    with pytest.warns(DeprecationWarning) as record:
+        call_method(level1)
+
+    assert len(record) == 1
+    assert record[0].filename == __file__
+

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_utils.py
@@ -1,0 +1,17 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import pytest
+
+from ..utils import deprecation
+
+def test_deprecation():
+    with pytest.deprecated_call() as w:
+        deprecation('Deprecated call')
+        # Make sure the deprecation pointed to the external function calling this test function
+        assert w[0].filename.endswith('_pytest/python.py')
+
+    with pytest.deprecated_call() as w:
+        deprecation('Deprecated call', ['ipywidgets/widgets/tests'])
+        # Make sure the deprecation pointed to the external function calling this test function
+        assert w[0].filename.endswith('_pytest/python.py')

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -6,11 +6,14 @@
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.display import display
 from IPython.utils.capture import capture_output
+import inspect
+import pytest
 
 from .. import widget
 from ..widget import Widget
 from ..widget_button import Button
 
+PYTEST_PATH = inspect.getfile(pytest.Function)
 
 def test_no_widget_view():
     # ensure IPython shell is instantiated
@@ -51,7 +54,7 @@ def test_close_all():
     widgets = [Button() for i in range(10)]
 
     assert len(widget._instances) > 0, "expect active widgets"
-
+    assert widget._instances[widgets[0].model_id] is widgets[0]
     # close all the widgets
     Widget.close_all()
 
@@ -60,12 +63,15 @@ def test_close_all():
 
 def test_compatibility():
     button = Button()
-    assert button in widget.Widget.widgets.values()
-    assert widget._instances is widget.Widget.widgets
-    assert widget._instances is widget.Widget._active_widgets
-    Widget.close_all()
-    assert not widget.Widget.widgets
-    assert not widget.Widget._active_widgets
+    assert widget._instances[button.model_id] is button
+    with pytest.deprecated_call() as record:
+        assert widget._instances is widget.Widget.widgets
+        assert widget._instances is widget.Widget._active_widgets
+        assert widget._registry is widget.Widget.widget_types
+        assert widget._registry is widget.Widget._widget_types
 
-    assert widget.Widget.widget_types is widget._registry
-    assert widget.Widget._widget_types is widget._registry
+        Widget.close_all()
+        assert not widget.Widget.widgets
+        assert not widget.Widget._active_widgets
+    assert all(x.filename == PYTEST_PATH for x in record)
+    assert len(record) == 6

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -13,8 +13,6 @@ from .. import widget
 from ..widget import Widget
 from ..widget_button import Button
 
-PYTEST_PATH = inspect.getfile(pytest.Function)
-
 def test_no_widget_view():
     # ensure IPython shell is instantiated
     # otherwise display() just calls print
@@ -73,5 +71,6 @@ def test_compatibility():
         Widget.close_all()
         assert not widget.Widget.widgets
         assert not widget.Widget._active_widgets
-    assert all(x.filename == PYTEST_PATH for x in record)
+    caller_path = inspect.stack(context=0)[1].filename
+    assert all(x.filename == caller_path for x in record)
     assert len(record) == 6

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_button.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_button.py
@@ -5,10 +5,8 @@ import inspect
 import pytest
 from ipywidgets import Button
 
-PYTEST_PATH = inspect.getfile(pytest.Function)
-
 def test_deprecation_fa_icons():
     with pytest.deprecated_call() as record:
         Button(icon='fa-home')
     assert len(record) == 1
-    assert record[0].filename == PYTEST_PATH
+    assert record[0].filename == inspect.stack(context=0)[1].filename

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_button.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_button.py
@@ -1,0 +1,18 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from unittest.mock import patch
+import pytest
+
+import ipywidgets as widgets
+
+
+@patch(
+    "ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL",
+    ['widgets/widget.py', 'widgets/widget_button.py']
+)
+def test_fa_prefix_deprecation():
+    with pytest.deprecated_call() as record:
+        widgets.Button(icon="fa-gear")
+    assert len(record) == 1
+    assert record[0].filename == __file__

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_string.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_string.py
@@ -6,11 +6,6 @@ import pytest
 
 from ..widget_string import Combobox, Text
 
-
-PYTEST_PATH = inspect.getfile(pytest.Function)
-
-
-
 def test_combobox_creation_blank():
     w = Combobox()
     assert w.value == ''
@@ -41,29 +36,30 @@ def test_combobox_creation_kwargs():
     assert w.ensure_option == True
 
 def test_tooltip_deprecation():
+    caller_path = inspect.stack(context=0)[1].filename
     with pytest.deprecated_call() as record:
         w = Text(description_tooltip="testing")
     assert len(record) == 1
-    assert record[0].filename == PYTEST_PATH
+    assert record[0].filename == caller_path
 
     with pytest.deprecated_call() as record:
         w.description_tooltip
     assert len(record) == 1
-    assert record[0].filename == PYTEST_PATH
+    assert record[0].filename == caller_path
 
     with pytest.deprecated_call() as record:
         w.description_tooltip == "testing"
     assert len(record) == 1
-    assert record[0].filename == PYTEST_PATH
+    assert record[0].filename == caller_path
 
     with pytest.deprecated_call() as record:
         w.description_tooltip = "second value"
     assert len(record) == 1
-    assert record[0].filename == PYTEST_PATH
+    assert record[0].filename == caller_path
     assert w.tooltip == "second value"
 
 def test_on_submit_deprecation():
     with pytest.deprecated_call() as record:
         Text().on_submit(lambda *args: ...)
     assert len(record) == 1
-    assert record[0].filename == PYTEST_PATH
+    assert record[0].filename == inspect.stack(context=0)[1].filename

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_string.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_string.py
@@ -1,7 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ..widget_string import Combobox
+from ..widget_string import Combobox, Text
+import pytest
 
 
 def test_combobox_creation_blank():
@@ -32,3 +33,19 @@ def test_combobox_creation_kwargs():
             "Vanilla",
         )
     assert w.ensure_option == True
+
+def test_deprecation_description_tooltip():
+    with pytest.deprecated_call():
+        Text(description_tooltip='tooltip')
+
+    with pytest.deprecated_call():
+        Text().description_tooltip
+
+
+    with pytest.deprecated_call():
+        Text().description_tooltip = 'tooltip'
+
+
+def test_deprecation_on_submit():
+    with pytest.deprecated_call():
+        Text().on_submit(lambda *args: ...)

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_string.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_string.py
@@ -1,7 +1,43 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from ..widget_string import Combobox
+from ..widget_string import Combobox, Text
+from unittest.mock import patch
+import pytest
+
+
+@patch(
+    "ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL",
+    ['widgets/widget_string.py']
+)
+def test_on_submit_deprecation():
+    w = Text()
+    with pytest.deprecated_call() as record:
+        w.on_submit(lambda: None)
+    assert len(record) == 1
+    assert record[0].filename == __file__
+
+
+@patch(
+    "ipywidgets.widgets.utils._IPYWIDGETS_INTERNAL",
+    ['widgets/widget_string.py', 'widgets/widget_description.py']
+)
+def test_tooltip_deprecation():
+    with pytest.deprecated_call() as record:
+        w = Text(description_tooltip="testing")
+    assert len(record) == 1
+    assert record[0].filename == __file__
+
+    with pytest.deprecated_call() as record:
+        assert w.description_tooltip == "testing"
+    assert len(record) == 1
+    assert record[0].filename == __file__
+
+    with pytest.deprecated_call() as record:
+        w.description_tooltip = "second value"
+    assert len(record) == 1
+    assert record[0].filename == __file__
+    assert w.tooltip == "second value"
 
 
 def test_combobox_creation_blank():

--- a/python/ipywidgets/ipywidgets/widgets/tests/utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/utils.py
@@ -45,3 +45,6 @@ def setup():
 
 def teardown():
     teardown_test_comm()
+
+def call_method(method, *args, **kwargs):
+    method(*args, **kwargs)

--- a/python/ipywidgets/ipywidgets/widgets/utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import sys
+import warnings
+
+# This function is from https://github.com/python/cpython/issues/67998
+# (https://bugs.python.org/file39550/deprecated_module_stacklevel.diff) and
+# calculates the appropriate stacklevel for deprecations to target the
+# deprecation for the caller, no matter how many internal stack frames we have
+# added in the process. For example, with the deprecation warning in the
+# __init__ below, the appropriate stacklevel will change depending on how deep
+# the inheritance hierarchy is.
+def external_stacklevel(internal):
+    """Find the first frame that doesn't any of the given internal strings
+
+    The depth will be 2 at minimum in order to start checking at the caller of
+    the function that called this utility method.
+    """
+    level = 2
+    frame = sys._getframe(level)
+    while frame and any(s in frame.f_code.co_filename for s in internal):
+        level +=1
+        frame = frame.f_back
+    return level
+
+def deprecation(message, internal=None):
+    """Generate a deprecation warning targeting the first external frame
+    
+    internal is a list of strings, which if they appear in filenames in the
+    frames, the frames will also be considered internal.
+    """
+    if internal is None:
+        internal = []
+    warnings.warn(message, DeprecationWarning, stacklevel=external_stacklevel(internal+['ipywidgets/widgets/']))

--- a/python/ipywidgets/ipywidgets/widgets/utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/utils.py
@@ -11,25 +11,28 @@ import warnings
 # added in the process. For example, with the deprecation warning in the
 # __init__ below, the appropriate stacklevel will change depending on how deep
 # the inheritance hierarchy is.
-def external_stacklevel(internal):
+def _external_stacklevel(internal):
     """Find the first frame that doesn't any of the given internal strings
 
-    The depth will be 2 at minimum in order to start checking at the caller of
+    The depth will be 1 at minimum in order to start checking at the caller of
     the function that called this utility method.
     """
+    # Get the level of my caller's caller
     level = 2
     frame = sys._getframe(level)
     while frame and any(s in frame.f_code.co_filename for s in internal):
         level +=1
         frame = frame.f_back
-    return level
+    # the returned value will be used one level up from here, so subtract one
+    return level-1
 
 def deprecation(message, internal=None):
-    """Generate a deprecation warning targeting the first external frame
+    """Generate a deprecation warning targeting the first frame outside the ipywidgets library.
     
     internal is a list of strings, which if they appear in filenames in the
-    frames, the frames will also be considered internal.
+    frames, the frames will also be considered internal. This can be useful if we know that ipywidgets
+    is calling out to, for example, traitlets internally.
     """
     if internal is None:
         internal = []
-    warnings.warn(message, DeprecationWarning, stacklevel=external_stacklevel(internal+['ipywidgets/widgets/']))
+    warnings.warn(message, DeprecationWarning, stacklevel=_external_stacklevel(internal+['ipywidgets/widgets/']))

--- a/python/ipywidgets/ipywidgets/widgets/utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/utils.py
@@ -12,7 +12,7 @@ import warnings
 # __init__ below, the appropriate stacklevel will change depending on how deep
 # the inheritance hierarchy is.
 def external_stacklevel(internal):
-    """Find the first frame that doesn't any of the given internal strings
+    """Find the first frame that doesn't contain any of the given internal strings
 
     The depth will be 2 at minimum in order to start checking at the caller of
     the function that called this utility method.

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -9,7 +9,6 @@ import os
 import typing
 from contextlib import contextmanager
 from collections.abc import Iterable
-import warnings
 from IPython import get_ipython
 from ipykernel.comm import Comm
 from traitlets import (
@@ -19,7 +18,12 @@ from json import loads as jsonloads, dumps as jsondumps
 
 from base64 import standard_b64encode
 
+from .utils import deprecation, _get_frame
+
 from .._version import __protocol_version__, __control_protocol_version__, __jupyter_widgets_base_version__
+
+import inspect
+TRAITLETS_FILE = inspect.getfile(HasTraits)
 
 # Based on jupyter_core.paths.envset
 def envset(name, default):
@@ -302,22 +306,42 @@ class Widget(LoggingHasTraits):
 
     @_staticproperty
     def widgets():
-        warnings.warn("Widget.widgets is deprecated.", DeprecationWarning)
+        # Because this is a static attribute, it will be accessed when initializing this class. In that case, since a user
+        # did not explicitly try to use this attribute, we do not want to throw a deprecation warning.
+        # So we check if the thing calling this static property is one of the known initialization functions in traitlets.
+        frame = _get_frame(2)
+        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance'))):
+            deprecation("Widget.widgets is deprecated.")
         return _instances
 
     @_staticproperty
     def _active_widgets():
-        warnings.warn("Widget._active_widgets is deprecated.", DeprecationWarning)
+        # Because this is a static attribute, it will be accessed when initializing this class. In that case, since a user
+        # did not explicitly try to use this attribute, we do not want to throw a deprecation warning.
+        # So we check if the thing calling this static property is one of the known initialization functions in traitlets.
+        frame = _get_frame(2)
+        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance'))):
+            deprecation("Widget._active_widgets is deprecated.")
         return _instances
 
     @_staticproperty
     def _widget_types():
-        warnings.warn("Widget._widget_types is deprecated.", DeprecationWarning)
+        # Because this is a static attribute, it will be accessed when initializing this class. In that case, since a user
+        # did not explicitly try to use this attribute, we do not want to throw a deprecation warning.
+        # So we check if the thing calling this static property is one of the known initialization functions in traitlets.
+        frame = _get_frame(2)
+        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance'))):
+            deprecation("Widget._widget_types is deprecated.")
         return _registry
 
     @_staticproperty
     def widget_types():
-        warnings.warn("Widget.widget_types is deprecated.", DeprecationWarning)
+        # Because this is a static attribute, it will be accessed when initializing this class. In that case, since a user
+        # did not explicitly try to use this attribute, we do not want to throw a deprecation warning.
+        # So we check if the thing calling this static property is one of the known initialization functions in traitlets.
+        frame = _get_frame(2)
+        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance'))):
+            deprecation("Widget.widget_types is deprecated.")
         return _registry
 
     @classmethod

--- a/python/ipywidgets/ipywidgets/widgets/widget_button.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_button.py
@@ -72,7 +72,7 @@ class Button(DOMWidget, CoreWidget):
         if 'fa-' in value:
             deprecation("icons names no longer need 'fa-', "
             "just use the class names themselves (for example, 'gear spin' instead of 'fa-gear fa-spin')",
-            internal=['traitlets/traitlets.py', '/contextlib.py'])
+            internal=['ipywidgets/widgets/', 'traitlets/traitlets.py', '/contextlib.py'])
             value = value.replace('fa-', '')
         return value
 

--- a/python/ipywidgets/ipywidgets/widgets/widget_button.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_button.py
@@ -7,6 +7,7 @@ Represents a button in the frontend using a widget.  Allows user to listen for
 click events on the button and trigger backend code when the clicks are fired.
 """
 
+from .utils import deprecation
 from .domwidget import DOMWidget
 from .widget import CallbackDispatcher, register, widget_serialization
 from .widget_core import CoreWidget
@@ -14,7 +15,6 @@ from .widget_style import Style
 from .trait_types import Color, InstanceDict
 
 from traitlets import Unicode, Bool, CaselessStrEnum, Instance, validate, default
-import warnings
 
 
 @register
@@ -70,8 +70,9 @@ class Button(DOMWidget, CoreWidget):
         """Strip 'fa-' if necessary'"""
         value = proposal['value']
         if 'fa-' in value:
-            warnings.warn("icons names no longer need 'fa-', "
-            "just use the class names themselves (for example, 'gear spin' instead of 'fa-gear fa-spin')", DeprecationWarning)
+            deprecation("icons names no longer need 'fa-', "
+            "just use the class names themselves (for example, 'gear spin' instead of 'fa-gear fa-spin')",
+            internal=['traitlets/traitlets.py', '/contextlib.py'])
             value = value.replace('fa-', '')
         return value
 

--- a/python/ipywidgets/ipywidgets/widgets/widget_description.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_description.py
@@ -9,6 +9,8 @@ from .trait_types import InstanceDict
 from .widget_style import Style
 from .widget_core import CoreWidget
 from .domwidget import DOMWidget
+from .utils import deprecation
+
 import warnings
 
 @register
@@ -27,7 +29,7 @@ class DescriptionWidget(DOMWidget, CoreWidget):
 
     def __init__(self, *args, **kwargs):
         if 'description_tooltip' in kwargs:
-            warnings.warn("the description_tooltip argument is deprecated, use tooltip instead", DeprecationWarning)
+            deprecation("the description_tooltip argument is deprecated, use tooltip instead")
             kwargs.setdefault('tooltip', kwargs['description_tooltip'])
             del kwargs['description_tooltip']
         super().__init__(*args, **kwargs)
@@ -47,10 +49,10 @@ class DescriptionWidget(DOMWidget, CoreWidget):
         .. deprecated :: 8.0.0
            Use tooltip attribute instead.
         """
-        warnings.warn(".description_tooltip is deprecated, use .tooltip instead", DeprecationWarning)
+        deprecation(".description_tooltip is deprecated, use .tooltip instead")
         return self.tooltip
 
     @description_tooltip.setter
     def description_tooltip(self, tooltip):
-        warnings.warn(".description_tooltip is deprecated, use .tooltip instead", DeprecationWarning)
+        deprecation(".description_tooltip is deprecated, use .tooltip instead")
         self.tooltip = tooltip

--- a/python/ipywidgets/ipywidgets/widgets/widget_string.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_string.py
@@ -11,8 +11,8 @@ from .valuewidget import ValueWidget
 from .widget import CallbackDispatcher, register, widget_serialization
 from .widget_core import CoreWidget
 from .trait_types import Color, InstanceDict, TypedTuple
+from .utils import deprecation
 from traitlets import Unicode, Bool, Int
-from warnings import warn
 
 
 class _StringStyle(DescriptionStyle, CoreWidget):
@@ -142,8 +142,7 @@ class Text(_String):
         remove: bool (optional)
             Whether to unregister the callback
         """
-        import warnings
-        warnings.warn("on_submit is deprecated. Instead, set the .continuous_update attribute to False and observe the value changing with: mywidget.observe(callback, 'value').", DeprecationWarning)
+        deprecation("on_submit is deprecated. Instead, set the .continuous_update attribute to False and observe the value changing with: mywidget.observe(callback, 'value').")
         self._submission_callbacks.register_callback(callback, remove=remove)
 
 


### PR DESCRIPTION
Generating deprecation warnings with the correct stacklevel is tricky to get right. Up to now, users have not been seeing these deprecation warnings because we had incorrect stacklevels. See https://github.com/python/cpython/issues/68493 and https://github.com/python/cpython/issues/67998 for good discussions, as well as https://github.com/ipython/ipython/issues/8478#issuecomment-106119371 and https://github.com/ipython/ipython/pull/8480#issuecomment-106107638 for more context.

We see these issues directly. Normally stacklevel=2 might be enough to target the caller of a function. However, in our deprecation warning in the __init__ method, each level of subclasses adds one stack frame, so depending on the subclass, the appropriate stacklevel is different. Thus this PR implements a trick from a discussion in Python to calculate the first stack frame that is external to the ipywidgets library, and use that as the target stack frame for the deprecation warning.

This code should now produce 6 deprecation warnings in Jupyter Notebook or JupyterLab, whereas before it was producing no visible deprecation warnings.

```python
import ipywidgets as w
def f(): pass
x=w.Text(description_tooltip='fda')
x.on_submit(f)
x.description_tooltip
x.description_tooltip='asdf'
w.FileUpload(description_tooltip='asdf')
w.Button(icon='fa-gear')
```
<img width="810" alt="Screen Shot 2022-08-26 at 04 35 19" src="https://user-images.githubusercontent.com/192614/186885858-e91a078f-6866-409f-87b7-0aefdbdc4bc3.png">
