### PR TITLE
Update to `jupyterlite==0.1.0b17`

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -25,5 +25,5 @@ dependencies:
   - sphinx_rtd_theme
   - sympy
   - pip:
-    - jupyterlite==0.1.0b14
+    - jupyterlite==0.1.0b17
     - jupyterlite-sphinx~=0.7.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,5 +14,5 @@ packaging
 scikit-image
 scikit-learn
 sympy
-jupyterlite==0.1.0b14
+jupyterlite==0.1.0b17
 jupyterlite-sphinx~=0.7.2

--- a/docs/source/jupyter_lite_config.json
+++ b/docs/source/jupyter_lite_config.json
@@ -12,7 +12,9 @@
       "https://files.pythonhosted.org/packages/py3/j/jupyterlab_github/jupyterlab_github-3.0.1-py3-none-any.whl",
       "../../python/jupyterlab_widgets/jupyterlab_widgets/labextension"
     ],
-    "ignore_sys_prefix": true,
+    "ignore_sys_prefix": true
+  },
+  "PipliteAddon": {
     "piplite_urls": [
       "../../python/ipywidgets/dist",
       "../../python/widgetsnbextension/dist",


### PR DESCRIPTION
Update to the latest `jupyterlite` release: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b17

In this release the `piplite_urls` configuration has changed and should be provided under `PipliteAddon`: https://jupyterlite.readthedocs.io/en/latest/howto/python/wheels.html