### PR TITLE
Explain that ipywidgets is part of jupyter-widgets software subproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Learning becomes an immersive, fun experience. Researchers can easily see
 how changing inputs to a model impact the results. We hope you will add
 ipywidgets to your notebooks, and we're here to help you get started.
 
-The ipywidgets is a package under the [Jupyter-Widgets](https://github.com/jupyter-widgets) (software subproject)[https://jupyter.org/governance/software_subprojects.html].
+The ipywidgets is a package under the [Jupyter-Widgets](https://github.com/jupyter-widgets) [software subproject](https://jupyter.org/governance/software_subprojects.html).
 
 ## Core Interactive Widgets
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Learning becomes an immersive, fun experience. Researchers can easily see
 how changing inputs to a model impact the results. We hope you will add
 ipywidgets to your notebooks, and we're here to help you get started.
 
+The ipywidgets is a package under the [Jupyter-Widgets](https://github.com/jupyter-widgets) (software subproject)[https://jupyter.org/governance/software_subprojects.html].
+
 ## Core Interactive Widgets
 
 The fundamental widgets provided by this library are called core interactive

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Learning becomes an immersive, fun experience. Researchers can easily see
 how changing inputs to a model impact the results. We hope you will add
 ipywidgets to your notebooks, and we're here to help you get started.
 
-The ipywidgets is a package under the [Jupyter-Widgets](https://github.com/jupyter-widgets) [software subproject](https://jupyter.org/governance/software_subprojects.html).
+The ipywidgets package is under the [Jupyter-Widgets](https://github.com/jupyter-widgets) [software subproject](https://jupyter.org/governance/software_subprojects.html).
 
 ## Core Interactive Widgets
 

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -1,5 +1,7 @@
 # Contributing
 
+The ipywidgets package is under the [Jupyter-Widgets](https://github.com/jupyter-widgets) [software subproject](https://jupyter.org/governance/software_subprojects.html).
+
 We appreciate contributions from the community.
 
 We follow the [IPython Contributing Guide](https://github.com/ipython/ipython/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
It helps new users understand context when we explain that Jupyter-Widgets is the subproject, and link to the defintion of what a subproject is.  

Most newcomers to Jupyter have no idea what the governance model of Jupyter is, or more importantly how it is relevant to them and the project they are looking at.