### PR TITLE
define `process.env` for jlab dependencies

### DIFF
--- a/examples/web3/webpack.config.js
+++ b/examples/web3/webpack.config.js
@@ -18,4 +18,12 @@ module.exports = {
       { test: /\.svg$/i, type: 'asset' },
     ],
   },
+  plugins: [
+    new webpack.DefinePlugin({
+      process: {
+        cwd: () => '/',
+        env: {},
+      },
+    }),
+  ],
 };


### PR DESCRIPTION
Addresses issue #3630 by using webpack to provide stubs for the expected globals `process` and `process.env`. Note defining `process` alone solved the first error but exposed a further issue in `bluebird` that required `process.env`. I maintained the `cwd` stub as per `jlab` example.