### PR TITLE
BUG: comm.kernel should be None when it has no kernel

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_output.py
@@ -111,7 +111,7 @@ class Output(DOMWidget):
         kernel = None
         if ip and getattr(ip, "kernel", None) is not None:
             kernel = ip.kernel
-        elif self.comm is not None and getattr(self.comm, 'kernel', True) is not None:
+        elif self.comm is not None and getattr(self.comm, 'kernel', None) is not None:
             kernel = self.comm.kernel
 
         if kernel:


### PR DESCRIPTION
Hopefully this will fix https://github.com/ipython/comm/issues/14 but I don't know for sure.

cc @maartenbreddels 