### PR TITLE
fix: do not hold sync during set_state

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/tests/test_set_state.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_set_state.py
@@ -287,10 +287,13 @@ def test_hold_sync(echo):
     msg = {'method': 'echo_update', 'state': {'value': 42.0}, 'buffer_paths': []}
     call42 = mock.call(msg, buffers=[])
 
-    msg = {'method': 'update', 'state': {'value': 2.0, 'other': 11.0}, 'buffer_paths': []}
+    msg = {'method': 'update', 'state': {'value': 2.0}, 'buffer_paths': []}
     call2 = mock.call(msg, buffers=[])
 
-    calls = [call42, call2] if echo else [call2]
+    msg = {'method': 'update', 'state': {'other': 11.0}, 'buffer_paths': []}
+    call11 = mock.call(msg, buffers=[])
+
+    calls = [call42, call2, call11] if echo else [call2, call11]
     widget._send.assert_has_calls(calls)
 
 

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -616,7 +616,7 @@ class Widget(LoggingHasTraits):
         # The order of these context managers is important. Properties must
         # be locked when the hold_trait_notification context manager is
         # released and notifications are fired.
-        with self.hold_sync(), self._lock_property(**sync_data), self.hold_trait_notifications():
+        with self._lock_property(**sync_data), self.hold_trait_notifications():
             for name in sync_data:
                 if name in self.keys:
                     from_json = self.trait_metadata(name, 'from_json',


### PR DESCRIPTION
If we do, we get very inconsistent behavior, see #3635 for more details and #3271 for the reasons to implement this.

Reverts https://github.com/jupyter-widgets/ipywidgets/pull/3271
Closes https://github.com/jupyter-widgets/ipywidgets/issues/3635