### PR TITLE
Reverts #3689 and #3738 back to the original working codebase

### DIFF
--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -34,12 +34,6 @@ import { KernelMessage } from '@jupyterlab/services';
  */
 const IPY_MODEL_ = 'IPY_MODEL_';
 
-/**
- * A best-effort method for performing deep copies.
- */
-const deepcopyJSON = (x: JSONValue) => JSON.parse(JSON.stringify(x));
-
-const deepcopy = globalThis.structuredClone || deepcopyJSON;
 
 /**
  * Replace model ids with models recursively.

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -34,7 +34,6 @@ import { KernelMessage } from '@jupyterlab/services';
  */
 const IPY_MODEL_ = 'IPY_MODEL_';
 
-
 /**
  * Replace model ids with models recursively.
  */

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -566,21 +566,12 @@ export class WidgetModel extends Backbone.Model {
       JSONExt.emptyObject;
     for (const k of Object.keys(state)) {
       try {
-        const keySerializers = serializers[k] || JSONExt.emptyObject;
-        let { serialize } = keySerializers;
-
-        if (serialize == null && keySerializers.deserialize === unpack_models) {
-          // handle https://github.com/jupyter-widgets/ipywidgets/issues/3735
-          serialize = deepcopyJSON;
-        }
-
-        if (serialize) {
-          state[k] = serialize(state[k], this);
+        if (serializers[k] && serializers[k].serialize) {
+          state[k] = serializers[k].serialize!(state[k], this);
         } else {
           // the default serializer just deep-copies the object
           state[k] = JSON.parse(JSON.stringify(state[k]));
         }
-
         if (state[k] && state[k].toJSON) {
           state[k] = state[k].toJSON();
         }

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -584,7 +584,7 @@ export class WidgetModel extends Backbone.Model {
           state[k] = serialize(state[k], this);
         } else {
           // the default serializer just deep-copies the object
-          state[k] = deepcopy(state[k]);
+          state[k] = JSON.parse(JSON.stringify(state[k]));
         }
 
         if (state[k] && state[k].toJSON) {


### PR DESCRIPTION
Reverts jupyter-widgets/ipywidgets#3689 and jupyter-widgets/ipywidgets#3738

As discussed in https://github.com/jupyter-widgets/ipywidgets/issues/3735. We should probably revert those in a patch release, then be back with a solution that works nicely later.