### PR TITLE
Remove migration note about selection widgets and dictionaries

### DIFF
--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -169,11 +169,11 @@ The version of [Backbone.js](https://backbonejs.org/) that ipywidgets depends on
 
 If you were using `.extend()`, you will also need to change how your model attribute defaults are defined. The model defaults are now given by a function that returns the defaults and includes the superclass defaults. For example, the Output widget model [looks like this](https://github.com/jupyter-widgets/ipywidgets/blob/8.0.0/packages/output/src/output.ts):
 
-```typescript
+```javascript
 export const OUTPUT_WIDGET_VERSION = '1.0.0';
 
 export class OutputModel extends DOMWidgetModel {
-  defaults(): Backbone.ObjectHash {
+  defaults() {
     return {
       ...super.defaults(),
       _model_name: 'OutputModel',

--- a/docs/source/user_migration_guides.md
+++ b/docs/source/user_migration_guides.md
@@ -40,16 +40,6 @@ that inherit `DOMWidget` have the attribute `tooltip` instead.
 Suggested migration: Search and replace `description_tooltip` to `tooltip` when you no longer
 need to support ipywidgets 7.
 
-#### Selection Widgets
-
-These widgets include: `ToggleButtons`, `Dropdown`, `RadioButtons`, `Select`, `SelectMultiple` `Selection`, `SelectionSlider`, and `SelectionRangeSlider`.
-
-For these, it is no longer possible to use `dict`s or other mapping types as values for the
-`options` trait. Using mapping types in this way has been deprecated since version 7.4, and
-will now raise a `TypeError`.
-
-Suggested migration: Instead of using a dict `my_dict` as options, use `my_dict.items()`, which returns the items in `my_dict` as key-value pairs. For example, `Select(options=my_dict.items())`.
-
 #### Description Sanitization
 
 The value of the `description` field of any widget that inherits `DescriptionWidget`


### PR DESCRIPTION
Follows up on #3557, where we reverted this change, to correct the docs

I also fixed a place in the docs where we accidentally used typescript (follow up of #3582).