### PR TITLE
Narrow deserialize and improve strictness

### DIFF
--- a/packages/base/src/errorwidget.ts
+++ b/packages/base/src/errorwidget.ts
@@ -9,7 +9,7 @@ import { BROKEN_FILE_SVG_ICON } from './utils';
 
 // create a Widget Model that captures an error object
 export function createErrorWidgetModel(
-  error: Error,
+  error: unknown,
   msg?: string
 ): typeof WidgetModel {
   class ErrorWidget extends DOMWidgetModel {
@@ -78,12 +78,15 @@ export class ErrorWidgetView extends DOMWidgetView {
 }
 
 export function createErrorWidgetView(
-  error?: Error,
+  error?: unknown,
   msg?: string
 ): typeof WidgetView {
   return class InnerErrorWidgetView extends ErrorWidgetView {
     generateErrorMessage(): { msg?: string; stack: string } {
-      return { msg, stack: String(error?.stack) };
+      return {
+        msg,
+        stack: String(error instanceof Error ? error.stack : error),
+      };
     }
   };
 }

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -655,9 +655,9 @@ export class WidgetModel extends Backbone.Model {
   static _deserialize_state(
     state: Dict<BufferJSON>,
     manager: IWidgetManager
-  ): Promise<utils.Dict<BufferJSON>> {
+  ): Promise<utils.Dict<unknown>> {
     const serializers = this.serializers;
-    let deserialized: Dict<PromiseLike<BufferJSON> | BufferJSON>;
+    let deserialized: Dict<unknown>;
     if (serializers) {
       deserialized = {};
       for (const k in state) {

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -295,7 +295,9 @@ export class WidgetModel extends Backbone.Model {
     try {
       this.set(state);
     } catch (e) {
-      console.error(`Error setting state: ${e.message}`);
+      console.error(
+        `Error setting state: ${e instanceof Error ? e.message : e}`
+      );
     } finally {
       this._state_lock = null;
     }

--- a/tsconfigbase.json
+++ b/tsconfigbase.json
@@ -15,7 +15,10 @@
     "noUnusedLocals": true,
     "preserveWatchOutput": true,
     "resolveJsonModule": true,
-    "strictNullChecks": true,
+    "strict": true,
+    "noImplicitThis": false,
+    "strictPropertyInitialization": false,
+    "strictFunctionTypes": false,
     "target": "es2017"
   }
 }


### PR DESCRIPTION
Some of the easier to approve changes from #3570:

This increases the typescript strictness, and makes the exceptions that we need explicit (this will also opt us in to any future TS strictness checks by default). In addition to that, the following changes were made:

- Fix assumptions about all caught errors being instances of Error. With strict checks, TS insists that these are unknown.
- Further narrow typing of output from _deserialize from #3554: After deserialization, we know we have a dict of something, but have no idea about what is in it, since deserializers can return anything.