### PR TITLE
Exclude browser asset dependencies in emscripten

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,12 +1,22 @@
 version: 2
 
 build:
-  os: 'ubuntu-22.04'
+  os: ubuntu-22.04
   tools:
-    python: 'mambaforge-4.10'
+    python: mambaforge-22.9
+  jobs:
+    pre_build:
+      - jlpm
+      - jlpm build
+      - jlpm docs
+      - cd python/jupyterlab_widgets && pyproject-build --no-isolation
+      - cd python/widgetsnbextension && pyproject-build --no-isolation
+      - cd python/ipywidgets && pyproject-build --no-isolation
+
 python:
   install:
     - method: pip
       path: ./python/ipywidgets
+
 conda:
   environment: docs/environment.yml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,7 +28,8 @@ dependencies:
   - bqplot
   - ipykernel
   - ipyleaflet
-  - jupyterlite >=0.1.1,<0.2.0
+  - jupyterlite >=0.1.2,<0.2.0
+  - jupyterlite-pyodide-kernel >=0.1.2,<0.2.0
   - matplotlib-base
   - numpy
   - scikit-image

--- a/python/ipywidgets/setup.cfg
+++ b/python/ipywidgets/setup.cfg
@@ -37,8 +37,8 @@ install_requires =
   comm>=0.1.3
   ipython>=6.1.0
   traitlets>=4.3.1
-  widgetsnbextension~=4.0.9
-  jupyterlab_widgets~=3.0.9
+  widgetsnbextension~=4.0.9; platform_system != "Emscripten"
+  jupyterlab_widgets~=3.0.9; platform_system != "Emscripten"
 
 [options.extras_require]
 test =


### PR DESCRIPTION
## Elevator Pitch

Don't require `jupyterlab_widgets` or `widgetsnbextension` when already in a browser environment, such as JupyteLite.

## Changes

- [x] add `; platform_system != "Emscripten"` to browser dependencies in `ipywidgets`' setup.cfg
- [x] update `.readthedocs.yaml` 
  - [x] update `jupyterlite` dependencies 
  - [x] use updated `mambaforge`
  - [x] pre-build assets for more inspectable logs
    - > errors will appear in dedicated steps, rather than in the monster `sphinx` call

## Motivation

Both [jupyterlite-pyodide-kernel](https://github.com/jupyterlite/pyodide-kernel) and [jupyterlite-xeus-python-kernel](https://github.com/jupyterlite/xeus-python-kernel) report `platform.system()` as `Emscripten`. There may be other in-the-wild uses, but these are the two primary ones I know of that implement enough of the Jupyter architecture to support widgets.

These assets are _relatively_ large, and in the end, don't really do anything... in fact, in `pyodide`'s `micropip`, they don't even _go_ anywhere, as `data_files` are [not respected](https://github.com/pyodide/micropip/issues/18). Further, when `ipywidgets` updates its asset dependencies (which is generally very _good_ for users) we have to scramble to deal with stuff downstream.

Particuarly for `jupyterlite-pyodide-kernel`, this would avoid having to deploy patches for `widgetsnbextension`, as the `notebook` dependency can't really be fulfilled (e.g. `pyzmq`).

## Test Procedure

Once the RTD job fires, on opening one of the [preview notebooks](https://ipywidgets--3834.org.readthedocs.build/en/3834/_static/lab/index.html?path=Widget%20List.ipynb) with the network tab open: 
- run all cells
- see `jupyterlab_widgets` and `widgetsnbextension` wheels are not be loaded
- `import jupyterlab_widgets, widgetsnbextension` should fail with `ModuleNotFoundError`

## Future Work

Unbundling `**/tests/**` from the `ipywidgets` wheel would take it from `137K` down to `73K`. Every little bit counts!

While there has been some pushback on this on e.g. `ipython`, whereas a large number of Jupyter projects (`jupyter_server`, etc) now only ship tests in `sdist` packages, which is good for downstreams.