### PR TITLE
docs: remove developer docs resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,6 @@ python -c "import IPython; print(IPython.sys_info())"
 - **All work is submitted through pull requests (PRs)**
   - PRs are submitted as soon as there is code to be discussed
 
-Current developer information can be found in the latest docs [here](https://ipywidgets.readthedocs.io/en/latest/developer_docs.html).
-
 ---
 
 # Check these resources:


### PR DESCRIPTION
**PR Summary**:
In PR #3488 the `developer_docs.rst` resource was removed but the `CONTRIBUTING.md` file still points to it, which leads to a broken [hyperlink](https://ipywidgets.readthedocs.io/en/latest/developer_docs.html). The PR simply removes it from `CONTRIBUTING.md`.