### PR TITLE
Update Output Widget.ipynb

### DIFF
--- a/docs/source/examples/Output Widget.ipynb
+++ b/docs/source/examples/Output Widget.ipynb
@@ -354,6 +354,7 @@
     "```python\n",
     "import threading\n",
     "import time\n",
+    "import itertools\n",
     "\n",
     "def run():\n",
     "    for i in itertools.count(0):\n",


### PR DESCRIPTION
Fix: the `itertools` library has not been loaded before being used.