### PR TITLE
fix: deserialize state before updating model on reconnect

### DIFF
--- a/packages/base/src/manager-base.ts
+++ b/packages/base/src/manager-base.ts
@@ -508,7 +508,10 @@ abstract class ManagerBase<T> {
                 } else {
                     // model already exists here
                     const model = await this.get_model(widget_id);
-                    model!.set_state(state.state);
+                    const deserializedState = await (
+                        model!.constructor as typeof WidgetModel
+                    )._deserialize_state(state.state, this);
+                    model!.set_state(deserializedState);
                 }
             } catch (error) {
                 // Failed to create a widget model, we continue creating other models so that


### PR DESCRIPTION
This is a backport of #3549 from 8.x to the 7.x branch.

When jupyterlab resumes from a sleeping computer, it will reconnect, and instead of creating the new comms, it will update the models. Like #3549 we did not deserialize the state in this rare condition. This caused a model widget to be passed as a string, which later on caused `model.state_change.then` to fail, since model.state_change is undefined.  On the js console, it would show:
```
Error setting state: Cannot read properties of undefined (reading ‘then’)
```

This caused widgets not to appear.

Privately reported, and also likely the cause of https://github.com/spacetelescope/jdaviz/issues/1977.

