### PR TITLE
chore: refine `IClassicCom` types

### DIFF
--- a/packages/base/src/services-shim.ts
+++ b/packages/base/src/services-shim.ts
@@ -8,6 +8,7 @@
  */
 
 import { Kernel, KernelMessage } from '@jupyterlab/services';
+import type { JSONValue, JSONObject } from '@lumino/coreutils';
 
 /**
  * Callbacks for services shim comms.
@@ -40,9 +41,9 @@ export interface IClassicComm {
    * @return msg id
    */
   open(
-    data: any,
-    callbacks: any,
-    metadata?: any,
+    data: JSONValue,
+    callbacks?: ICallbacks,
+    metadata?: JSONObject,
     buffers?: ArrayBuffer[] | ArrayBufferView[]
   ): string;
 
@@ -55,9 +56,9 @@ export interface IClassicComm {
    * @return message id
    */
   send(
-    data: any,
-    callbacks: any,
-    metadata?: any,
+    data: JSONValue,
+    callbacks?: ICallbacks,
+    metadata?: JSONObject,
     buffers?: ArrayBuffer[] | ArrayBufferView[]
   ): string;
 
@@ -70,9 +71,9 @@ export interface IClassicComm {
    * @return msg id
    */
   close(
-    data?: any,
-    callbacks?: any,
-    metadata?: any,
+    data?: JSONValue,
+    callbacks?: ICallbacks,
+    metadata?: JSONObject,
     buffers?: ArrayBuffer[] | ArrayBufferView[]
   ): string;
 
@@ -218,9 +219,9 @@ export namespace shims {
        * @return msg id
        */
       open(
-        data: any,
-        callbacks: any,
-        metadata?: any,
+        data: JSONValue,
+        callbacks?: ICallbacks,
+        metadata?: JSONObject,
         buffers?: ArrayBuffer[] | ArrayBufferView[]
       ): string {
         const future = this.jsServicesComm.open(data, metadata, buffers);
@@ -237,9 +238,9 @@ export namespace shims {
        * @return message id
        */
       send(
-        data: any,
-        callbacks: any,
-        metadata?: any,
+        data: JSONValue,
+        callbacks?: ICallbacks,
+        metadata?: JSONObject,
         buffers?: ArrayBuffer[] | ArrayBufferView[]
       ): string {
         const future = this.jsServicesComm.send(data, metadata, buffers);
@@ -255,9 +256,9 @@ export namespace shims {
        * @return msg id
        */
       close(
-        data?: any,
-        callbacks?: any,
-        metadata?: any,
+        data?: JSONValue,
+        callbacks?: ICallbacks,
+        metadata?: JSONObject,
         buffers?: ArrayBuffer[] | ArrayBufferView[]
       ): string {
         const future = this.jsServicesComm.close(data, metadata, buffers);
@@ -288,7 +289,7 @@ export namespace shims {
        */
       _hookupCallbacks(
         future: Kernel.IShellFuture,
-        callbacks: ICallbacks
+        callbacks?: ICallbacks
       ): void {
         if (callbacks) {
           future.onReply = function (msg): void {

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -9,7 +9,7 @@ import $ from 'jquery';
 
 import { NativeView } from './nativeview';
 
-import { JSONObject } from '@lumino/coreutils';
+import { JSONObject, JSONValue } from '@lumino/coreutils';
 
 import { Message, MessageLoop } from '@lumino/messaging';
 
@@ -164,8 +164,8 @@ export class WidgetModel extends Backbone.Model {
    * Send a custom msg over the comm.
    */
   send(
-    content: {},
-    callbacks: {},
+    content: JSONValue,
+    callbacks?: ICallbacks,
     buffers?: ArrayBuffer[] | ArrayBufferView[]
   ): void {
     if (this.comm !== undefined) {

--- a/packages/controls/test/src/utils.ts
+++ b/packages/controls/test/src/utils.ts
@@ -45,7 +45,7 @@ export class MockComm implements widgets.IClassicComm {
 
   close(
     data?: JSONValue,
-    callbacks?: ICallbacks,
+    callbacks?: widgets.ICallbacks,
     metadata?: JSONObject,
     buffers?: ArrayBuffer[] | ArrayBufferView[]
   ): string {

--- a/packages/controls/test/src/utils.ts
+++ b/packages/controls/test/src/utils.ts
@@ -5,6 +5,8 @@ import * as widgets from '@jupyter-widgets/base';
 import * as services from '@jupyterlab/services';
 import { DummyManager } from './dummy-manager';
 
+import type { JSONValue, JSONObject } from '@lumino/coreutils';
+
 let numComms = 0;
 
 export class MockComm implements widgets.IClassicComm {
@@ -30,8 +32,9 @@ export class MockComm implements widgets.IClassicComm {
   }
 
   open(
-    data?: any,
-    metadata?: any,
+    data: JSONValue,
+    callbacks?: widgets.ICallbacks,
+    metadata?: JSONObject,
     buffers?: ArrayBuffer[] | ArrayBufferView[]
   ): string {
     if (this._on_open) {
@@ -41,8 +44,9 @@ export class MockComm implements widgets.IClassicComm {
   }
 
   close(
-    data?: any,
-    metadata?: any,
+    data?: JSONValue,
+    callbacks?: ICallbacks,
+    metadata?: JSONObject,
     buffers?: ArrayBuffer[] | ArrayBufferView[]
   ): string {
     if (this._on_close) {
@@ -52,8 +56,9 @@ export class MockComm implements widgets.IClassicComm {
   }
 
   send(
-    data?: any,
-    metadata?: any,
+    data: JSONValue,
+    callbacks?: widgets.ICallbacks,
+    metadata?: JSONObject,
     buffers?: ArrayBuffer[] | ArrayBufferView[]
   ): string {
     return '';


### PR DESCRIPTION
There is heavy use of `any` in `IClassicCom` types but then the wrapper in Widget adds unecessary strictness. These types are forwarded by [anywidget](https://github.com/manzt/anywidget) and raise type errors downstream for seemingly valid arguments: https://twitter.com/domoritz/status/1637504802543345666

This PR adds more precise types and relaxes the strictness of `Widget.send` to make `callbacks` optional.

cc: @domoritz
