### PR TITLE
Add "widget_id" filter to "request_states" message, fixing + refactoring some CI

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/tests/test_send_state.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_send_state.py
@@ -1,21 +1,11 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from traitlets import Bool, Tuple, List
-
-from .utils import setup, teardown, DummyComm
+from .utils import setup, teardown, DummyComm, SimpleWidget, NumberWidget
 
 from ..widget import Widget
 
 from ..._version import __control_protocol_version__
-
-# A widget with simple traits
-class SimpleWidget(Widget):
-    a = Bool().tag(sync=True)
-    b = Tuple(Bool(), Bool(), Bool(), default_value=(False, False, False)).tag(
-        sync=True
-    )
-    c = List(Bool()).tag(sync=True)
 
 
 def test_empty_send_state():
@@ -29,3 +19,42 @@ def test_empty_hold_sync():
     with w.hold_sync():
         pass
     assert w.comm.messages == []
+
+def test_control():
+    comm = DummyComm()
+    Widget.close_all()
+    w = SimpleWidget()
+    Widget.handle_control_comm_opened(
+        comm, dict(metadata={'version': __control_protocol_version__})
+    )
+    Widget._handle_control_comm_msg(dict(content=dict(
+        data={'method': 'request_states'}
+    )))
+    assert comm.messages
+
+def test_control_filter():
+    comm = DummyComm()
+    random_widget = SimpleWidget()
+    random_widget.open()
+    random_widget_id = random_widget.model_id
+    important_widget = NumberWidget()
+    important_widget.open()
+    important_widget_id = important_widget.model_id
+    Widget.handle_control_comm_opened(
+        comm, dict(metadata={'version': __control_protocol_version__})
+    )
+    Widget._handle_control_comm_msg(dict(content=dict(
+        data={'method': 'request_states', 'widget_id': important_widget_id}
+    )))
+    # comm.messages have very complicated nested structure, we just want to verify correct widget is included
+    assert important_widget_id in str(comm.messages[0])
+    # And widget not supposed to be there is filtered off
+    assert random_widget_id not in str(comm.messages[0])
+
+    # Negative case (should contain all states)
+    Widget._handle_control_comm_msg(dict(content=dict(
+        data={'method': 'request_states'}
+    )))
+    assert important_widget_id in str(comm.messages[1])
+    assert random_widget_id in str(comm.messages[1])
+

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_send_state.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_send_state.py
@@ -58,3 +58,10 @@ def test_control_filter():
     assert important_widget_id in str(comm.messages[1])
     assert random_widget_id in str(comm.messages[1])
 
+    # Invalid case (widget either already closed or does not exist)
+    Widget._handle_control_comm_msg(dict(content=dict(
+        data={'method': 'request_states', 'widget_id': 'no_such_widget'}
+    )))
+    # Should not contain any iPyWidget information in the states
+    assert not comm.messages[2][0][0]['states']
+

--- a/python/ipywidgets/ipywidgets/widgets/tests/utils.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/utils.py
@@ -2,7 +2,10 @@
 # Distributed under the terms of the Modified BSD License.
 
 from ipywidgets import Widget
+from traitlets import Bool, Tuple, List, Instance, CFloat, CInt, Float, Int
+
 import ipywidgets.widgets.widget
+import uuid
 
 # The new comm package is not available in our Python 3.7 CI (older ipykernel version)
 try:
@@ -15,11 +18,11 @@ import ipykernel.comm
 
 
 class DummyComm():
-    comm_id = 'a-b-c-d'
     kernel = 'Truthy'
 
     def __init__(self, *args, **kwargs):
         super().__init__()
+        self.comm_id = uuid.uuid4().hex
         self.messages = []
 
     def open(self, *args, **kwargs):
@@ -95,3 +98,56 @@ def teardown():
 
 def call_method(method, *args, **kwargs):
     method(*args, **kwargs)
+
+
+# A widget with simple traits (list + tuple to ensure both are handled)
+class SimpleWidget(Widget):
+    a = Bool().tag(sync=True)
+    b = Tuple(Bool(), Bool(), Bool(), default_value=(False, False, False)).tag(sync=True)
+    c = List(Bool()).tag(sync=True)
+
+
+# A widget with various kinds of number traits
+class NumberWidget(Widget):
+    f = Float().tag(sync=True)
+    cf = CFloat().tag(sync=True)
+    i = Int().tag(sync=True)
+    ci = CInt().tag(sync=True)
+
+
+
+# A widget where the data might be changed on reception:
+def transform_fromjson(data, widget):
+    # Switch the two last elements when setting from json, if the first element is True
+    # and always set first element to False
+    if not data[0]:
+        return data
+    return [False] + data[1:-2] + [data[-1], data[-2]]
+
+class TransformerWidget(Widget):
+    d = List(Bool()).tag(sync=True, from_json=transform_fromjson)
+
+
+# A widget that has a buffer:
+class DataInstance():
+    def __init__(self, data=None):
+        self.data = data
+
+def mview_serializer(instance, widget):
+    return { 'data': memoryview(instance.data) if instance.data else None }
+
+def bytes_serializer(instance, widget):
+    return { 'data': bytearray(memoryview(instance.data).tobytes()) if instance.data else None }
+
+def deserializer(json_data, widget):
+    return DataInstance( memoryview(json_data['data']).tobytes() if json_data else None )
+
+class DataWidget(SimpleWidget):
+    d = Instance(DataInstance, args=()).tag(sync=True, to_json=mview_serializer, from_json=deserializer)
+
+# A widget that has a buffer that might be changed on reception:
+def truncate_deserializer(json_data, widget):
+    return DataInstance( json_data['data'][:20].tobytes() if json_data else None )
+
+class TruncateDataWidget(SimpleWidget):
+    d = Instance(DataInstance, args=()).tag(sync=True, to_json=bytes_serializer, from_json=truncate_deserializer)

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -445,9 +445,7 @@ class Widget(LoggingHasTraits):
         state = {}
         if widgets is None:
             widgets = _instances.values()
-        print(widgets)
         for widget in widgets:
-            print(widget.model_id)
             state[widget.model_id] = widget._get_embed_state(drop_defaults=drop_defaults)
         return {'version_major': 2, 'version_minor': 0, 'state': state}
 
@@ -539,7 +537,6 @@ class Widget(LoggingHasTraits):
                 args['comm_id'] = self._model_id
 
             self.comm = comm.create_comm(**args)
-            print(self.comm)
 
     @observe('comm')
     def _comm_changed(self, change):

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -399,6 +399,10 @@ class Widget(LoggingHasTraits):
                     'model_module_version': widget._model_module_version,
                     'state': widget.get_state(drop_defaults=drop_defaults),
                 }
+            if 'widget_id' in data:
+                # In this case, we only want 1 widget state
+                id = data['widget_id']
+                full_state = {k: v for k, v in full_state.items() if k == id}
             full_state, buffer_paths, buffers = _remove_buffers(full_state)
             cls._control_comm.send(dict(
                 method='update_states',
@@ -441,7 +445,9 @@ class Widget(LoggingHasTraits):
         state = {}
         if widgets is None:
             widgets = _instances.values()
+        print(widgets)
         for widget in widgets:
+            print(widget.model_id)
             state[widget.model_id] = widget._get_embed_state(drop_defaults=drop_defaults)
         return {'version_major': 2, 'version_minor': 0, 'state': state}
 
@@ -533,6 +539,7 @@ class Widget(LoggingHasTraits):
                 args['comm_id'] = self._model_id
 
             self.comm = comm.create_comm(**args)
+            print(self.comm)
 
     @observe('comm')
     def _comm_changed(self, change):


### PR DESCRIPTION
## Explanation of motivation
There is a bug in iPyWidgets state handling that happened quite frequently: If the `comm` target is already closed (when the widget is closed/deleted) before the frontend sends the `request_state`, Jupyter kernel swallows the `request_state` and does nothing (as the comm target does not exist), leading to the frontend thinking backend hangs. As a result, we need a source of truth for widget state when a widget is closed, and Widget Manager is currently the best source of truth since it have all the widget states.

In order to solve the bug, the frontend can now ask Widget for the state with `request_states`. We do not want to send back the entire chunk of all widget states when we only need one state, we added the filter for `request_states`. This will send back the state for a specific widget frontend is requesting, and if the response coming back is an empty dictionary frontend knows the widget doesn't exist any more. This solves the bug I mentioned above.

## Testing fixes
The testing pipeline's `DummyComm` have default `comm_id`, but widgets' `model_id` is set to be its `self.comm.comm_id`. This means all widgets created in test environment have same model_id. Due to the way we set-up `_instances` (`_instances[self.model_id] = self`), that effectively means we only have 1 active widget available. This is fine in most cases, but in our case we do need different widgets co-exist for filtering verification. Hence, not the `comm_id` is randomly generated.