### PR TITLE
Stricter typescript + some cleanups

### DIFF
--- a/packages/base/src/errorwidget.ts
+++ b/packages/base/src/errorwidget.ts
@@ -9,7 +9,7 @@ import { BROKEN_FILE_SVG_ICON } from './utils';
 
 // create a Widget Model that captures an error object
 export function createErrorWidgetModel(
-  error: Error,
+  error: unknown,
   msg?: string
 ): typeof WidgetModel {
   class ErrorWidget extends DOMWidgetModel {
@@ -78,12 +78,15 @@ export class ErrorWidgetView extends DOMWidgetView {
 }
 
 export function createErrorWidgetView(
-  error?: Error,
+  error?: unknown,
   msg?: string
 ): typeof WidgetView {
   return class InnerErrorWidgetView extends ErrorWidgetView {
     generateErrorMessage(): { msg?: string; stack: string } {
-      return { msg, stack: String(error?.stack) };
+      return {
+        msg,
+        stack: String(error instanceof Error ? error.stack : error),
+      };
     }
   };
 }

--- a/packages/base/src/services-shim.ts
+++ b/packages/base/src/services-shim.ts
@@ -13,9 +13,9 @@ import { Kernel, KernelMessage } from '@jupyterlab/services';
  * Callbacks for services shim comms.
  */
 export interface ICallbacks {
-  shell?: { [key: string]: (msg: KernelMessage.IMessage) => void };
-  iopub?: { [key: string]: (msg: KernelMessage.IMessage) => void };
-  input?: (msg: KernelMessage.IMessage) => void;
+  shell?: { [key: string]: (msg: KernelMessage.IShellMessage) => void };
+  iopub?: { [key: string]: (msg: KernelMessage.IIOPubMessage) => void };
+  input?: (msg: KernelMessage.IStdinMessage) => void;
 }
 
 export interface IClassicComm {

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -655,9 +655,9 @@ export class WidgetModel extends Backbone.Model {
   static _deserialize_state(
     state: Dict<BufferJSON>,
     manager: IWidgetManager
-  ): Promise<utils.Dict<BufferJSON>> {
+  ): Promise<utils.Dict<unknown>> {
     const serializers = this.serializers;
-    let deserialized: Dict<PromiseLike<BufferJSON> | BufferJSON>;
+    let deserialized: Dict<unknown>;
     if (serializers) {
       deserialized = {};
       for (const k in state) {

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -34,7 +34,7 @@ import { KernelMessage } from '@jupyterlab/services';
  */
 export function unpack_models(
   value: any | Dict<unknown> | string | (Dict<unknown> | string)[],
-  manager: IWidgetManager
+  manager?: IWidgetManager // actually required, but typed to be compatible with ISerializers
 ): Promise<WidgetModel | Dict<WidgetModel> | WidgetModel[] | any> {
   if (Array.isArray(value)) {
     const unpacked: any[] = [];
@@ -50,7 +50,7 @@ export function unpack_models(
     return utils.resolvePromisesDict(unpacked);
   } else if (typeof value === 'string' && value.slice(0, 10) === 'IPY_MODEL_') {
     // get_model returns a promise already
-    return manager.get_model(value.slice(10, value.length));
+    return manager!.get_model(value.slice(10, value.length));
   } else {
     return Promise.resolve(value);
   }

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -295,7 +295,9 @@ export class WidgetModel extends Backbone.Model {
     try {
       this.set(state);
     } catch (e) {
-      console.error(`Error setting state: ${e.message}`);
+      console.error(
+        `Error setting state: ${e instanceof Error ? e.message : e}`
+      );
     } finally {
       this._state_lock = null;
     }

--- a/packages/controls/src/widget_controller.ts
+++ b/packages/controls/src/widget_controller.ts
@@ -389,8 +389,8 @@ export class ControllerView extends DOMWidgetView {
     const dummy = new Widget();
     this.button_box.addWidget(dummy);
 
-    return this.create_child_view(model)
-      .then((view: ControllerButtonView) => {
+    return this.create_child_view<ControllerButtonView>(model)
+      .then((view) => {
         // replace the dummy widget with the new one.
         const i = ArrayExt.firstIndexOf(this.button_box.widgets, dummy);
         this.button_box.insertWidget(i, view.luminoWidget);
@@ -406,8 +406,8 @@ export class ControllerView extends DOMWidgetView {
     const dummy = new Widget();
     this.axis_box.addWidget(dummy);
 
-    return this.create_child_view(model)
-      .then((view: ControllerAxisView) => {
+    return this.create_child_view<ControllerAxisView>(model)
+      .then((view) => {
         // replace the dummy widget with the new one.
         const i = ArrayExt.firstIndexOf(this.axis_box.widgets, dummy);
         this.axis_box.insertWidget(i, view.luminoWidget);

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -317,8 +317,8 @@ export class RadioButtonsView extends DescriptionView {
   update(options?: any): void {
     const items: string[] = this.model.get('_options_labels');
     const radios = Array.from(
-      this.container.querySelectorAll('input[type="radio"]')
-    ).map((x: HTMLInputElement) => x.value);
+      this.container.querySelectorAll<HTMLInputElement>('input[type="radio"]')
+    ).map((x) => x.value);
     let stale = items.length !== radios.length;
 
     if (!stale) {

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -15,7 +15,10 @@
     "noUnusedLocals": true,
     "preserveWatchOutput": true,
     "resolveJsonModule": true,
-    "strictNullChecks": true,
+    "strict": true,
+    "noImplicitThis": false,
+    "strictPropertyInitialization": false,
+    "strictFunctionTypes": false,
     "target": "es2017"
   }
 }

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -18,7 +18,6 @@
     "strict": true,
     "noImplicitThis": false,
     "strictPropertyInitialization": false,
-    "strictFunctionTypes": false,
     "target": "es2017"
   }
 }


### PR DESCRIPTION
This increases the typescript strictness, and makes the exceptions that we need explicit (this will also opt us in to any future TS strictness checks by default). In addition to that, the following changes were made:
- Fix assumptions about all caught errors being instances of `Error`. With strict checks, TS insists that these are `unknown`.
- Further narrow typing of output from `_deserialize` from #3554: After deserialization, we know we have a dict of something, but have no idea about what is in it, since deserializers can return anything. Ideally we should also make it explicit in `ISerializers` that the return type is unknown, but this might be a breaking change.. ?
- Change the typing of `unpack_models` so that it is compatible with `ISerializers` (newly included strictness check will also complain if not). This is because the `ISerlializers` make all argument optional to allow them to ignore arguments they don't care about, even if the arguments *must always be passed by a caller*. This is chosen to be the lesser of two evils, but this might be open for discussion.
- Narrows the typings of the `ICallbacks` callbacks. Also not clear whether this is an ok change or not.