### PR TITLE
Docs: Remove the note about mappings not working with selection widgets.

### DIFF
--- a/docs/source/examples/Widget List.ipynb
+++ b/docs/source/examples/Widget List.ipynb
@@ -482,13 +482,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are several widgets that can be used to display single selection lists, and two that can be used to select multiple values.  All inherit from the same base class.  You can specify the **enumeration of selectable options by passing a list** (options are either (label, value) pairs, or simply values for which the labels are derived by calling `str`).\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "Changes in *ipywidgets 8*:\n",
-    "    \n",
-    "Selection widgets no longer accept a dictionary of options. Pass a list of key-value pairs instead.\n",
-    "</div>"
+    "There are several widgets that can be used to display single selection lists, and two that can be used to select multiple values.  All inherit from the same base class.  You can specify the **enumeration of selectable options by passing a list** (options are either (label, value) pairs, or simply values for which the labels are derived by calling `str`)."
    ]
   },
   {


### PR DESCRIPTION
The documentation for Selection widgets still contained a prominent admonishment that `options=` could no longer be a Mapping as of ipywidgets 8.0. But #3557 undid that change, so it's no longer an issue.

This reverts commit 5a7307413a0d432af0b6aaa773ee3372178bf504.