### PR TITLE
Replace ipykernel dependency by the comm dependency

### DIFF
--- a/.github/workflows/devinstall.yml
+++ b/.github/workflows/devinstall.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install notebook jupyterlab jupyter_packaging~=0.10
+          python -m pip install notebook jupyterlab notebook~=6.0 jupyter_packaging~=0.10
       - name: Run the dev-install script
         run: |
           ./dev-install.sh

--- a/dev-install.sh
+++ b/dev-install.sh
@@ -31,11 +31,11 @@ jlpm build
 echo -n "widgetsnbextension"
 pip install -v -e ./python/widgetsnbextension
 if [[ "$OSTYPE" == "msys" ]]; then
-    jupyter nbextension install --overwrite --py $nbExtFlags widgetsnbextension
+    jupyter nbextension install --overwrite --py $nbExtFlags widgetsnbextension || true
 else
-    jupyter nbextension install --overwrite --py --symlink $nbExtFlags widgetsnbextension
+    jupyter nbextension install --overwrite --py --symlink $nbExtFlags widgetsnbextension || true
 fi
-jupyter nbextension enable --py $nbExtFlags widgetsnbextension
+jupyter nbextension enable --py $nbExtFlags widgetsnbextension || true
 
 echo -n "ipywidgets"
 pip install -v -e "./python/ipywidgets[test]"

--- a/docs/source/examples/Widget Custom.ipynb
+++ b/docs/source/examples/Widget Custom.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "tags": ["remove-cell"]
+    "tags": [
+     "remove-cell"
+    ]
    },
    "source": [
     "[Index](Index.ipynb) - [Back](Widget%20Styling.ipynb) - [Next](Widget%20Asynchronous.ipynb)"
@@ -828,7 +830,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "tags": ["remove-cell"]
+    "tags": [
+     "remove-cell"
+    ]
    },
    "source": [
     "[Index](Index.ipynb) - [Back](Widget%20Styling.ipynb) - [Next](Widget%20Asynchronous.ipynb)"

--- a/python/ipywidgets/ipywidgets/__init__.py
+++ b/python/ipywidgets/ipywidgets/__init__.py
@@ -26,17 +26,6 @@ import sys
 from traitlets import link, dlink
 from IPython import get_ipython
 
-# ipykernel <6.18 when the comm package did not exist
-if "ipykernel" in sys.modules and "comm" not in sys.modules:
-    def get_comm_manager():
-        ip = get_ipython()
-
-        if ip is not None and getattr(ip, "kernel", None) is not None:
-            return get_ipython().kernel.comm_manager
-# Using the comm package
-else:
-    from comm import get_comm_manager
-
 from .widgets import *
 
 
@@ -48,7 +37,8 @@ def load_ipython_extension(ip):
 
 def register_comm_target(kernel=None):
     """Register the jupyter.widget comm target"""
-    comm_manager = get_comm_manager()
+    from . import comm
+    comm_manager = comm.get_comm_manager()
     if comm_manager is None:
         return
     comm_manager.register_target('jupyter.widget', Widget.handle_comm_opened)

--- a/python/ipywidgets/ipywidgets/__init__.py
+++ b/python/ipywidgets/ipywidgets/__init__.py
@@ -21,17 +21,21 @@ accessible as a `value` attribute.
 from ._version import __version__, __protocol_version__, __jupyter_widgets_controls_version__, __jupyter_widgets_base_version__
 
 import os
+import sys
 
 from traitlets import link, dlink
 from IPython import get_ipython
-try:
-    from comm import get_comm_manager
-except ImportError:
+
+# ipykernel <6.18 when the comm package did not exist
+if "ipykernel" in sys.modules and "comm" not in sys.modules:
     def get_comm_manager():
         ip = get_ipython()
 
         if ip is not None and getattr(ip, "kernel", None) is not None:
             return get_ipython().kernel.comm_manager
+# Using the comm package
+else:
+    from comm import get_comm_manager
 
 from .widgets import *
 

--- a/python/ipywidgets/ipywidgets/comm.py
+++ b/python/ipywidgets/ipywidgets/comm.py
@@ -1,0 +1,33 @@
+# compatibility shim for ipykernel < 6.18
+import sys
+from IPython import get_ipython
+import comm
+
+
+def requires_ipykernel_shim():
+    if "ipykernel" in sys.modules:
+        import ipykernel
+
+        version = ipykernel.version_info
+        return version < (6, 18)
+    else:
+        return False
+
+
+def get_comm_manager():
+    if requires_ipykernel_shim():
+        ip = get_ipython()
+
+        if ip is not None and getattr(ip, "kernel", None) is not None:
+            return get_ipython().kernel.comm_manager
+    else:
+        return comm.get_comm_manager()
+
+
+def create_comm(*args, **kwargs):
+    if requires_ipykernel_shim():
+        from ipykernel.comm import Comm
+
+        return Comm(*args, **kwargs)
+    else:
+        return comm.create_comm(*args, **kwargs)

--- a/python/ipywidgets/ipywidgets/tests/test_embed.py
+++ b/python/ipywidgets/ipywidgets/tests/test_embed.py
@@ -9,9 +9,6 @@ import shutil
 
 import traitlets
 
-# This has a byproduct of setting up the comms
-import ipykernel.ipkernel
-
 from ..widgets import IntSlider, IntText, Text, Widget, jslink, HBox, widget_serialization, widget as widget_module
 from ..embed import embed_data, embed_snippet, embed_minimal_html, dependency_state
 

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -15,6 +15,7 @@ from traitlets import (
     Any, HasTraits, Unicode, Dict, Instance, List, Int, Set, Bytes, observe, default, Container,
     Undefined)
 from json import loads as jsonloads, dumps as jsondumps
+from .. import comm
 
 from base64 import standard_b64encode
 
@@ -525,16 +526,7 @@ class Widget(LoggingHasTraits):
             if self._model_id is not None:
                 args['comm_id'] = self._model_id
 
-            # ipykernel <6.18 when the comm package did not exist
-            if "ipykernel" in sys.modules and "comm" not in sys.modules:
-                def create_comm(**kwargs):
-                    from ipykernel.comm import Comm
-
-                    return Comm(**kwargs)
-            else:
-                from comm import create_comm
-
-            self.comm = create_comm(**args)
+            self.comm = comm.create_comm(**args)
 
     @observe('comm')
     def _comm_changed(self, change):

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -6,6 +6,7 @@
 in the Jupyter notebook front-end.
 """
 import os
+import sys
 import typing
 from contextlib import contextmanager
 from collections.abc import Iterable
@@ -524,13 +525,14 @@ class Widget(LoggingHasTraits):
             if self._model_id is not None:
                 args['comm_id'] = self._model_id
 
-            try:
-                from comm import create_comm
-            except ImportError:
+            # ipykernel <6.18 when the comm package did not exist
+            if "ipykernel" in sys.modules and "comm" not in sys.modules:
                 def create_comm(**kwargs):
                     from ipykernel.comm import Comm
 
                     return Comm(**kwargs)
+            else:
+                from comm import create_comm
 
             self.comm = create_comm(**args)
 

--- a/python/ipywidgets/setup.cfg
+++ b/python/ipywidgets/setup.cfg
@@ -34,7 +34,7 @@ zip_safe = False
 packages = find:
 
 install_requires =
-  ipykernel>=4.5.1
+  comm>=0.1.3
   ipython>=6.1.0
   traitlets>=4.3.1
   widgetsnbextension~=4.0.7


### PR DESCRIPTION
As discussed in https://github.com/jupyter-widgets/ipywidgets/pull/3749

This will:
- Use the comm implementation from ipykernel if it's available
- Otherwise import the comm implementation from the new comm package (typically the case of xeus-python, or in a test runtime where there is no kernel)