### PR TITLE
fix: fallback to lumino deepCopy rather than JSON.parse

### DIFF
--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -34,7 +34,6 @@ import { KernelMessage } from '@jupyterlab/services';
  */
 const IPY_MODEL_ = 'IPY_MODEL_';
 
-const deepcopy = globalThis.structuredClone || JSONExt.deepCopy;
 
 /**
  * Replace model ids with models recursively.
@@ -579,6 +578,7 @@ export class WidgetModel extends Backbone.Model {
           state[k] = serialize(state[k], this);
         } else {
           // the default serializer just deep-copies the object
+          const deepcopy = globalThis.structuredClone || JSONExt.deepCopy;
           state[k] = deepcopy(state[k]);
         }
 

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -34,12 +34,7 @@ import { KernelMessage } from '@jupyterlab/services';
  */
 const IPY_MODEL_ = 'IPY_MODEL_';
 
-/**
- * A best-effort method for performing deep copies.
- */
-const deepcopyJSON = (x: JSONValue) => JSON.parse(JSON.stringify(x));
-
-const deepcopy = globalThis.structuredClone || deepcopyJSON;
+const deepcopy = globalThis.structuredClone || JSONExt.deepCopy;
 
 /**
  * Replace model ids with models recursively.
@@ -577,7 +572,7 @@ export class WidgetModel extends Backbone.Model {
 
         if (serialize == null && keySerializers.deserialize === unpack_models) {
           // handle https://github.com/jupyter-widgets/ipywidgets/issues/3735
-          serialize = deepcopyJSON;
+          serialize = JSONExt.deepCopy;
         }
 
         if (serialize) {


### PR DESCRIPTION
This PR fixes issue: https://github.com/jupyter-widgets/ipywidgets/issues/3701

You can test this by:
1. Rendering a widget
2. Using it as normal
3. Opening your console and writing `delete window.structuredClone`
4. Continuing to use the widget and seeing it still works as normal

I think this is a proper test, as I have verified that the `serialize` code is being called, and that it defaults to the correct function. Let me know if there is more to test though!