### PR TITLE
fix: using _comm_default shadows possible bugs

### DIFF
--- a/ipywidgets/widgets/tests/test_set_state.py
+++ b/ipywidgets/widgets/tests/test_set_state.py
@@ -64,14 +64,14 @@ def deserializer(json_data, widget):
     return DataInstance( memoryview(json_data['data']).tobytes() if json_data else None )
 
 class DataWidget(SimpleWidget):
-    d = Instance(DataInstance).tag(sync=True, to_json=mview_serializer, from_json=deserializer)
+    d = Instance(DataInstance, args=()).tag(sync=True, to_json=mview_serializer, from_json=deserializer)
 
 # A widget that has a buffer that might be changed on reception:
 def truncate_deserializer(json_data, widget):
     return DataInstance( json_data['data'][:20].tobytes() if json_data else None )
 
 class TruncateDataWidget(SimpleWidget):
-    d = Instance(DataInstance).tag(sync=True, to_json=bytes_serializer, from_json=truncate_deserializer)
+    d = Instance(DataInstance, args=()).tag(sync=True, to_json=bytes_serializer, from_json=truncate_deserializer)
 
 
 #

--- a/ipywidgets/widgets/tests/utils.py
+++ b/ipywidgets/widgets/tests/utils.py
@@ -3,6 +3,7 @@
 
 from ipykernel.comm import Comm
 from ipywidgets import Widget
+import ipywidgets.widgets.widget
 
 class DummyComm(Comm):
     comm_id = 'a-b-c-d'
@@ -25,14 +26,16 @@ _widget_attrs = {}
 undefined = object()
 
 def setup_test_comm():
-    _widget_attrs['_comm_default'] = getattr(Widget, '_comm_default', undefined)
-    Widget._comm_default = lambda self: DummyComm()
+    Widget.comm.klass = DummyComm
+    ipywidgets.widgets.widget.Comm = DummyComm
     _widget_attrs['_ipython_display_'] = Widget._ipython_display_
     def raise_not_implemented(*args, **kwargs):
         raise NotImplementedError()
     Widget._ipython_display_ = raise_not_implemented
 
 def teardown_test_comm():
+    Widget.comm.klass = Comm
+    ipywidgets.widgets.widget.Comm = Comm
     for attr, value in _widget_attrs.items():
         if value is undefined:
             delattr(Widget, attr)


### PR DESCRIPTION
This came up when working on  https://github.com/ipython/traitlets/pull/777, instead of `_comm_default`, this method seems to trigger more code paths, which revealed that we couldn't create the DataWidget (since the default was None because we didn't pass in `args=()`). 

