### PR TITLE
Make the widget renderer higher priority in JupyterLab

### DIFF
--- a/python/jupyterlab_widgets/src/plugin.ts
+++ b/python/jupyterlab_widgets/src/plugin.ts
@@ -130,7 +130,7 @@ export function registerWidgetManager(
       mimeTypes: [WIDGET_VIEW_MIMETYPE],
       createRenderer: (options) => new WidgetRenderer(options, wManager),
     },
-    0
+    -10
   );
 
   return new DisposableDelegate(() => {
@@ -225,7 +225,7 @@ function activateWidgetExtension(
       mimeTypes: [WIDGET_VIEW_MIMETYPE],
       createRenderer: (options) => new WidgetRenderer(options),
     },
-    0
+    -10
   );
 
   if (tracker !== null) {


### PR DESCRIPTION
The widget renderer should take precedence over the core jlab json renderer. However, the json renderer is priority 0, so we lose (since our id is also sorted after the json renderer id). This bumps up our priority to be higher priority than the json renderer.

Fixes #3576