### PR TITLE
docs/environment: Use jupyterlab-myst from pypi

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - jupyter_client
   # docs
   - docutils >=0.19
-  # - jupyterlab-myst
+  - jupyterlab-myst
   - myst-nb >=0.17,<0.18
   - pandoc
   - pydata-sphinx-theme
@@ -39,4 +39,3 @@ dependencies:
   - python-libarchive-c
   - pip:
       - jupyterlite ==0.1.0b18
-      - git+https://github.com/executablebooks/jupyterlab-myst.git@agoose77/feat-jupyterlab-v4-next


### PR DESCRIPTION
Version 2.0.0, with support for jlab4, released on 2023-06-23.

As of last week's merge of executablebooks/jupyterlab-myst#155, the PR source branch that was being pulled in<sup>1</sup> is deleted from the repo. But that's OK, as PyPi has the new release.

Fixes ReadTheDocs CI builds. (Or at least, it should...)

#### Notes
1. (Actually the environment file was pulling in the source branch for an earlier PR, executablebooks/jupyterlab-myst#142, that was abandoned in favor of the now-merged 155.)