### PR TITLE
update image processing example notebok imports and function call

### DIFF
--- a/docs/source/examples/Image Processing.ipynb
+++ b/docs/source/examples/Image Processing.ipynb
@@ -18,7 +18,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": ["remove-cell"]
+    "tags": [
+     "remove-cell"
+    ]
    },
    "outputs": [],
    "source": [
@@ -39,6 +41,7 @@
     "from IPython.display import Image\n",
     "from ipywidgets import interact, interactive, fixed\n",
     "import matplotlib as mpl\n",
+    "import matplotlib.pyplot as plt\n",
     "from skimage import data, filters, io, img_as_float\n",
     "import numpy as np"
    ]
@@ -84,7 +87,7 @@
     "    # Don't let matplotlib autoscale the color range so we can control overall luminosity\n",
     "    vmax = 255 if arr.dtype == 'uint8' else 1.0\n",
     "    with BytesIO() as buffer:\n",
-    "        mpl.image.imsave(buffer, arr, format=format, cmap=cmap, vmin=0, vmax=vmax)\n",
+    "        plt.imsave(buffer, arr, format=format, cmap=cmap, vmin=0, vmax=vmax)\n",
     "        out = buffer.getvalue()\n",
     "    return Image(out)"
    ]
@@ -230,9 +233,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
I was running into the error:
```
AttributeError: module 'matplotlib' has no attribute 'image'
```
and I found two workarounds, using `import matplotlib.pyplot as plt` to use the pyplot submodule's `imsave()` or to import the image submodule with `import matplotlib.image as mpimg` to use its `imsave()` function. After some brief research I could not discern any major differences between the two functions so I have gone with the pyplot submodule's function.