### PR TITLE
Add option to interact which hides widget description

### DIFF
--- a/packages/controls/src/widget_description.ts
+++ b/packages/controls/src/widget_description.ts
@@ -41,6 +41,7 @@ export class DescriptionModel extends DOMWidgetModel {
       _view_module_version: JUPYTER_CONTROLS_VERSION,
       _model_module_version: JUPYTER_CONTROLS_VERSION,
       description: '',
+      description_displayed: true,
       description_allow_html: false,
     };
   }
@@ -70,6 +71,11 @@ export class DescriptionView extends DOMWidgetView {
   }
 
   updateDescription(): void {
+    if (!this.model.get('description_displayed')) {
+      this.label.style.display = 'none';
+      return;
+    }
+
     const description = this.model.get('description');
     if (description.length === 0) {
       this.label.style.display = 'none';

--- a/python/ipywidgets/ipywidgets/widgets/interaction.py
+++ b/python/ipywidgets/ipywidgets/widgets/interaction.py
@@ -13,11 +13,11 @@ from IPython import get_ipython
 from . import (Widget, ValueWidget, Text,
     FloatSlider, IntSlider, Checkbox, Dropdown,
     VBox, Button, DOMWidget, Output)
+from .widget_description import DescriptionWidget
 from IPython.display import display, clear_output
 from traitlets import HasTraits, Any, Unicode, observe
 from numbers import Real, Integral
 from warnings import warn
-
 
 
 empty = Parameter.empty
@@ -168,6 +168,7 @@ class interactive(VBox):
         self.manual = __options.get("manual", False)
         self.manual_name = __options.get("manual_name", "Run Interact")
         self.auto_display = __options.get("auto_display", False)
+        self.description_displayed = __options.get("description_displayed", True)
 
         new_kwargs = self.find_abbreviations(kwargs)
         # Before we proceed, let's make sure that the user has passed a set of args+kwargs
@@ -207,11 +208,15 @@ class interactive(VBox):
             # Also register input handlers on text areas, so the user can hit return to
             # invoke execution.
             for w in self.kwargs_widgets:
+                if isinstance(w, DescriptionWidget):
+                    w.description_displayed = self.description_displayed
                 if isinstance(w, Text):
                     w.on_submit(self.update)
         else:
-            for widget in self.kwargs_widgets:
-                widget.observe(self.update, names='value')
+            for w in self.kwargs_widgets:
+                if isinstance(w, DescriptionWidget):
+                    w.description_displayed = self.description_displayed
+                w.observe(self.update, names='value')
             self.update()
 
     # Callback function
@@ -377,7 +382,7 @@ class interactive(VBox):
     # Return a factory for interactive functions
     @classmethod
     def factory(cls):
-        options = dict(manual=False, auto_display=True, manual_name="Run Interact")
+        options = dict(manual=False, auto_display=True, manual_name="Run Interact", description_displayed=True)
         return _InteractFactory(cls, options)
 
 

--- a/python/ipywidgets/ipywidgets/widgets/widget_description.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_description.py
@@ -22,6 +22,7 @@ class DescriptionWidget(DOMWidget, CoreWidget):
     """Widget that has a description label to the side."""
     _model_name = Unicode('DescriptionModel').tag(sync=True)
     description = Unicode('', help="Description of the control.").tag(sync=True)
+    description_displayed = Bool(True, help="Enable or disable the display of the description").tag(sync=True)
     description_allow_html = Bool(False, help="Accept HTML in the description.").tag(sync=True)
     style = InstanceDict(DescriptionStyle, help="Styling customizations").tag(sync=True, **widget_serialization)
 


### PR DESCRIPTION
This addresses the request from https://github.com/jupyter-widgets/ipywidgets/issues/614

DescriptionWidget had to be imported this way to avoid circular dependency. 

It's fine if this is something that doesn't ever end up getting merged, it was good practice for how widgets work between server and front end. Also of note, I tried [recreating this](https://github.com/jupyter-widgets/ipywidgets/pull/771#issuecomment-262684060) but the functionality appears to work now. Decorators seem to have been improved within the last 6 years 😅 

For example, the following doesn't create any problems:

```python
from ipywidgets import interact
@interact.options(description_displayed=False, manual=True, manual_name="click me")(first="first string", second="second string")
def f(first, second):
    print(first,second)
```

