### PR TITLE
Update to `jupyterlite==0.1.0b14`

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -25,5 +25,5 @@ dependencies:
   - sphinx_rtd_theme
   - sympy
   - pip:
-    - jupyterlite==0.1.0b11
+    - jupyterlite==0.1.0b14
     - jupyterlite-sphinx~=0.7.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,5 +14,5 @@ packaging
 scikit-image
 scikit-learn
 sympy
-jupyterlite==0.1.0b11
+jupyterlite==0.1.0b14
 jupyterlite-sphinx~=0.7.2

--- a/docs/source/examples/Beat Frequencies.ipynb
+++ b/docs/source/examples/Beat Frequencies.ipynb
@@ -21,11 +21,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets', 'matplotlib', 'numpy'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets matplotlib numpy"
    ]
   },
   {

--- a/docs/source/examples/Controller.ipynb
+++ b/docs/source/examples/Controller.ipynb
@@ -21,11 +21,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install('ipywidgets')\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {

--- a/docs/source/examples/Exploring Graphs.ipynb
+++ b/docs/source/examples/Exploring Graphs.ipynb
@@ -21,11 +21,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets', 'matplotlib', 'networkx'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets matplotlib networkx"
    ]
   },
   {

--- a/docs/source/examples/Factoring.ipynb
+++ b/docs/source/examples/Factoring.ipynb
@@ -21,11 +21,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets', 'sympy'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets sympy"
    ]
   },
   {

--- a/docs/source/examples/Image Browser.ipynb
+++ b/docs/source/examples/Image Browser.ipynb
@@ -21,11 +21,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets', 'matplotlib', 'scikit-learn'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets matplotlib scikit-learn"
    ]
   },
   {

--- a/docs/source/examples/Image Processing.ipynb
+++ b/docs/source/examples/Image Processing.ipynb
@@ -21,11 +21,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets', 'scikit-learn', 'numpy', 'matplotlib'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets scikit-learn numpy matplotlib"
    ]
   },
   {

--- a/docs/source/examples/Layout Example.ipynb
+++ b/docs/source/examples/Layout Example.ipynb
@@ -28,11 +28,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets', 'ipyleaflet', 'numpy', 'bqplot', 'pandas'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets ipyleaflet numpy bqplot pandas"
    ]
   },
   {

--- a/docs/source/examples/Layout Templates.ipynb
+++ b/docs/source/examples/Layout Templates.ipynb
@@ -16,11 +16,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets', 'bqplot', 'numpy'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets bqplot numpy"
    ]
   },
   {

--- a/docs/source/examples/Lorenz Differential Equations.ipynb
+++ b/docs/source/examples/Lorenz Differential Equations.ipynb
@@ -45,11 +45,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets', 'matplotlib', 'numpy', 'scipy'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets matplotlib numpy scipy"
    ]
   },
   {

--- a/docs/source/examples/Media widgets.ipynb
+++ b/docs/source/examples/Media widgets.ipynb
@@ -16,11 +16,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {

--- a/docs/source/examples/Output Widget.ipynb
+++ b/docs/source/examples/Output Widget.ipynb
@@ -23,11 +23,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {

--- a/docs/source/examples/Using Interact.ipynb
+++ b/docs/source/examples/Using Interact.ipynb
@@ -21,11 +21,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {

--- a/docs/source/examples/Variable Inspector.ipynb
+++ b/docs/source/examples/Variable Inspector.ipynb
@@ -28,11 +28,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {

--- a/docs/source/examples/Widget Alignment.ipynb
+++ b/docs/source/examples/Widget Alignment.ipynb
@@ -16,11 +16,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {

--- a/docs/source/examples/Widget Asynchronous.ipynb
+++ b/docs/source/examples/Widget Asynchronous.ipynb
@@ -55,11 +55,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets', 'matplotlib', 'numpy', 'scipy'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets matplotlib numpy scipy"
    ]
   },
   {

--- a/docs/source/examples/Widget Basics.ipynb
+++ b/docs/source/examples/Widget Basics.ipynb
@@ -78,11 +78,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {

--- a/docs/source/examples/Widget Events.ipynb
+++ b/docs/source/examples/Widget Events.ipynb
@@ -41,11 +41,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {

--- a/docs/source/examples/Widget Layout.ipynb
+++ b/docs/source/examples/Widget Layout.ipynb
@@ -115,11 +115,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {

--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -23,11 +23,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {
@@ -1169,8 +1165,8 @@
     "\n",
     "This is useful if you need to compare the picked datetime to naive datetime objects, as Python will otherwise complain!"
    ]
-   },
-   {
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/docs/source/examples/Widget Low Level.ipynb
+++ b/docs/source/examples/Widget Low Level.ipynb
@@ -127,11 +127,7 @@
    "outputs": [],
    "source": [
     "# Imports for JupyterLite\n",
-    "try:\n",
-    "    import piplite\n",
-    "    await piplite.install(['ipywidgets'])\n",
-    "except ImportError:\n",
-    "    pass"
+    "%pip install -q ipywidgets"
    ]
   },
   {


### PR DESCRIPTION
This allows for using the `%pip` magic to install packages instead of `piplite`.

This might make the notebooks look familiar to regular Jupyter users.