### PR TITLE
fix: deepcopy with `structuredClone` over JSON.parse/stringify

### DIFF
--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -524,6 +524,8 @@ export class WidgetModel extends Backbone.Model {
    * binary array buffers.
    */
   serialize(state: Dict<any>): JSONObject {
+    const deepcopy = 
+      globalThis.structuredClone || (x: any) => JSON.parse(JSON.stringify(x));
     const serializers =
       (this.constructor as typeof WidgetModel).serializers || {};
     for (const k of Object.keys(state)) {
@@ -532,7 +534,7 @@ export class WidgetModel extends Backbone.Model {
           state[k] = serializers[k].serialize!(state[k], this);
         } else {
           // the default serializer just deep-copies the object
-          state[k] = JSON.parse(JSON.stringify(state[k]));
+          state[k] = deepcopy(state[k]);
         }
         if (state[k] && state[k].toJSON) {
           state[k] = state[k].toJSON();

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -524,8 +524,8 @@ export class WidgetModel extends Backbone.Model {
    * binary array buffers.
    */
   serialize(state: Dict<any>): JSONObject {
-    const deepcopy = 
-      globalThis.structuredClone || (x: any) => JSON.parse(JSON.stringify(x));
+    const deepcopy =
+      globalThis.structuredClone || ((x: any) => JSON.parse(JSON.stringify(x)));
     const serializers =
       (this.constructor as typeof WidgetModel).serializers || {};
     for (const k of Object.keys(state)) {


### PR DESCRIPTION
[`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) is now the preferred way to deeply copy objects in JS. It is widely supported across browsers, minus some edge cases like in Safari web-workers (see the table in the linked documentation).

 The old `JSON.parse` + `JSON.stringify` trick **deletes** any `DataView`s (without a custom serializer) within `WidgetModel.serialize`, leading to a serious bug when using raw "binary" traitlets. With the `{remove,put}_buffers` implementations, extra serializers are _not_ required for transferring binary data. The following example should work without custom serializers but immediately deletes `text` value when `this.model.save_changes()` is called for the first time.

```javascript
import { DOMWidgetModel, DOMWidgetView } from "@jupyter-widgets/base";
class CustomModel extends DOMWidgetModel { /* ... */ }
class CustomView extends DOMWidgetView {
  render() {
    let decoder = new TextDecoder(), encoder = new TextEncoder();
    let text = document.createElement("textarea");
    text.oninput = () => {
      let bytes = encoder.encode(text.value);
      this.model.set("text", new DataView(bytes.buffer));
      this.model.save_changes(); // internally calls JSON.parse(JSON.stringify(DataView)) -> {}
    };
    let on_change = () => text.value = decoder.decode(this.model.get("text"));
    on_change();
    this.model.on("change:text", on_change);
    this.el.appendChild(text);
  }
}
export { CustomModel, CustomView };
```

```python
class CustomWidget(ipywidgets.DOMWidget):
    # ...
    text = traitlets.Any(b'hello, world').tag(sync=True)
```