### PR TITLE
Fix unintentional deprecation warnings

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -310,7 +310,7 @@ class Widget(LoggingHasTraits):
         # did not explicitly try to use this attribute, we do not want to throw a deprecation warning.
         # So we check if the thing calling this static property is one of the known initialization functions in traitlets.
         frame = _get_frame(2)
-        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance'))):
+        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance', 'setup_class'))):
             deprecation("Widget.widgets is deprecated.")
         return _instances
 
@@ -320,7 +320,7 @@ class Widget(LoggingHasTraits):
         # did not explicitly try to use this attribute, we do not want to throw a deprecation warning.
         # So we check if the thing calling this static property is one of the known initialization functions in traitlets.
         frame = _get_frame(2)
-        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance'))):
+        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance', 'setup_class'))):
             deprecation("Widget._active_widgets is deprecated.")
         return _instances
 
@@ -330,7 +330,7 @@ class Widget(LoggingHasTraits):
         # did not explicitly try to use this attribute, we do not want to throw a deprecation warning.
         # So we check if the thing calling this static property is one of the known initialization functions in traitlets.
         frame = _get_frame(2)
-        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance'))):
+        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance', 'setup_class'))):
             deprecation("Widget._widget_types is deprecated.")
         return _registry
 
@@ -340,7 +340,7 @@ class Widget(LoggingHasTraits):
         # did not explicitly try to use this attribute, we do not want to throw a deprecation warning.
         # So we check if the thing calling this static property is one of the known initialization functions in traitlets.
         frame = _get_frame(2)
-        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance'))):
+        if not (frame.f_code.co_filename == TRAITLETS_FILE and (frame.f_code.co_name in ('getmembers', 'setup_instance', 'setup_class'))):
             deprecation("Widget.widget_types is deprecated.")
         return _registry
 


### PR DESCRIPTION
We missed a traitlet setup function that is called when the class is setup.

Fixes #3648

With these changes:

```
$ python -c "import warnings; warnings.resetwarnings(); import ipywidgets"
/private/var/folders/l0/km7g2yss183d7nrskwl4xgbc0000gn/T/tmpenv.Moiql2qU/env/lib/python3.11/site-packages/jupyter_client/connect.py:27: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
given by the platformdirs library.  To remove this warning and
see the appropriate new directories, set the environment variable
`JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
The use of platformdirs will be the default in `jupyter_core` v6
  from jupyter_core.paths import jupyter_data_dir
```