### PR TITLE
Remove shebang lines from test_* files

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/tests/test_datetime_serializers.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_datetime_serializers.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 # Copyright (c) Vidar Tonaas Fauske.

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_datetime.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_datetime.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 # Copyright (c) Jupyter Development Team.

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_naive_datetime.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_naive_datetime.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 # Copyright (c) Vidar Tonaas Fauske.

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_time.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_time.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # coding: utf-8
 
 # Copyright (c) Vidar Tonaas Fauske.


### PR DESCRIPTION
The files are not executable and there is no code that would make sense to run directly so the shebang lines are not needed.