### PR TITLE
Docs: specify Jupyterlab (version 3.x or above)

### DIFF
--- a/docs/source/examples/Widget Custom.ipynb
+++ b/docs/source/examples/Widget Custom.ipynb
@@ -122,7 +122,7 @@
     "\n",
     "You also need to enable the widget frontend extension.\n",
     "\n",
-    "If you are using JupyterLab 3.x:\n",
+    "If you are using JupyterLab (version 3.x or above):\n",
     "\n",
     "\n",
     "```bash\n",


### PR DESCRIPTION
Current Jupyterlab is 4.x, added clarity to version compat.