### PR TITLE
Bump font awesome version to 5.15.4

### DIFF
--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -35,7 +35,7 @@
     "test:unit:firefox:headless": "npm run test:unit:default -- --browsers=FirefoxHeadless"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.12.0",
+    "@fortawesome/fontawesome-free": "^5.15.4",
     "@jupyter-widgets/base": "^6.0.2",
     "@jupyter-widgets/base-manager": "^1.0.3",
     "@jupyter-widgets/controls": "^5.0.3",


### PR DESCRIPTION
The current version for the fontawesome icons is 5.12. Some icons have been added to later versions, this is for example the case of https://fontawesome.com/v5/icons/uncharted?s=&f=brands which was added in 5.15.

It would be great if we could bump the version for fontawesome.

I tried to copy the changes from https://github.com/jupyter-widgets/ipywidgets/pull/2713, but note that I am not sure how to update the `yarn.lock` file.
I tried to follow the instructions in the developer docs, but when running `yarn build` it generated a lot of changes with new versions for everything, so for now I left it out until someone can provide guidance.
Maybe the file gets updated during the CI?

Thanks!