### PR TITLE
fix: get_metadata deprecated since traitlets 4.1

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -684,7 +684,7 @@ class Widget(LoggingHasTraits):
         """Dynamically add trait attributes to the Widget."""
         super().add_traits(**traits)
         for name, trait in traits.items():
-            if trait.get_metadata('sync'):
+            if 'sync' in trait.metadata:
                 self.keys.append(name)
                 self.send_state(name)
 


### PR DESCRIPTION
Hello, 

This is a very tiny PR, but I get a deprecation warning raised by this line from the traitlets library when using a custom ipywidget:

 https://github.com/ipython/traitlets/blob/cb672eb5ba235fdfee6407bd7f1b1985de934e7c/traitlets/traitlets.py#L833
 
 Here is a fix that should remove it?
 
 Edit: I explicitly allow anyone to edit anything I might have done wrong, I have no idea why the tests are failing