### PR TITLE
fix: revert ipykernel dependency removal

### DIFF
--- a/python/ipywidgets/setup.cfg
+++ b/python/ipywidgets/setup.cfg
@@ -34,6 +34,7 @@ zip_safe = False
 packages = find:
 
 install_requires =
+  ipykernel>=4.5.1
   ipython>=6.1.0
   traitlets>=4.3.1
   widgetsnbextension~=4.0


### PR DESCRIPTION
This change was too large for a fix release and hurt many people.
Let's move this to an 8.1 release, add comm as a dependency, and not have it break anything
see https://github.com/jupyter-widgets/ipywidgets/pull/3748 for the 7.x fix