### PR TITLE
Change Layout.border from a property to a trait

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/widget_layout.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_layout.py
@@ -78,13 +78,13 @@ class Layout(Widget):
     grid_column = Unicode(None, allow_none=True, help="The grid-column CSS attribute.").tag(sync=True)
     grid_area = Unicode(None, allow_none=True, help="The grid-area CSS attribute.").tag(sync=True)
 
-    @observe("border")
+    @validate("border")
     def _validate_border(self, proposal):
         
         self.border_bottom = proposal.value
         return self.border_bottom
 
-    @validate("border")
+    @observe("border")
     def _observe_border(self, change):
         self._set_border(change.new)
 


### PR DESCRIPTION
In v7 Layout.border was a trait and meant that the border could be linked between widgets. In v8 it was changed to a property which non longer supports this functionality. To achieve the same functionality all 4 borders (top, left, bottom, right) would need to be linked, but is somewhat clunky.

The changes suggested haven't been tested, but approximate the functionality that would be useful.
Making this change might help reduce the pain of switching from v7 to v8.