### PR TITLE
Fix wrong tag index in TagsInput when updated via python

### DIFF
--- a/packages/controls/src/widget_tagsinput.ts
+++ b/packages/controls/src/widget_tagsinput.ts
@@ -167,6 +167,7 @@ abstract class TagsInputBaseView extends DOMWidgetView {
     this.tags = [];
 
     const value: Array<any> = this.model.get('value');
+    this.inputIndex = value.length;
     for (const idx in value) {
       const index = parseInt(idx);
 


### PR DESCRIPTION
This change fixes a bug in the `TagsInput` when the `value` attribute is updated from `python` with a list of different length than the widget currently has and the `inputIndex` in the frontend not being updated.

This leads to wrong insertions of new values
![TagsInput-bug](https://github.com/jupyter-widgets/ipywidgets/assets/9513634/5a824f5b-a7c9-4dd8-afbc-11c31b888d9f)
