### PR TITLE
Pass change options into update calls

### DIFF
--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -737,13 +737,13 @@ export class WidgetView extends NativeView<WidgetModel> {
    * Initializer, called at the end of the constructor.
    */
   initialize(parameters: WidgetView.IInitializeParameters): void {
-    this.listenTo(this.model, 'change', () => {
+    this.listenTo(this.model, 'change', (model, options) => {
       const changed = Object.keys(this.model.changedAttributes() || {});
       if (changed[0] === '_view_count' && changed.length === 1) {
         // Just the view count was updated
         return;
       }
-      this.update();
+      this.update(options);
     });
 
     this.options = parameters.options;


### PR DESCRIPTION
We assume these options several places in the code, for example in the selection widget views, but we were never passing them through when we called the update method.