### PR TITLE
Remove stray require from lib/index.js

### DIFF
--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "npm run build:src && npm run build:css",
     "build:css": "lessc css/nouislider.less css/nouislider.css && postcss --use postcss-import --use postcss-cssnext -o css/widgets.built.css css/widgets.css",
-    "build:src": "tsc --build",
+    "build:src": "npm run clean:src && tsc --build && npm run build:fixup-version",
+    "build:fixup-version": "node ./scripts/fixup-version.js",
     "build:test": "tsc --build test && webpack --config test/webpack.conf.js",
     "clean": "npm run clean:src",
     "clean:src": "rimraf lib && rimraf tsconfig.tsbuildinfo",

--- a/packages/controls/scripts/fixup-version.js
+++ b/packages/controls/scripts/fixup-version.js
@@ -1,0 +1,18 @@
+
+const fs = require("fs")
+
+const json = JSON.parse(fs.readFileSync("package.json", "utf8"));
+const version = json.version;
+
+const index = fs.readFileSync("lib/index.js", "utf8");
+
+const indexFixed = index.replace(
+  'export const version = "";',
+  'export const version = "' + version + '";'
+);
+
+if (indexFixed === index) {
+  throw new Error("Failed to insert version string into lib/index.js");
+}
+
+fs.writeFileSync("lib/index.js", indexFixed);

--- a/packages/controls/src/index.ts
+++ b/packages/controls/src/index.ts
@@ -24,4 +24,4 @@ export * from './widget_string';
 export * from './widget_description';
 export * from './widget_upload';
 
-export const version = (require('../package.json') as any).version;
+export const version = "";


### PR DESCRIPTION
To fix #3854.

This adds a fixup step to the build, so the proper version string gets inserted into `lib/index.js`.

For example, at the current version, the file is now

```javascript
// Copyright (c) Jupyter Development Team.
// Distributed under the terms of the Modified BSD License.
export * from './utils';
export * from './version';
export * from './widget_link';
...
export * from './widget_upload';
export const version = "5.0.7";
//# sourceMappingURL=index.js.map
```