### PR TITLE
feat: Thread safe kernel side Output widget

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output.py
@@ -237,3 +237,16 @@ def test_append_display_data():
         },
     )
     assert widget.outputs == expected1 or widget.outputs == expected2
+
+
+def test_kernel_side_output():
+    output = widget_output.Output()
+    with output:
+        print("snakes!")
+    assert output.outputs == (
+        {
+            'output_type': 'stream',
+            'name': 'stdout',
+            'text': 'snakes!
+        }
+    )


### PR DESCRIPTION
# Background
Working on support the output widget in solara:
 * https://github.com/widgetti/solara/pull/68
 * More specifically https://github.com/widgetti/solara/pull/68/commits/6802aa53a307eeb15ca0b57c87e9b414f97d9149

I found out about the hooks in ipykernel https://github.com/ipython/ipykernel/pull/115

This approach will probably be better way forward.

# The issue
Without a frontend, the output widget does not work. We had to work around that for Voila https://github.com/voila-dashboards/voila/pull/91 (now ported to nbclient https://github.com/jupyter/nbclient/pull/68 ).

Futhermore, the frontend is not aware of threads, causing all kinds of issues, e.g.:
 * https://github.com/jupyter-widgets/ipywidgets/issues/3260
 * https://github.com/jupyter-widgets/ipywidgets/issues/2358

This does require https://github.com/ipython/ipykernel/pull/1110, so even if we go forward with this, the old code will have to stay in.

# Testing and ipykernel

This solution only works with ipykernel/ipython, and I am not sure how to test this. Also, this goes against the direction of begin independent of a particular implementation. For instance, I am not sure xeus-kernel could support this (cc @martinRenou ).

