### PR TITLE
Fix deprecation warning

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/interaction.py
+++ b/python/ipywidgets/ipywidgets/widgets/interaction.py
@@ -208,7 +208,8 @@ class interactive(VBox):
             # invoke execution.
             for w in self.kwargs_widgets:
                 if isinstance(w, Text):
-                    w.on_submit(self.update)
+                    w.continuous_update = False
+                    w.observe(self.update, names='value')
         else:
             for widget in self.kwargs_widgets:
                 widget.observe(self.update, names='value')


### PR DESCRIPTION
Fixes #3669

Test:
```python
from ipywidgets import interact_manual

@interact_manual
def f(x=(0,10)):
    print(x)
```

Before:
<img width="618" alt="Screen Shot 2023-01-18 at 08 55 22" src="https://user-images.githubusercontent.com/192614/213224192-fa5427a6-513b-4141-a4c9-50e91525c42e.png">


After:
<img width="549" alt="Screen Shot 2023-01-18 at 08 56 25" src="https://user-images.githubusercontent.com/192614/213224238-17fe7611-6ae0-4014-9df6-ab025d08374d.png">

