### PR TITLE
Handle `null` _view_count

### DIFF
--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -759,7 +759,7 @@ export class WidgetView extends NativeView<WidgetModel> {
 
     this.once('displayed', () => {
       if (typeof this.model.get('_view_count') === 'number') {
-        this.model.set('_view_count', this.model.get('_view_count') + 1);
+        this.model.set('_view_count', (this.model.get('_view_count') || 0) + 1);
         this.model.save_changes();
       }
     });


### PR DESCRIPTION
This ensures the `_view_count` doesn't stay `null` once displayed.

c/f https://discourse.jupyter.org/t/how-do-i-trigger-an-event-after-a-widget-is-displayed/18506