### PR TITLE
Add pytest-check-links for internal URLs

### DIFF
--- a/.binder/README
+++ b/.binder/README
@@ -1,10 +1,10 @@
 This directory holds configuration files for https://mybinder.org/.
 
 The interactive notebooks can be accessed with this link:
-https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/master?filepath=docs/source/examples
+https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/main?filepath=docs/source/examples
 
-To check out a different version, just replace "master" with the desired
+To check out a different version, just replace `main` with the desired
 branch/tag name or commit hash.
 
 To use JupyterLab, use:
-https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/master?urlpath=lab/tree/docs/source/examples
+https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/main?urlpath=lab/tree/docs/source/examples

--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -18,7 +18,7 @@ jobs:
           script: |
             var PR_HEAD_USERREPO = process.env.PR_HEAD_USERREPO;
             var PR_HEAD_REF = process.env.PR_HEAD_REF;
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build jupyterlab_widgets
 
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
     branches: '*'
 

--- a/.github/workflows/devinstall.yml
+++ b/.github/workflows/devinstall.yml
@@ -2,7 +2,7 @@ name: Run the dev-install script
 
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
     branches: '*'
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -2,7 +2,8 @@ name: Packaging
 
 on:
   push:
-    branches: [master]
+    branches:
+      - main
   pull_request:
     branches: '*'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,9 @@ jobs:
         run: |
           cd docs/source
           python -m sphinx -T -E -b html -d ../build/doctrees -D language=en . ../build/html
+      - name: Check internal links
+        run: |
+          pytest-check-links -vv --check-anchors --check-links-ignore "^https?://" --links-ext html
   js:
     name: JavaScript
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 | Purpose                         | Badges                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Latest (master: future 8.0)** | [![Test Status](https://github.com/jupyter-widgets/ipywidgets/actions/workflows/tests.yml/badge.svg?query=branch%3Amaster)](https://github.com/jupyter-widgets/ipywidgets/actions?query=branch%3Amaster) [![Documentation Status: latest](https://img.shields.io/readthedocs/ipywidgets?logo=read-the-docs)](https://ipywidgets.readthedocs.io/en/latest/?badge=latest) [![Binder:master](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/master?urlpath=lab/tree/docs%2Fsource%2Fexamples)                                     |
+| **Latest (`main`: future 8.0)** | [![Test Status](https://github.com/jupyter-widgets/ipywidgets/actions/workflows/tests.yml/badge.svg?query=branch%3Amain)](https://github.com/jupyter-widgets/ipywidgets/actions?query=branch%3Amain) [![Documentation Status: latest](https://img.shields.io/readthedocs/ipywidgets?logo=read-the-docs)](https://ipywidgets.readthedocs.io/en/latest/?badge=latest) [![Binder:main](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/main?urlpath=lab/tree/docs%2Fsource%2Fexamples)                                             |
 | **Stable**                      | [![Version](https://img.shields.io/pypi/v/ipywidgets.svg?logo=pypi)](https://pypi.python.org/pypi/ipywidgets) [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ipywidgets.svg?logo=conda-forge)](https://anaconda.org/conda-forge/ipywidgets) [![Documentation Status](https://img.shields.io/readthedocs/ipywidgets?logo=read-the-docs)](https://ipywidgets.readthedocs.io/en/stable/?badge=stable) [![Binder:7.x](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyter-widgets/ipywidgets/7.x?urlpath=lab/tree/docs%2Fsource%2Fexamples) |
 | **Communication**               | [![Join the chat at https://gitter.im/ipython/ipywidgets](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jupyter-widgets/Lobby) [![Discourse](https://img.shields.io/badge/help_forum-discourse-blue?logo=discourse)](https://discourse.jupyter.org/c/widgets/46)                                                                                                                                                                                                                                                                                             |
 |                                 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 **ipywidgets**, also known as jupyter-widgets or simply widgets, are
-[interactive HTML widgets](https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/examples/Index.ipynb)
+[interactive HTML widgets](https://github.com/jupyter-widgets/ipywidgets/blob/main/docs/source/examples/Index.ipynb)
 for Jupyter notebooks and the IPython kernel.
 
 Notebooks come alive when interactive widgets are used. Users gain control of
@@ -21,7 +21,7 @@ ipywidgets to your notebooks, and we're here to help you get started.
 ## Core Interactive Widgets
 
 The fundamental widgets provided by this library are called core interactive
-widgets. A [demonstration notebook](https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/examples/Index.ipynb)
+widgets. A [demonstration notebook](https://github.com/jupyter-widgets/ipywidgets/blob/main/docs/source/examples/Index.ipynb)
 provides an overview of the core interactive widgets, including:
 
 - sliders
@@ -87,14 +87,14 @@ see the detailed [developer install](docs/source/dev_install.md) instructions.
 
 If you want to install ipywidgets from source, **you will need the
 [yarn](https://yarnpkg.com/) package manager version 1.2.1 or later**.
-To install the latest master version from the root directory of the source
+To install the latest `main` version from the root directory of the source
 code, run `dev-install.sh`. To only build the Python package enter
 `pip install -e .`.
 
 ## Usage
 
 See the [examples](docs/source/examples.md) section of the documentation. The widgets are being used in a variety of ways; some uses can be seen in these notebooks:
-[Demo notebook of interactive widgets](https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/examples/Index.ipynb)
+[Demo notebook of interactive widgets](https://github.com/jupyter-widgets/ipywidgets/blob/main/docs/source/examples/Index.ipynb)
 
 ## Change log
 
@@ -106,13 +106,13 @@ Refer to change log for more detail.
 
 | ipywidgets | JupyterLab | [Classic Notebook](https://github.com/jupyter/notebook) | [nbclassic](https://github.com/jupyterlab/nbclassic) |
 | ---------- | :--------: | :-----------------------------------------------------: | :--------------------------------------------------: |
-| master     |            |                            -                            |                         TBD                          |
-| 7.6.3      |            |                                                         |                        0.2.6                         |
+| `main`     |            |                            -                            |                         TBD                          |
+| `7.6.3`    |            |                                                         |                        0.2.6                         |
 | **Legacy** |            |                                                         |                                                      |
-| 6.x        |            |                                                         |                          -                           |
-| 5.x        |            |                           4.2                           |                          -                           |
-| 4.1.x      |            |                           4.1                           |                          -                           |
-| 4.0.x      |            |                           4.0                           |                          -                           |
+| `6.x`      |            |                                                         |                          -                           |
+| `5.x`      |            |                           4.2                           |                          -                           |
+| `4.1.x`    |            |                           4.1                           |                          -                           |
+| `4.0.x`    |            |                           4.0                           |                          -                           |
 
 ## Contributing to ipywidgets
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -33,7 +33,10 @@ dependencies:
   - scikit-image
   - scikit-learn
   - sympy
-  # jupyterlite dependencies
+  # test
+  - pytest-check-links
+  - requests-cache
+  # jupyterlite
   - doit
   - pkginfo
   - python-libarchive-c

--- a/docs/lite/jupyter_lite_config.json
+++ b/docs/lite/jupyter_lite_config.json
@@ -5,11 +5,13 @@
       "Layout Templates\\.ipynb",
       "Variable Inspector\\.ipynb"
     ],
-    "contents": ["../source/examples"],
+    "contents": ["../source/examples"]
+  },
+  "PipliteAddon": {
     "piplite_urls": [
-      "../python/ipywidgets/dist",
-      "../python/widgetsnbextension/dist",
-      "../python/jupyterlab_widgets/dist"
+      "../../python/ipywidgets/dist",
+      "../../python/widgetsnbextension/dist",
+      "../../python/jupyterlab_widgets/dist"
     ]
   }
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,9 @@ numpy
 packaging
 pkginfo
 pydata-sphinx-theme
+pytest-check-links
 recommonmark
+requests-cache
 scikit-image
 scikit-learn
 sphinx >=1.4.6

--- a/docs/source/_templates/demo.html
+++ b/docs/source/_templates/demo.html
@@ -11,7 +11,7 @@
         autocomplete="off"
         checked
         title="Lab"
-        value="{{ pathto('try/lab/index') }}?path=Index.ipynb&path=Widget%20List.ipynb"
+        value="{{ pathto('try/lab/index') }}?path=Widget%20List.ipynb"
       >
       <i class="fas fa-flask"></i> Lab
     </label>
@@ -20,14 +20,14 @@
         type="radio"
         name="demo-app"
         title="Notebook"
-        value="{{ pathto('try/retro/index') }}?path=Index.ipynb&path=Widget%20List.ipynb"
+        value="{{ pathto('try/retro/index') }}?path=Widget%20List.ipynb"
       >
       <i class="fas fa-book"></i> Notebook
     </label>
   </div>
 
   <a
-    href="{{ pathto('try/lab/index') }}?path=Index.ipynb&path=Widget%20List.ipynb"
+    href="{{ pathto('try/lab/index') }}?path=Widget%20List.ipynb"
     class="btn btn-primary"
     target="_blank"
     title="Try Jupyter Widgets in your browser."

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -447,7 +447,7 @@ If you are developing a custom widget or widget manager, here are some major cha
   - A custom serializer is given the widget instance as its second argument, and a custom deserializer is given the widget manager as its second argument.
   - The Javascript model `.id` attribute has been renamed to `.model_id` to avoid conflicting with the Backbone `.id` attribute. ([#1410](https://github.com/jupyter-widgets/ipywidgets/pull/1410))
 - Regarding widget managers and the syncing message protocol:
-  - The widget protocol was significantly overhauled. The new widget messaging protocol (version 2) is specified in the [version 2 protocol documentation](https://github.com/jupyter-widgets/ipywidgets/blob/master/jupyter-widgets-schema/messages.md).
+  - The widget protocol was significantly overhauled. The new widget messaging protocol (version 2) is specified in the [version 2 protocol documentation](https://github.com/jupyter-widgets/ipywidgets/blob/main/jupyter-widgets-schema/messages.md).
   - Widgets are now displayed with a `display_data` message instead of with a custom comm message. See the [ipywidgets](https://github.com/jupyter-widgets/ipywidgets/blob/20cd0f050090b1b19bb9657b8c3fa42ae384cfca/ipywidgets/widgets/widget.py#L656) implementation for an example. ([#1274](https://github.com/jupyter-widgets/ipywidgets/pull/1274))
   - Custom widget managers are now responsible completely for loading widget model and view classes. Widget managers should provide an output model and view class appropriate for their environment so that the `Output` widget works. ([#1313](https://github.com/jupyter-widgets/ipywidgets/pull/1313))
   - The widget manager `clear_state` method no longer has a `commlessOnly` argument. All models in the widget manager will be closed and cleared when `clear_state` is called. ([#1354](https://github.com/jupyter-widgets/ipywidgets/pull/1354))
@@ -459,7 +459,7 @@ Major user-visible changes in ipywidgets 6.0 include:
 - Rendering of Jupyter interactive widgets in various web contexts
 
   sphinx documentation: http://ipywidgets.readthedocs.io/en/latest/examples/Widget%20List.html
-  nbviewer: http://nbviewer.jupyter.org/github/jupyter-widgets/ipywidgets/blob/master/docs/source/examples/Widget%20List.ipynb
+  nbviewer: http://nbviewer.jupyter.org/github/jupyter-widgets/ipywidgets/blob/main/docs/source/examples/Widget%20List.ipynb
   Static web pages: http://jupyter.org/widgets
 
 - Addition of a DatePicker widget in the core widget collection.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,7 +46,6 @@ def setup(app):
 
 extensions = [
     'myst_nb',
-    'sphinx.ext.autosectionlabel',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -178,7 +178,7 @@ html_context = {
     "doc_path": "docs",
     "github_repo": "ipywidgets",
     "github_user": "jupyter-widgets",
-    "github_version": "master",
+    "github_version": "main",
 }
 
 html_sidebars = {

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -2,5 +2,5 @@
 
 We appreciate contributions from the community.
 
-We follow the [IPython Contributing Guide](https://github.com/ipython/ipython/blob/master/CONTRIBUTING.md)
+We follow the [IPython Contributing Guide](https://github.com/ipython/ipython/blob/main/CONTRIBUTING.md)
 and [Jupyter Contributing Guides](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).

--- a/docs/source/dev_docs.md
+++ b/docs/source/dev_docs.md
@@ -91,3 +91,22 @@ all output from a notebook:
 ```bash
 nbstripout "docs/source/examples/Widget List.ipynb"
 ```
+
+## Checking links
+
+After build the docs, it is possible to check all links point to pages (and `#` anchors)
+that actually exist with [pytest-check-links](https://github.com/jupyterlab/pytest-check-links).
+
+To check all _internal_ links, which is still quite slow:
+
+```bash
+cd docs/build/html
+pytest-check-links -vv --check-anchors --check-links-ignore="^https?://" --links-ext=html
+```
+
+To also check _external_ links, ensure external requests are cached:
+
+```bash
+cd docs/build/html
+pytest-check-links -vv --check-anchors --links-ext=html --check-links-cache
+```

--- a/docs/source/dev_install.md
+++ b/docs/source/dev_install.md
@@ -12,7 +12,7 @@ To install ipywidgets from git, you will need:
 - the latest [Jupyter Notebook development release](https://github.com/jupyter/notebook/releases)
 
   - Everything in the ipywidgets repository is developed using Jupyter
-    notebook's master branch.
+    notebook's `main` branch.
   - If you want to have a copy of ipywidgets that works against a stable
     version of the notebook, checkout the appropriate tag.
   - See the

--- a/docs/source/dev_release.md
+++ b/docs/source/dev_release.md
@@ -1,7 +1,7 @@
 # Developer Release Procedure
 
 To release a new version of the widgets on PyPI and npm, first checkout the
-`master` branch and `cd` into the repo root.
+`main` branch and `cd` into the repo root.
 
 ```
 cd release
@@ -43,9 +43,9 @@ Commit the changes (don't forget to `git add` the new model spec file).
 
 ```
 # clean out all dirty files
-git checkout master
-git pull origin master
-git reset --hard origin/master
+git checkout main
+git pull origin main
+git reset --hard origin/main
 git clean -fdx
 yarn install
 yarn version
@@ -121,11 +121,11 @@ Using the above script, you can do:
 ./scripts/hashes python/jupyterlab_widgets/dist/*
 ```
 
-Commit the changes you've made above, and include the uploaded files hashes in the commit message. Tag the release if ipywidgets was released. Push to origin master (and include the tag in the push), e.g:
+Commit the changes you've made above, and include the uploaded files hashes in the commit message. Tag the release if ipywidgets was released. Push to origin `main` (and include the tag in the push), e.g:
 
 ```
 git tag 8.0.4
-git push origin master 8.0.4
+git push origin main 8.0.4
 ```
 
 Update conda-forge packages (if the requirements changed to ipywidgets, make sure to update widgetsnbextension first).
@@ -150,7 +150,7 @@ Here are some commands used to generate some of the statistics above.
 
 ```
 # merges since in 6.0.0, but not 7.0.0, which is a rough list of merged PRs
-git log --merges 6.0.0...master --pretty=oneline
+git log --merges 6.0.0...main --pretty=oneline
 
 # To really make sure we get all PRs, we could write a program that
 # pulled all of the PRs, examined a commit in each one, and did
@@ -164,11 +164,11 @@ git log --merges 6.0.0...master --pretty=oneline
 git show -s --format=%cd --date=short 6.0.0^{commit}
 
 # Non-merge commits in 7.0.0 not in any 6.x release
-git log --pretty=oneline --no-merges ^6.0.0 master | wc -l
+git log --pretty=oneline --no-merges ^6.0.0 main | wc -l
 
 # Authors of non-merge commits
-git shortlog -s  6.0.0..master --no-merges | cut -c8- | sort -f
+git shortlog -s  6.0.0..main --no-merges | cut -c8- | sort -f
 
 # New committers: authors unique in the 6.0.0..7.0.0 logs, but not in the 6.0.0 log
-comm -23 <(git shortlog -s -n 6.0.0..master --no-merges | cut -c8- | sort) <(git shortlog -s -n 6.0.0 --no-merges | cut -c8- | sort) | sort -f
+comm -23 <(git shortlog -s -n 6.0.0..main --no-merges | cut -c8- | sort) <(git shortlog -s -n 6.0.0 --no-merges | cut -c8- | sort) | sort -f
 ```

--- a/docs/source/dev_testing.md
+++ b/docs/source/dev_testing.md
@@ -18,9 +18,9 @@ This will run the test suite using `karma` with 'debug' level logging.
 
 `ipywidgets` uses the [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) framework for visual regression testing. Galata provides a high level API to programmatically interact with the JupyterLab UI, and tools for taking screenshots and generating test reports.
 
-UI tests are written in TypeScript and run with the Playwright test runner. The test suites are located in the [ui-tests/tests](https://github.com/jupyter-widgets/ipywidgets/tree/master/ui-tests/tests) directory.
+UI tests are written in TypeScript and run with the Playwright test runner. The test suites are located in the [ui-tests/tests](https://github.com/jupyter-widgets/ipywidgets/tree/main/ui-tests/tests) directory.
 
-The [main test suite](https://github.com/jupyter-widgets/ipywidgets/tree/master/ui-tests/tests/widgets.test.ts) uploads a [notebook](https://github.com/jupyter-widgets/ipywidgets/tree/master/ui-tests/tests/notebooks/widgets.ipynb) to JupyterLab, runs it cell by cell and captures a screenshot of the cell outputs. The cell outputs correspond to widgets of different types. The cell outputs captures are then compared to the [reference snapshots](https://github.com/jupyter-widgets/ipywidgets/tree/master/ui-tests/tests/widgets.test.ts-snapshots/) to detect any visual regression. The test report (diffs, result, videos) is uploaded to GitHub as an artifact and accessible from the GitHub Actions page in `Artifacts` section.
+The [main test suite](https://github.com/jupyter-widgets/ipywidgets/tree/main/ui-tests/tests/widgets.test.ts) uploads a [notebook](https://github.com/jupyter-widgets/ipywidgets/tree/main/ui-tests/tests/notebooks/widgets.ipynb) to JupyterLab, runs it cell by cell and captures a screenshot of the cell outputs. The cell outputs correspond to widgets of different types. The cell outputs captures are then compared to the [reference snapshots](https://github.com/jupyter-widgets/ipywidgets/tree/main/ui-tests/tests/widgets.test.ts-snapshots/) to detect any visual regression. The test report (diffs, result, videos) is uploaded to GitHub as an artifact and accessible from the GitHub Actions page in `Artifacts` section.
 
 ## Running Tests Locally
 
@@ -51,7 +51,7 @@ Checkout the [Playwright Command Line Reference](https://playwright.dev/docs/tes
 
 ## Adding new UI tests
 
-New test suites can be added to the [ui-tests/tests](https://github.com/jupyter-widgets/ipywidgets/tree/master/ui-tests/tests) directory. Their names need to end with `.test.ts`. You can see some additional example test suites in the [JupyterLab repo](https://github.com/jupyterlab/jupyterlab/blob/master/galata/test). If the tests in new suites are doing visual regression tests or HTML source regression tests then you also need to add their reference images to the `-snapshots` directories.
+New test suites can be added to the [ui-tests/tests](https://github.com/jupyter-widgets/ipywidgets/tree/main/ui-tests/tests) directory. Their names need to end with `.test.ts`. You can see some additional example test suites in the [JupyterLab repo](https://github.com/jupyterlab/jupyterlab/blob/master/galata/test). If the tests in new suites are doing visual regression tests or HTML source regression tests then you also need to add their reference images to the `-snapshots` directories.
 
 ## Reference Image Captures
 

--- a/docs/source/embedding.md
+++ b/docs/source/embedding.md
@@ -252,7 +252,7 @@ If your notebook was saved with the special "Save Notebook Widget State" action
 in the Widgets menu, interactive widgets displayed in your notebook should also
 be rendered on nbviewer.
 
-See e.g. the [Widget List](http://nbviewer.jupyter.org/github/jupyter-widgets/ipywidgets/blob/master/docs/source/examples/Widget%20List.ipynb)
+See e.g. the [Widget List](http://nbviewer.jupyter.org/github/jupyter-widgets/ipywidgets/blob/main/docs/source/examples/Widget%20List.ipynb)
 example from the documentation.
 
 ## The Case of Custom Widget Libraries
@@ -306,14 +306,14 @@ Specifically:
   the `Sphinx` extension, `nbviewer`, and the "Embed Widgets" command
   discussed above.
 
-We provide [additional examples](https://github.com/jupyter-widgets/ipywidgets/tree/master/examples) of specializations of the base widget manager
+We provide [additional examples](https://github.com/jupyter-widgets/ipywidgets/tree/main/examples) of specializations of the base widget manager
 implementing other usages of Jupyter widgets in web contexts.
 
-1. The [`web1`](https://github.com/jupyter-widgets/ipywidgets/tree/master/examples/web1) example is a simplistic example showcasing the use of
+1. The [`web1`](https://github.com/jupyter-widgets/ipywidgets/tree/main/examples/web1) example is a simplistic example showcasing the use of
    Jupyter widgets in a web context.
-2. The [`web2`](https://github.com/jupyter-widgets/ipywidgets/tree/master/examples/web2) example is a simple example making use of the
+2. The [`web2`](https://github.com/jupyter-widgets/ipywidgets/tree/main/examples/web2) example is a simple example making use of the
    `application/vnd.jupyter.widget-state+json` mime type.
-3. The [`web3`](https://github.com/jupyter-widgets/ipywidgets/tree/master/examples/web3) example showcases how communication with a Jupyter kernel can
+3. The [`web3`](https://github.com/jupyter-widgets/ipywidgets/tree/main/examples/web3) example showcases how communication with a Jupyter kernel can
    happen in a web context outside of the notebook or jupyterlab contexts.
-4. The [`web4`](https://github.com/jupyter-widgets/ipywidgets/tree/master/examples/web4) example shows how to embed widgets in an HTML document
+4. The [`web4`](https://github.com/jupyter-widgets/ipywidgets/tree/main/examples/web4) example shows how to embed widgets in an HTML document
    using the HTML widget manager.

--- a/docs/source/examples/Layout Templates.ipynb
+++ b/docs/source/examples/Layout Templates.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Using Layout Templates\n",
     "\n",
-    "As we showed in [Layout of Jupyter widgets](Widget%20Layout.ipynb), multiple widgets can be arranged together using the flexible [GridBox](Widget%20Styling.ipynb#The-Grid-layout) specification. However, use of the specification involves some understanding of CSS properties and may impose sharp learning curve. Here, we will describe layout templates built on top of `GridBox` that simplify creation of common widget layouts."
+    "As we showed in [Layout of Jupyter widgets](Widget%20Layout.ipynb), multiple widgets can be arranged together using the flexible [GridBox](Widget%20Layout.ipynb#The-Grid-layout) specification. However, use of the specification involves some understanding of CSS properties and may impose sharp learning curve. Here, we will describe layout templates built on top of `GridBox` that simplify creation of common widget layouts."
    ]
   },
   {

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -9,7 +9,7 @@ The documentation for `ipywidgets` 7 is available at
 [ipywidgets 7 documentation](https://ipywidgets.readthedocs.io/en/7.x).
 ```
 
-Jupyter Widgets are [interactive browser controls](https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/examples/Index.ipynb)
+Jupyter Widgets are [interactive browser controls](https://github.com/jupyter-widgets/ipywidgets/blob/main/docs/source/examples/Index.ipynb)
 for Jupyter notebooks. Examples include:
 
 - Basic form controls like **sliders**, **checkboxes**, **text inputs**

--- a/docs/source/migration_guides.md
+++ b/docs/source/migration_guides.md
@@ -313,10 +313,10 @@ for details.
 Since you probably want to avoid repeating the module version in every
 widget, a common pattern is to import the version from `package.json` and
 prepend a `~`. See
-[ipyvolume](https://github.com/maartenbreddels/ipyvolume/blob/master/js/src/figure.js#L1245)
+[ipyvolume](https://github.com/widgetti/ipyvolume/blob/master/js/src/figure.ts)
 for an example. If you do this, make sure that your webpack configuration
 includes a JSON loader. See the Webpack configuration for
-[ipyvolume](https://github.com/maartenbreddels/ipyvolume/blob/master/js/webpack.config.js#L7)
+[ipyvolume](https://github.com/widgetti/ipyvolume/blob/master/js/webpack.config.js#L7)
 for an example.
 
 ### Updating the notebook extension

--- a/docs/source/user_install.md
+++ b/docs/source/user_install.md
@@ -77,7 +77,7 @@ jupyter labextension install @jupyter-widgets/jupyterlab-manager
 
 This command defaults to installing the latest version of the **ipywidgets**
 JupyterLab extension. Depending on the version of JupyterLab you have installed, you
-may need to install [an older version](https://github.com/jupyter-widgets/ipywidgets/tree/master/packages/jupyterlab-manager#version-compatibility).
+may need to install [an older version](https://github.com/jupyter-widgets/ipywidgets/tree/main/packages/jupyterlab-manager#version-compatibility).
 
 If you install this extension while JupyterLab is running, you will need to
 refresh the page or restart JupyterLab before the changes take effect.

--- a/packages/base/src/services-shim.ts
+++ b/packages/base/src/services-shim.ts
@@ -295,7 +295,6 @@ export namespace shims {
             if (callbacks.shell && callbacks.shell.reply) {
               callbacks.shell.reply(msg);
             }
-            // TODO: Handle payloads.  See https://github.com/jupyter/notebook/blob/master/notebook/static/services/kernels/kernel.js#L923-L947
           };
 
           future.onStdin = function (msg): void {

--- a/python/ipywidgets/README.md
+++ b/python/ipywidgets/README.md
@@ -1,7 +1,7 @@
 # ipywidgets: Interactive HTML Widgets
 
 **ipywidgets**, also known as jupyter-widgets or simply widgets, are
-[interactive HTML widgets](https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/examples/Index.ipynb)
+[interactive HTML widgets](https://github.com/jupyter-widgets/ipywidgets/blob/main/docs/source/examples/Index.ipynb)
 for Jupyter notebooks and the IPython kernel.
 
 This package contains the python implementation of the core interactive widgets bundled in ipywidgets.
@@ -9,7 +9,7 @@ This package contains the python implementation of the core interactive widgets 
 ## Core Interactive Widgets
 
 The fundamental widgets provided by this library are called core interactive
-widgets. A [demonstration notebook](https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/examples/Index.ipynb)
+widgets. A [demonstration notebook](https://github.com/jupyter-widgets/ipywidgets/blob/main/docs/source/examples/Index.ipynb)
 provides an overview of the core interactive widgets, including:
 
 - sliders

--- a/python/ipywidgets/ipywidgets/widgets/trait_types.py
+++ b/python/ipywidgets/ipywidgets/widgets/trait_types.py
@@ -367,11 +367,11 @@ class InstanceDict(traitlets.Instance):
 
 
 # The regexp is taken
-# from https://github.com/d3/d3-format/blob/master/src/formatSpecifier.js
+# from https://github.com/d3/d3-format/blob/main/src/formatSpecifier.js
 _number_format_re = re.compile(r'^(?:(.)?([<>=^]))?([+\-\( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?([a-z%])?$', re.I)
 
 # The valid types are taken from
-# https://github.com/d3/d3-format/blob/master/src/formatTypes.js
+# https://github.com/d3/d3-format/blob/main/src/formatTypes.js
 _number_format_types = {
     'e', 'f', 'g', 'r', 's', '%', 'p', 'b', 'o', 'd', 'x',
     'X', 'c', ''

--- a/scripts/milestone_check.py
+++ b/scripts/milestone_check.py
@@ -15,7 +15,7 @@ import sys
 REPO = 'jupyter-widgets/ipywidgets'
 
 ranges = {
-    '8.0': 'origin/master ^7.x',
+    '8.0': 'origin/main ^7.x',
 }
 
 try:
@@ -182,7 +182,7 @@ print()
 
 if len(prs_not_represented) > 0:
     print("""
-PRs that are in the milestone, but have no commits in the version range. 
+PRs that are in the milestone, but have no commits in the version range.
 These PRs probably belong in a different milestone.
 """)
     print('\n'.join(f'https://github.com/{REPO}/pull/{i}' for i in prs_not_represented))
@@ -196,7 +196,7 @@ print()
 if len(notfound):
     print("""The following commits are not included in any PR on this milestone.
 This probably means the commit's PR needs to be assigned to this milestone,
-or the commit was pushed to master directly.
+or the commit was pushed to main directly.
 """)
     print('\n'.join('%s %s %s'%(c, commits[c][0], commits[c][1]) for c in notfound))
     prs_to_check = [c for c in notfound if 'Merge pull request #' in commits[c][1] and commits[c][0] == 'noreply@github.com']


### PR DESCRIPTION
## References
- contains #3674 
  - this could be an _unrelated_ PR, but is also testing that the binder badge workflow is correct 
- continues #3673

## Changes
- [x] adds `pytest-check-links`
- [x] adds docs about running locally
- [x] adds to docs CI

## Future work
- checking external links is a bit more fiddly, and benefits from a more precise use of caching to avoid making _way_ too many requests and getting rate-banned 