### PR TITLE
Button tooltip fix - default to description

### DIFF
--- a/packages/controls/src/widget_button.ts
+++ b/packages/controls/src/widget_button.ts
@@ -106,9 +106,7 @@ export class ButtonView extends DOMWidgetView {
     const description = this.model.get('description');
     const icon = this.model.get('icon');
 
-    tooltip
-      ? this.el.setAttribute('title', tooltip)
-      : this.el.setAttribute('title', description);
+    this.el.setAttribute('title', tooltip ?? description);
 
     if (description.length || icon.length) {
       this.el.textContent = '';

--- a/packages/controls/src/widget_button.ts
+++ b/packages/controls/src/widget_button.ts
@@ -101,10 +101,15 @@ export class ButtonView extends DOMWidgetView {
   update(): void {
     this.el.disabled = this.model.get('disabled');
     this.updateTabindex();
-    this.el.setAttribute('title', this.model.get('tooltip'));
 
+    const tooltip = this.model.get('tooltip');
     const description = this.model.get('description');
     const icon = this.model.get('icon');
+
+    tooltip
+      ? this.el.setAttribute('title', tooltip)
+      : this.el.setAttribute('title', description);
+
     if (description.length || icon.length) {
       this.el.textContent = '';
       if (icon.length) {


### PR DESCRIPTION
Fixes jupyter-widgets/ipywidgets#2286 . Tooltip on buttons no longer defaults to "null". Rather, it defaults to the description if no tooltip is set.

There had been some discussion related to description_tooltips previously, but description_tooltips has been deprecated after PR https://github.com/jupyter-widgets/ipywidgets/pull/2680 was merged. Issue jupyter-widgets/ipywidgets#421 can be closed too.