### PR TITLE
DRAFT: Single widget manager per kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ ui-tests/playwright-report
 **/lite/.cache
 **/*.doit.*
 **/docs/typedoc/
+.yarn/*

--- a/docs/source/dev_release.md
+++ b/docs/source/dev_release.md
@@ -58,11 +58,14 @@ Lerna will prompt you for version numbers for each of the changed npm packages i
 ## Configure twine username
 
 If you have 2FA on, make sure you have your `~/.pypirc` file set to:
+
 ```
 [pypi]
 username = __token__
 ```
+
 Or set the environment variable
+
 ```
 export TWINE_USERNAME=__token__
 ```

--- a/packages/base-manager/package.json
+++ b/packages/base-manager/package.json
@@ -50,7 +50,6 @@
     "chai": "^4.0.0",
     "chai-as-promised": "^7.0.0",
     "expect.js": "^0.3.1",
-    "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.3",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.3",

--- a/packages/base-manager/package.json
+++ b/packages/base-manager/package.json
@@ -36,7 +36,7 @@
     "@jupyterlab/services": "^6.0.0 || ^7.0.0",
     "@lumino/coreutils": "^1.11.1 || ^2",
     "base64-js": "^1.2.1",
-    "sanitize-html": "^2.3"
+    "sanitize-html": "^2.13.0"
   },
   "devDependencies": {
     "@types/base64-js": "^1.2.5",
@@ -44,7 +44,7 @@
     "@types/chai-as-promised": "^7.1.0",
     "@types/expect.js": "^0.3.29",
     "@types/mocha": "^9.0.0",
-    "@types/sanitize-html": "^2.6.0",
+    "@types/sanitize-html": "^2.11.0",
     "@types/sinon": "^10.0.2",
     "@types/sinon-chai": "^3.2.2",
     "chai": "^4.0.0",

--- a/packages/base-manager/src/manager-base.ts
+++ b/packages/base-manager/src/manager-base.ts
@@ -217,7 +217,7 @@ export abstract class ManagerBase implements IWidgetManager {
   async get_model(model_id: string): Promise<WidgetModel> {
     const modelPromise = this._models[model_id];
     if (modelPromise === undefined) {
-      throw new Error('widget model not found');
+      throw new Error(`widget model '${model_id}' not found`);
     }
     return modelPromise;
   }

--- a/packages/base-manager/src/manager-base.ts
+++ b/packages/base-manager/src/manager-base.ts
@@ -413,7 +413,10 @@ export abstract class ManagerBase implements IWidgetManager {
           resolve(null);
         });
 
-        initComm.on_close(() => reject('Control comm was closed too early'));
+        initComm.on_close(() => {
+          if (data.method !== 'update_states')
+            reject('Control comm was closed too early');
+        });
 
         // Send a states request msg
         initComm.send({ method: 'request_states' }, {});

--- a/packages/base-manager/src/manager-base.ts
+++ b/packages/base-manager/src/manager-base.ts
@@ -214,7 +214,11 @@ export abstract class ManagerBase implements IWidgetManager {
    *
    * If you would like to synchronously test if a model exists, use .has_model().
    */
-  async get_model(model_id: string): Promise<WidgetModel> {
+  async get_model(model_id: string, timeout = 1000): Promise<WidgetModel> {
+    let count = 0;
+    while (!this._models[model_id] && count++ < timeout / 10) {
+      await sleep(10);
+    }
     const modelPromise = this._models[model_id];
     if (modelPromise === undefined) {
       throw new Error(`widget model '${model_id}' not found`);
@@ -918,6 +922,8 @@ export function serialize_state(
   });
   return { version_major: 2, version_minor: 0, state: state };
 }
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 namespace Private {
   /**

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -55,7 +55,6 @@
     "chai": "^4.0.0",
     "chai-as-promised": "^7.0.0",
     "expect.js": "^0.3.1",
-    "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.3",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.3",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@jupyterlab/services": "^6.0.0 || ^7.0.0",
     "@lumino/coreutils": "^1.11.1 || ^2.1",
-    "@lumino/messaging": "^1.10.1 || ^2.1",
+    "@lumino/messaging": "^1.10.1 || ^2.0.1",
     "@lumino/widgets": "^1.30.0 || ^2.1",
     "@types/backbone": "1.4.14",
     "@types/lodash": "^4.14.134",

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -1095,12 +1095,18 @@ export class DOMWidgetView extends WidgetView {
   }
 
   updateTooltip(): void {
-    const title = this.model.get('tooltip');
+    const title = this.tooltip;
     if (!title) {
       this.el.removeAttribute('title');
     } else if (this.model.get('description').length === 0) {
       this.el.setAttribute('title', title);
     }
+  }
+
+  get tooltip() {
+    return (
+      this.model.get('tooltip') ?? (this.model.get('description') || 'null')
+    );
   }
 
   /**

--- a/packages/base/src/widget.ts
+++ b/packages/base/src/widget.ts
@@ -1098,14 +1098,14 @@ export class DOMWidgetView extends WidgetView {
     const title = this.tooltip;
     if (!title) {
       this.el.removeAttribute('title');
-    } else if (this.model.get('description').length === 0) {
+    } else if (!this.model.get('description')) {
       this.el.setAttribute('title', title);
     }
   }
 
   get tooltip() {
     return (
-      this.model.get('tooltip') ?? (this.model.get('description') || 'null')
+      this.model.get('tooltip') ?? (this.model.get('description'))
     );
   }
 

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -57,7 +57,6 @@
     "chai": "^4.0.0",
     "css-loader": "^6.5.1",
     "expect.js": "^0.3.1",
-    "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.3",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.3",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -35,9 +35,9 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^6.0.7",
-    "@lumino/algorithm": "^1.9.1 || ^2.1",
+    "@lumino/algorithm": "^1.9.2 || ^2.0.1",
     "@lumino/domutils": "^1.8.1 || ^2.1",
-    "@lumino/messaging": "^1.10.1 || ^2.1",
+    "@lumino/messaging": "^1.10.1 || ^2.0.1",
     "@lumino/signaling": "^1.10.1 || ^2.1",
     "@lumino/widgets": "^1.30.0 || ^2.1",
     "d3-color": "^3.0.1",

--- a/packages/controls/src/widget_bool.ts
+++ b/packages/controls/src/widget_bool.ts
@@ -153,8 +153,6 @@ export class CheckboxView extends DescriptionView {
       this.descriptionSpan.textContent = description;
     }
     this.typeset(this.descriptionSpan);
-    this.descriptionSpan.title = description;
-    this.checkbox.title = description;
   }
 
   /**
@@ -181,13 +179,11 @@ export class CheckboxView extends DescriptionView {
   }
 
   updateTooltip(): void {
+    super.updateTooltip();
     if (!this.checkbox) return; // we might be constructing the parent
-    const title = this.model.get('tooltip');
-    if (!title) {
-      this.checkbox.removeAttribute('title');
-    } else if (this.model.get('description').length === 0) {
-      this.checkbox.setAttribute('title', title);
-    }
+    const title = this.model.get('tooltip') || '';
+    this.checkbox.setAttribute('title', title);
+    this.descriptionSpan.setAttribute('title', title);
   }
 
   events(): { [e: string]: string } {

--- a/packages/controls/src/widget_bool.ts
+++ b/packages/controls/src/widget_bool.ts
@@ -181,7 +181,7 @@ export class CheckboxView extends DescriptionView {
   updateTooltip(): void {
     super.updateTooltip();
     if (!this.checkbox) return; // we might be constructing the parent
-    const title = this.model.get('tooltip') || '';
+    const title = this.tooltip;
     this.checkbox.setAttribute('title', title);
     this.descriptionSpan.setAttribute('title', title);
   }

--- a/packages/controls/src/widget_box.ts
+++ b/packages/controls/src/widget_box.ts
@@ -91,9 +91,6 @@ export class BoxView extends DOMWidgetView {
     this.set_box_style();
   }
 
-  updateTooltip(): void {
-    return;
-  }
   update_children(): void {
     this.children_views
       ?.update(this.model.get('children'))

--- a/packages/controls/src/widget_box.ts
+++ b/packages/controls/src/widget_box.ts
@@ -91,6 +91,9 @@ export class BoxView extends DOMWidgetView {
     this.set_box_style();
   }
 
+  updateTooltip(): void {
+    return;
+  }
   update_children(): void {
     this.children_views
       ?.update(this.model.get('children'))

--- a/packages/controls/src/widget_description.ts
+++ b/packages/controls/src/widget_description.ts
@@ -99,7 +99,7 @@ export class DescriptionView extends DOMWidgetView {
 
   updateTooltip(): void {
     if (!this.label) return;
-    this.label.title = this.model.get('tooltip');
+    this.label.title = this.model.get('tooltip') || '';
   }
 
   label: HTMLLabelElement;

--- a/packages/controls/src/widget_description.ts
+++ b/packages/controls/src/widget_description.ts
@@ -99,7 +99,7 @@ export class DescriptionView extends DOMWidgetView {
 
   updateTooltip(): void {
     if (!this.label) return;
-    this.label.title = this.model.get('tooltip') || '';
+    this.label.title = this.tooltip;
   }
 
   label: HTMLLabelElement;

--- a/packages/controls/src/widget_description.ts
+++ b/packages/controls/src/widget_description.ts
@@ -98,6 +98,7 @@ export class DescriptionView extends DOMWidgetView {
   }
 
   updateTooltip(): void {
+    super.updateTooltip();
     if (!this.label) return;
     this.label.title = this.tooltip;
   }

--- a/packages/controls/src/widget_link.ts
+++ b/packages/controls/src/widget_link.ts
@@ -85,9 +85,12 @@ export class DirectionalLinkModel extends CoreWidgetModel {
         undefined
       );
       this.stopListening(this.sourceModel, 'destroy', undefined);
+      this.set('source', [null, '']);
     }
     if (this.targetModel) {
       this.stopListening(this.targetModel, 'destroy', undefined);
+      this.set('target', [null, '']);
+      this.save_changes();
     }
   }
 

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -70,8 +70,7 @@ export class SelectionView extends DescriptionView {
   updateTooltip(): void {
     super.updateTooltip();
     if (!this.listbox) return; // we might be constructing the parent
-    const title = this.model.get('tooltip') || '';
-    this.listbox.setAttribute('title', title);
+    this.listbox.setAttribute('title', this.tooltip);
   }
 
   listbox: HTMLSelectElement;

--- a/packages/controls/src/widget_selection.ts
+++ b/packages/controls/src/widget_selection.ts
@@ -68,13 +68,10 @@ export class SelectionView extends DescriptionView {
   }
 
   updateTooltip(): void {
+    super.updateTooltip();
     if (!this.listbox) return; // we might be constructing the parent
-    const title = this.model.get('tooltip');
-    if (!title) {
-      this.listbox.removeAttribute('title');
-    } else if (this.model.get('description').length === 0) {
-      this.listbox.setAttribute('title', title);
-    }
+    const title = this.model.get('tooltip') || '';
+    this.listbox.setAttribute('title', title);
   }
 
   listbox: HTMLSelectElement;

--- a/packages/controls/src/widget_string.ts
+++ b/packages/controls/src/widget_string.ts
@@ -381,8 +381,7 @@ export class TextareaView extends StringView {
   updateTooltip(): void {
     super.updateTooltip();
     if (!this.textbox) return; // we might be constructing the parent
-    const title = this.model.get('tooltip') || '';
-    this.textbox.setAttribute('title', title);
+    this.textbox.setAttribute('title', this.tooltip);
   }
 
   events(): { [e: string]: string } {
@@ -504,8 +503,7 @@ export class TextView extends StringView {
   updateTooltip(): void {
     super.updateTooltip();
     if (!this.textbox) return; // we might be constructing the parent
-    const title = this.model.get('tooltip') || '';
-    this.textbox.setAttribute('title', title);
+    this.textbox.setAttribute('title', this.tooltip);
   }
 
   update(options?: any): void {

--- a/packages/controls/src/widget_string.ts
+++ b/packages/controls/src/widget_string.ts
@@ -379,13 +379,10 @@ export class TextareaView extends StringView {
   }
 
   updateTooltip(): void {
+    super.updateTooltip();
     if (!this.textbox) return; // we might be constructing the parent
-    const title = this.model.get('tooltip');
-    if (!title) {
-      this.textbox.removeAttribute('title');
-    } else if (this.model.get('description').length === 0) {
-      this.textbox.setAttribute('title', title);
-    }
+    const title = this.model.get('tooltip') || '';
+    this.textbox.setAttribute('title', title);
   }
 
   events(): { [e: string]: string } {
@@ -505,13 +502,10 @@ export class TextView extends StringView {
   }
 
   updateTooltip(): void {
+    super.updateTooltip();
     if (!this.textbox) return; // we might be constructing the parent
-    const title = this.model.get('tooltip');
-    if (!title) {
-      this.textbox.removeAttribute('title');
-    } else if (this.model.get('description').length === 0) {
-      this.textbox.setAttribute('title', title);
-    }
+    const title = this.model.get('tooltip') || '';
+    this.textbox.setAttribute('title', title);
   }
 
   update(options?: any): void {

--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -44,7 +44,7 @@
     "@jupyterlab/outputarea": "^3.0.0 || ^4.0.0",
     "@jupyterlab/rendermime": "^3.0.0 || ^4.0.0",
     "@jupyterlab/rendermime-interfaces": "^3.0.0 || ^4.0.0",
-    "@lumino/messaging": "^1.10.1 || ^2.1",
+    "@lumino/messaging": "^1.10.1 || ^2.0.1",
     "@lumino/widgets": "^1.30.0 || ^2.1",
     "ajv": "^8.6.0",
     "jquery": "^3.1.1"
@@ -53,7 +53,7 @@
     "@types/jquery": "^3.5.16",
     "@types/mocha": "^9.0.0",
     "@types/node": "^17.0.2",
-    "@types/sanitize-html": "^2.6.0",
+    "@types/sanitize-html": "^2.11.0",
     "chai": "^4.0.0",
     "css-loader": "^6.5.1",
     "karma": "^6.3.3",

--- a/python/ipywidgets/ipywidgets/widgets/__init__.py
+++ b/python/ipywidgets/ipywidgets/widgets/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from .widget import Widget, CallbackDispatcher, register, widget_serialization, enable_weakrefence, disable_weakrefence
+from .widget import Widget, CallbackDispatcher, register, widget_serialization, enable_weakreference, disable_weakreference
 from .domwidget import DOMWidget
 from .valuewidget import ValueWidget
 

--- a/python/ipywidgets/ipywidgets/widgets/__init__.py
+++ b/python/ipywidgets/ipywidgets/widgets/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from .widget import Widget, CallbackDispatcher, register, widget_serialization
+from .widget import Widget, CallbackDispatcher, register, widget_serialization, enable_weakrefence, disable_weakrefence
 from .domwidget import DOMWidget
 from .valuewidget import ValueWidget
 

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -182,7 +182,7 @@ def test_widget_open():
 def test_weakreference(class_name, enable_weakref):
     # Ensure the base instance of all widgets can be deleted / garbage collected.
     if enable_weakref:
-        ipw.enable_weakrefence()
+        ipw.enable_weakreference()
     cls = getattr(ipw, class_name)
     if class_name in ['SelectionRangeSlider', 'SelectionSlider']:
         kwgs = {"options": [1, 2, 4]}
@@ -204,7 +204,7 @@ def test_weakreference(class_name, enable_weakref):
         assert deleted
     finally:
         if enable_weakref:
-            ipw.disable_weakrefence()
+            ipw.disable_weakreference()
 
 
 @pytest.mark.parametrize("weakref_enabled", [True, False])
@@ -234,11 +234,11 @@ def test_button_weakreference(weakref_enabled: bool):
         assert click_count == 1
 
         if weakref_enabled:
-            ipw.enable_weakrefence()
+            ipw.enable_weakreference()
             assert b in widget._instances.values(), "Instances not transferred"
-            ipw.disable_weakrefence()
+            ipw.disable_weakreference()
             assert b in widget._instances.values(), "Instances not transferred"
-            ipw.enable_weakrefence()
+            ipw.enable_weakreference()
             assert b in widget._instances.values(), "Instances not transferred"
 
         b.click()
@@ -257,4 +257,4 @@ def test_button_weakreference(weakref_enabled: bool):
             assert deleted, "Closing should remove the last strong reference."
 
     finally:
-        ipw.disable_weakrefence()
+        ipw.disable_weakreference()

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -95,6 +95,17 @@ def test_widget_copy():
         copy.deepcopy(button)
 
 
+def test_widget_open():
+    button = Button()
+    assert not button.closed
+    model_id = button.model_id
+    assert model_id in widget._instances
+    button.close()
+    assert model_id not in widget._instances
+    with pytest.raises(RuntimeError):
+        button.open()
+    
+
 def test_gc():
     # Ensure the base instance of all widgets can be deleted / garbage collected.
     classes = {}
@@ -195,7 +206,6 @@ def test_gc_box_advanced():
     # When a widget is closed it should be removed from the box.children.
     b.children[0].close()
     assert len(b.children) == 2, "b0 not removed."
-    # assert 'b0' in deleted
     
     # When the ref to box is removed it should be deleted.
     del b

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -104,9 +104,9 @@ def test_widget_open():
     assert spec["model_id"]
     button.close()
     assert model_id not in widget._instances
-    with pytest.raises(RuntimeError, match="This widget is closed"):
+    with pytest.raises(RuntimeError, match="Widget is closed"):
         button.open()
-    with pytest.raises(RuntimeError, match="This widget is closed"):
+    with pytest.raises(RuntimeError, match="Widget is closed"):
         button.get_view_spec()
 
 

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -97,7 +97,6 @@ def test_widget_copy():
 
 def test_widget_open():
     button = Button()
-    assert not button.closed
     model_id = button.model_id
     assert model_id in widget._instances
     button.close()
@@ -160,58 +159,3 @@ def test_gc_button():
     del b
     gc.collect()
     assert deleted
-
-
-def test_gc_box():
-    # Test Box gc collected and children lifecycle managed.
-    deleted = False
-    b = VBox(children=[Button(description='button')])
-
-    def on_delete():
-        nonlocal deleted
-        deleted = True
-
-    weakref.finalize(b, on_delete)
-    del b
-    gc.collect()
-    assert deleted
-
-def test_gc_box_advanced():
-    # A more advanced test for:
-    # 1. A child widget is removed from the children when it is closed
-    # 2. The children are discarded when the widget is closed.
-
-    deleted = False
-    
-    b = VBox(
-        children=[
-            Button(description="b0"),
-            Button(description="b1"),
-            Button(description="b2"),
-        ]
-    )
-
-    def on_delete():
-        nonlocal deleted
-        deleted = True
-
-    weakref.finalize(b, on_delete)
-    
-    ids = [model_id for w in  b.children if (model_id:=w.model_id)  in widget._instances]
-    assert len(ids) == 3, 'Not all button comms were registered.'
-
-    # keep a strong ref to `b1`
-    b1 = b.children[1] 
-
-    # When a widget is closed it should be removed from the box.children.
-    b.children[0].close()
-    assert len(b.children) == 2, "b0 not removed."
-    
-    # When the ref to box is removed it should be deleted.
-    del b
-    assert deleted, "`b` should have been the only strong ref to the box."
-    # assert not b.children, '`children` should be removed when the widget is closed.'
-    assert not b1.closed, 'A removed widget should remain alive.'
-
-    # b2 shouldn't have any strong references so should be deleted.
-    assert ids[2] not in widget._instances, 'b2 should have been auto deleted.'

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -178,9 +178,11 @@ def test_widget_open():
         "Widget",
     ],
 )
-def test_weakreference(class_name):
+@pytest.mark.parametrize("enable_weakref", [True, False])
+def test_weakreference(class_name, enable_weakref):
     # Ensure the base instance of all widgets can be deleted / garbage collected.
-    ipw.enable_weakrefence()
+    if enable_weakref:
+        ipw.enable_weakrefence()
     cls = getattr(ipw, class_name)
     if class_name in ['SelectionRangeSlider', 'SelectionSlider']:
         kwgs = {"options": [1, 2, 4]}
@@ -195,11 +197,14 @@ def test_weakreference(class_name):
         weakref.finalize(w, on_delete)
         # w should be the only strong ref to the widget.
         # calling `del` should invoke its immediate deletion calling the `__del__` method.
+        if not enable_weakref:
+            w.close()
         del w
         gc.collect()
         assert deleted
     finally:
-        ipw.disable_weakrefence()
+        if enable_weakref:
+            ipw.disable_weakrefence()
 
 
 @pytest.mark.parametrize("weakref_enabled", [True, False])

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -152,7 +152,7 @@ def test_gc():
 def test_gc_button():
     deleted = False
     b = Button()
-    b.on_click(lambda x: setattr(b, "clicked", True))
+    b.on_click(lambda x: setattr(x, "clicked", True))
 
     def on_delete():
         nonlocal deleted

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget.py
@@ -99,10 +99,15 @@ def test_widget_open():
     button = Button()
     model_id = button.model_id
     assert model_id in widget._instances
+    spec = button.get_view_spec()
+    assert list(spec) == ['version_major', 'version_minor', 'model_id']
+    assert spec['model_id']
     button.close()
     assert model_id not in widget._instances
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match='This widget is closed'):
         button.open()
+    with pytest.raises(RuntimeError, match='This widget is closed'):
+        button.get_view_spec()
     
 
 def test_gc():

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
@@ -36,70 +36,74 @@ class TestBox(TestCase):
             widgets.Box(box_style='invalid')
 
 
-def test_box_gc():
-    # Test Box gc collected and children lifecycle managed.
-    deleted = False
-    b = widgets.VBox(children=[widgets.Button(description='button')])
+    def test_gc(test):
+        # Test Box gc collected and children lifecycle managed.
+        deleted = False
+        b = widgets.VBox(children=[widgets.Button(description='button')])
 
-    def on_delete():
-        nonlocal deleted
-        deleted = True
+        def on_delete():
+            nonlocal deleted
+            deleted = True
 
-    weakref.finalize(b, on_delete)
-    del b
-    gc.collect()
-    assert deleted
+        weakref.finalize(b, on_delete)
+        del b
+        gc.collect()
+        assert deleted        
 
-def test_box_child_closed_observe_childen():
+    def test_child_closed_not_observe_childen(self):
 
-    b1 = widgets.Button(description='button')
-    b = widgets.VBox(children=[b1], observe_children=True)
-    b1.close()
-    assert b1 not in b.children
+        b1 = widgets.Button(description='button')
+        b = widgets.Box([b1], observe_children=False)
+        b1.close()
+        assert b1 in b.children
 
-def test_box_child_closed_not_observe_childen():
+    def test_child_closed_observe_childen(self):
 
-    b1 = widgets.Button(description='button')
-    b = widgets.GridBox(children=[b1], observe_children=False)
-    b1.close()
-    assert b1 in b.children
+        b1 = widgets.Button(description='button')
+        b = widgets.Box([b1], observe_children=True)
+        b1.close()
+        assert b1 not in b.children
+        model_id = b.model_id
+        del b
+        assert model_id not in widgets.widget._instances
 
-def test_box_gc_advanced():
-    # A more advanced test for:
-    # 1. A child widget is removed from the children when it is closed
-    # 2. The children are discarded when the widget is closed.
 
-    deleted = False
-    
-    b = widgets.VBox(
-        children=[
-            widgets.Button(description="b0"),
-            widgets.Button(description="b1"),
-            widgets.Button(description="b2"),
-        ]
-    )
+    def test_box_gc_advanced(self):
+        # A more advanced test for:
+        # 1. A child widget is removed from the children when it is closed
+        # 2. The children are discarded when the widget is closed.
 
-    def on_delete():
-        nonlocal deleted
-        deleted = True
+        deleted = False
+        
+        b = widgets.VBox(
+            children=[
+                widgets.Button(description="b0"),
+                widgets.Button(description="b1"),
+                widgets.Button(description="b2"),
+            ], observe_children=True
+        )
 
-    weakref.finalize(b, on_delete)
-    
-    ids = [model_id for w in  b.children if (model_id:=w.model_id)  in widgets.widget._instances]
-    assert len(ids) == 3, 'Not all button comms were registered.'
+        def on_delete():
+            nonlocal deleted
+            deleted = True
 
-    # keep a strong ref to `b1`
-    b1 = b.children[1] 
+        weakref.finalize(b, on_delete)
+        
+        ids = [model_id for w in  b.children if (model_id:=w.model_id)  in widgets.widget._instances]
+        assert len(ids) == 3, 'Not all button comms were registered.'
 
-    # When a widget is closed it should be removed from the box.children.
-    b.children[0].close()
-    assert len(b.children) == 2, "b0 not removed."
-    
-    # When the ref to box is removed it should be deleted.
-    del b
-    assert deleted, "`b` should have been the only strong ref to the box."
-    # assert not b.children, '`children` should be removed when the widget is closed.'
-    assert b1.comm, 'A removed widget should remain alive.'
+        # keep a strong ref to `b1`
+        b1 = b.children[1] 
 
-    # b2 shouldn't have any strong references so should be deleted.
-    assert ids[2] not in widgets.widget._instances, 'b2 should have been auto deleted.'
+        # When a widget is closed it should be removed from the box.children.
+        b.children[0].close()
+        assert len(b.children) == 2, "b0 not removed."
+        
+        # When the ref to box is removed it should be deleted.
+        del b
+        assert deleted, "`b` should have been the only strong ref to the box."
+        # assert not b.children, '`children` should be removed when the widget is closed.'
+        assert b1.comm, 'A removed widget should remain alive.'
+
+        # b2 shouldn't have any strong references so should be deleted.
+        assert ids[2] not in widgets.widget._instances, 'b2 should have been auto deleted.'

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
@@ -8,6 +8,8 @@ from unittest import TestCase
 
 from traitlets import TraitError
 
+import pytest
+
 import ipywidgets as widgets
 
 
@@ -68,7 +70,7 @@ class TestBox(TestCase):
         assert model_id not in widgets.widget._instances
 
 
-    def test_box_gc_advanced(self):
+    def test_gc_advanced(self):
         # A more advanced test for:
         # 1. A child widget is removed from the children when it is closed
         # 2. The children are discarded when the widget is closed.
@@ -107,3 +109,19 @@ class TestBox(TestCase):
 
         # b2 shouldn't have any strong references so should be deleted.
         assert ids[2] not in widgets.widget._instances, 'b2 should have been auto deleted.'
+
+
+    def test_repr_mimebundle(self):
+
+        b1 = widgets.Button()
+        
+        class wrapper:
+            _repr_mimebundle_ = b1._repr_mimebundle_
+
+        w = wrapper()
+        with pytest.raises(NotImplementedError):
+            b = widgets.Box([b1, w])
+
+
+
+        

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
@@ -3,59 +3,76 @@
 
 import gc
 import weakref
-from unittest import TestCase
 
+import pytest
 from traitlets import TraitError
 
 import ipywidgets as widgets
 
 
-class TestBox(TestCase):
-
-    def test_construction(self):
-        box = widgets.Box()
-        assert box.get_state()['children'] == []
-
-    def test_construction_with_children(self):
-        html = widgets.HTML('some html')
-        slider = widgets.IntSlider()
-        box = widgets.Box([html, slider])
-        children_state = box.get_state()['children']
-        assert children_state == [
-            widgets.widget._widget_to_json(html, None),
-            widgets.widget._widget_to_json(slider, None),
-        ]
-
-    def test_construction_style(self):
-        box = widgets.Box(box_style='warning')
-        assert box.get_state()['box_style'] == 'warning'
-
-    def test_construction_invalid_style(self):
-        with self.assertRaises(TraitError):
-            widgets.Box(box_style='invalid')
+def test_box_construction():
+    box = widgets.Box()
+    assert box.get_state()["children"] == []
 
 
-    def test_gc(self):
-        widgets.enable_weakrefence()
-        # Test Box gc collected and children lifecycle managed.
-        try:
-            deleted = False
-            class TestButton(widgets.Button):
-                def my_click (self, b):
-                    pass
-            button = TestButton(description='button')
-            button.on_click(button.my_click)
-            
-            b = widgets.VBox(children=[button])
+def test_box_construction_with_children():
+    html = widgets.HTML("some html")
+    slider = widgets.IntSlider()
+    box = widgets.Box([html, slider])
+    children_state = box.get_state()["children"]
+    assert children_state == [
+        widgets.widget._widget_to_json(html, None),
+        widgets.widget._widget_to_json(slider, None),
+    ]
 
-            def on_delete():
-                nonlocal deleted
-                deleted = True
 
-            weakref.finalize(b, on_delete)
-            del b
-            gc.collect()
-            assert deleted        
-        finally:
-            widgets.disable_weakrefence()
-        
+def test_box_construction_style():
+    box = widgets.Box(box_style="warning")
+    assert box.get_state()["box_style"] == "warning"
+
+
+def test_construction_invalid_style():
+    with pytest.raises(TraitError):
+        widgets.Box(box_style="invalid")
+
+
+def test_box_invalid_children():
+    box = widgets.Box()
+    closed_button = widgets.Button(description="Closed")
+    closed_button.close()
+
+    with pytest.raises(TypeError):
+        box.children = ["Not a widget"]
+    with pytest.raises(TypeError):
+        box.children = [closed_button]
+    with pytest.raises(TypeError):
+        box.children = [closed_button]
+
+
+def test_box_gc():
+    widgets.VBox._active_widgets
+    widgets.enable_weakrefence()
+    # Test Box gc collected and children lifecycle managed.
+    try:
+        deleted = False
+
+        class TestButton(widgets.Button):
+            def my_click(self, b):
+                pass
+
+        button = TestButton(description="button")
+        button.on_click(button.my_click)
+
+        b = widgets.VBox(children=[button])
+
+        def on_delete():
+            nonlocal deleted
+            deleted = True
+
+        weakref.finalize(b, on_delete)
+        del b
+        gc.collect()
+        assert deleted
+        widgets.VBox._active_widgets
+    finally:
+        widgets.disable_weakrefence()

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
@@ -35,18 +35,27 @@ class TestBox(TestCase):
             widgets.Box(box_style='invalid')
 
 
-    def test_gc(test):
+    def test_gc(self):
+        widgets.enable_weakrefence()
         # Test Box gc collected and children lifecycle managed.
-        deleted = False
-        b = widgets.VBox(children=[widgets.Button(description='button')])
+        try:
+            deleted = False
+            class TestButton(widgets.Button):
+                def my_click (self, b):
+                    pass
+            button = TestButton(description='button')
+            button.on_click(button.my_click)
+            
+            b = widgets.VBox(children=[button])
 
-        def on_delete():
-            nonlocal deleted
-            deleted = True
+            def on_delete():
+                nonlocal deleted
+                deleted = True
 
-        weakref.finalize(b, on_delete)
-        del b
-        gc.collect()
-        assert deleted        
-
+            weakref.finalize(b, on_delete)
+            del b
+            gc.collect()
+            assert deleted        
+        finally:
+            widgets.disable_weakrefence()
         

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
@@ -36,17 +36,24 @@ def test_construction_invalid_style():
         widgets.Box(box_style="invalid")
 
 
-def test_box_invalid_children():
-    box = widgets.Box()
-    closed_button = widgets.Button(description="Closed")
+def test_box_validate_mode():
+    slider = widgets.IntSlider()
+    closed_button = widgets.Button()
     closed_button.close()
+    with pytest.raises(TraitError, match="Invalid or closed items found.*"):
+        widgets.Box(
+        children=[closed_button, slider, "Not a widget"]
+        )
+    box = widgets.Box(
+        children=[closed_button, slider, "Not a widget"],
+        validate_mode="log_error",
+    )
+    assert len (box.children) == 1, "Invalid items should be dropped."
+    assert slider in box.children
 
-    with pytest.raises(TypeError):
-        box.children = ["Not a widget"]
-    with pytest.raises(TypeError):
-        box.children = [closed_button]
-    with pytest.raises(TypeError):
-        box.children = [closed_button]
+    box.validate_mode = "raise"
+    with pytest.raises(TraitError):
+        box.children += ("Not a widget", closed_button)
 
 
 def test_box_gc():

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
@@ -1,6 +1,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import gc
+import weakref
+
 from unittest import TestCase
 
 from traitlets import TraitError
@@ -31,3 +34,72 @@ class TestBox(TestCase):
     def test_construction_invalid_style(self):
         with self.assertRaises(TraitError):
             widgets.Box(box_style='invalid')
+
+
+def test_box_gc():
+    # Test Box gc collected and children lifecycle managed.
+    deleted = False
+    b = widgets.VBox(children=[widgets.Button(description='button')])
+
+    def on_delete():
+        nonlocal deleted
+        deleted = True
+
+    weakref.finalize(b, on_delete)
+    del b
+    gc.collect()
+    assert deleted
+
+def test_box_child_closed_observe_childen():
+
+    b1 = widgets.Button(description='button')
+    b = widgets.VBox(children=[b1], observe_children=True)
+    b1.close()
+    assert b1 not in b.children
+
+def test_box_child_closed_not_observe_childen():
+
+    b1 = widgets.Button(description='button')
+    b = widgets.GridBox(children=[b1], observe_children=False)
+    b1.close()
+    assert b1 in b.children
+
+def test_box_gc_advanced():
+    # A more advanced test for:
+    # 1. A child widget is removed from the children when it is closed
+    # 2. The children are discarded when the widget is closed.
+
+    deleted = False
+    
+    b = widgets.VBox(
+        children=[
+            widgets.Button(description="b0"),
+            widgets.Button(description="b1"),
+            widgets.Button(description="b2"),
+        ]
+    )
+
+    def on_delete():
+        nonlocal deleted
+        deleted = True
+
+    weakref.finalize(b, on_delete)
+    
+    ids = [model_id for w in  b.children if (model_id:=w.model_id)  in widgets.widget._instances]
+    assert len(ids) == 3, 'Not all button comms were registered.'
+
+    # keep a strong ref to `b1`
+    b1 = b.children[1] 
+
+    # When a widget is closed it should be removed from the box.children.
+    b.children[0].close()
+    assert len(b.children) == 2, "b0 not removed."
+    
+    # When the ref to box is removed it should be deleted.
+    del b
+    assert deleted, "`b` should have been the only strong ref to the box."
+    # assert not b.children, '`children` should be removed when the widget is closed.'
+    assert b1.comm, 'A removed widget should remain alive.'
+
+    # b2 shouldn't have any strong references so should be deleted.
+    assert ids[2] not in widgets.widget._instances, 'b2 should have been auto deleted.'

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_box.py
@@ -58,7 +58,7 @@ def test_box_validate_mode():
 
 def test_box_gc():
     widgets.VBox._active_widgets
-    widgets.enable_weakrefence()
+    widgets.enable_weakreference()
     # Test Box gc collected and children lifecycle managed.
     try:
         deleted = False
@@ -82,4 +82,4 @@ def test_box_gc():
         assert deleted
         widgets.VBox._active_widgets
     finally:
-        widgets.disable_weakrefence()
+        widgets.disable_weakreference()

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -51,7 +51,7 @@ def _widget_to_json(x, obj):
             # a closed widget will not be found at the frontend so raise an error here. 
             msg = f"Widget is {x!r}"
             raise RuntimeError(msg)
-        # _model_id provides faster access if a comm is already open which typically it is. 
+        # _model_id provides faster access if its comm is already open. 
         return "IPY_MODEL_" +  x._model_id or x.model_id
     elif isinstance(x, (list, tuple)):
         return [_widget_to_json(v, obj) for v in x]
@@ -59,8 +59,9 @@ def _widget_to_json(x, obj):
         return {k: _widget_to_json(v, obj) for k, v in x.items()}
     elif hasattr(x, "_repr_mimebundle_"):
         msg = (
-            "Support for _repr_mimebundle_ not yet implemented in the Box widget."
-            f"The object may be viewed with Output widget instead. Invalid object: {x!r}"
+            f"{x!r} is not a widget, but provides a `_repr_mimebundle_` attribute. "
+            "Support for direct `_repr_mimebundle_` has not been implemented yet. In the "
+            "meantime, it should be possible to view the object wih an `Output` widget."
         )
         raise NotImplementedError(msg)
     else:

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -51,6 +51,9 @@ def _widget_to_json(x, obj):
     elif isinstance(x, (list, tuple)):
         return [_widget_to_json(v, obj) for v in x]
     elif isinstance(x, Widget):
+        if x.closed:
+            msg = f"Widget is {x!r}"
+            raise RuntimeError(msg)
         return "IPY_MODEL_" + x.model_id
     else:
         return x
@@ -557,6 +560,14 @@ class Widget(LoggingHasTraits):
 
         If a Comm doesn't exist yet, a Comm will be created automagically."""
         return getattr(self.comm, "comm_id", None)
+    
+    @property
+    def closed(self) -> bool:
+        """Returns True when comms is closed.
+        
+        There is no possibility to re-open once it is closed."""
+        # If comm is None it indicates the comm is closed and the widget is closed. 
+        return self._trait_values.get('comm', False) is None
 
     #-------------------------------------------------------------------------
     # Methods
@@ -706,7 +717,8 @@ class Widget(LoggingHasTraits):
         super().notify_change(change)
 
     def __repr__(self):
-        return self._gen_repr_from_keys(self._repr_keys())
+        rep  =  self._gen_repr_from_keys(self._repr_keys())
+        return  'closed: ' + rep  if  self.closed else rep
 
     #-------------------------------------------------------------------------
     # Support methods

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -565,7 +565,7 @@ class Widget(LoggingHasTraits):
     def close(self):
         """Permanently close the widget.
 
-        Closes the underlying comm and discards trait values.
+        Closes the underlying comm.
         When the comm is closed, all of the widget views are automatically
         removed from the front-end."""
         self.comm = None

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -576,10 +576,13 @@ class Widget(LoggingHasTraits):
         if change['old']:
             change['old'].on_msg(None)
             change['old'].close()
-            _instances.pop(change['old'].comm_id, None)
+            # On python shutdown _instances can be None
+            if isinstance(_instances, dict):
+                _instances.pop(change['old'].comm_id, None)
         if change['new']:
             self._model_id = change['new'].comm_id
-            _instances[change['new'].comm_id] = self        
+            if isinstance(_instances, dict):
+                _instances[change['new'].comm_id] = self        
             
             # prevent memory leaks by using a weak reference to self.
             ref = weakref.ref(self)

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -513,7 +513,11 @@ class Widget(LoggingHasTraits):
 
     def open(self):
         """Open a comm to the frontend if one isn't already open."""
-        self.comm
+        # Accessing comm will load a default if it isn't already open.
+        if self.comm is None:
+            # None indicates the widget has been closed and shall not be opened.
+            msg = f"This widget is {self!r}."
+            raise RuntimeError(msg)
 
     def _create_comm(self, comm_id=None):
         """Open a new comm to the frontend."""

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -538,15 +538,15 @@ class Widget(LoggingHasTraits):
         if change['new']:
             _instances[change['new'].comm_id] = self        
             
-            # prevent memory leaks by using a weak reference to the widget.
+            # prevent memory leaks by using a weak reference to self.
             ref = weakref.ref(self)
             def _handle_msg(msg):
-                widget = ref()
-                if widget:
+                self_ = ref()
+                if self_ is not None:
                     try:
-                        widget._handle_msg(msg)
+                        self_._handle_msg(msg)
                     except Exception as e:
-                        widget._show_traceback(_handle_msg, e)
+                        self_._show_traceback(self_._handle_msg, e)
 
             change['new'].on_msg(_handle_msg)
 

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -859,8 +859,9 @@ class Widget(LoggingHasTraits):
 
     def _send(self, msg, buffers=None):
         """Sends a message to the model in the front-end."""
-        if self.comm is not None and (self.comm.kernel is not None if hasattr(self.comm, "kernel") else True):
-            self.comm.send(data=msg, buffers=buffers)
+        comm = self.comm
+        if comm is not None and getattr(comm, "kernel", True):
+            comm.send(data=msg, buffers=buffers)
 
     def _repr_keys(self):
         traits = self.traits()

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -485,7 +485,7 @@ class Widget(LoggingHasTraits):
 
     def get_view_spec(self):
         if not self._repr_mimebundle_:
-            msg = f"This widget is {self!r}"
+            msg = f"This widget is closed {self!r}"
             raise RuntimeError(msg)
         return {"version_major":2, "version_minor":0, "model_id":self._model_id or self.model_id}
 
@@ -551,7 +551,7 @@ class Widget(LoggingHasTraits):
         # Accessing comm will load a default if it isn't already open.
         if self.comm is None:
             # None indicates the widget has been closed and shall not be opened.
-            msg = f"This widget is {self!r}."
+            msg = f"This widget is closed {self!r}."
             raise RuntimeError(msg)
 
     def _create_comm(self, comm_id=None):

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -45,7 +45,7 @@ JUPYTER_WIDGETS_ECHO = envset('JUPYTER_WIDGETS_ECHO', default=True)
 #  https://github.com/jupyter-widgets/ipywidgets/issues/1345
 _instances : typing.MutableMapping[str, "Widget"] = {}
 
-def enable_weakrefence():
+def enable_weakreference():
     """Use a WeakValueDictionary instead of a standard dictionary to map 
     `comm_id` to `widget` for every widget instance.
 
@@ -56,7 +56,7 @@ def enable_weakrefence():
     if not isinstance(_instances, weakref.WeakValueDictionary):
         _instances  = weakref.WeakValueDictionary(_instances)
 
-def disable_weakrefence():
+def disable_weakreference():
     """Use a Dictionary to map `comm_id` to `widget` for every widget instance.
     
     Note: this is the default setting and maintains a strong reference to the 

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -43,7 +43,29 @@ CONTROL_PROTOCOL_VERSION_MAJOR = __control_protocol_version__.split('.')[0]
 JUPYTER_WIDGETS_ECHO = envset('JUPYTER_WIDGETS_ECHO', default=True)
 # for a discussion on using weak references see:
 #  https://github.com/jupyter-widgets/ipywidgets/issues/1345
-_instances : typing.MutableMapping[str, "Widget"] = weakref.WeakValueDictionary()
+_instances : typing.MutableMapping[str, "Widget"] = {}
+
+def enable_weakrefence():
+    """Use a WeakValueDictionary instead of a standard dictionary to map 
+    `comm_id` to `widget` for every widget instance.
+
+    By default widgets are mapped using a standard dictionary. Use this feature
+    to permit widget garbage collection. 
+    """
+    global _instances
+    if not isinstance(_instances, weakref.WeakValueDictionary):
+        _instances  = weakref.WeakValueDictionary(_instances)
+
+def disable_weakrefence():
+    """Use a Dictionary to map `comm_id` to `widget` for every widget instance.
+    
+    Note: this is the default setting and maintains a strong reference to the 
+    the widget preventing automatic garbage collection. If the close method
+    is called, the widget will remove itself enabling garbage collection.
+    """
+    global _instances
+    if  isinstance(_instances, weakref.WeakValueDictionary):
+        _instances  = dict(_instances)
 
 def _widget_to_json(x, obj):
     if isinstance(x, Widget):

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -462,7 +462,10 @@ class Widget(LoggingHasTraits):
         return state
 
     def get_view_spec(self):
-        return dict(version_major=2, version_minor=0, model_id=self.model_id)
+        if not self._repr_mimebundle_:
+            msg = f"This widget is {self!r}"
+            raise RuntimeError(msg)
+        return {"version_major":2, "version_minor":0, "model_id":self._model_id or self.model_id}
 
     #-------------------------------------------------------------------------
     # Traits

--- a/python/ipywidgets/ipywidgets/widgets/widget.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget.py
@@ -697,9 +697,10 @@ class Widget(LoggingHasTraits):
         # Send the state to the frontend before the user-registered callbacks
         # are called.
         name = change['name']
-        if self.comm is not None and getattr(self.comm, 'kernel', True) is not None:
+        comm = self._trait_values.get('comm')
+        if comm  and getattr(comm, 'kernel', None):
             # Make sure this isn't information that the front-end just sent us.
-            if name in self.keys and self._should_send_property(name, getattr(self, name)):
+            if name in self.keys and self._should_send_property(name, change['new']):
                 # Send new state to front-end
                 self.send_state(key=name)
         super().notify_change(change)

--- a/python/ipywidgets/ipywidgets/widgets/widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_box.py
@@ -29,12 +29,20 @@ _doc_snippets['box_params'] = """
         Applies a predefined style to the box. Defaults to '',
         which applies no pre-defined style.
 """
+import sys
+if sys.version_info < (3, 11):
+    class Children(TraitType):
+        default_value = ()
 
-class Children(TraitType):
-    default_value = ()
+        def validate(self, obj, value):
+            return tuple(v for v in value if getattr(v, '_repr_mimebundle_', None))
+else:
+    import typing
+    class Children(TraitType[tuple[Widget,...], typing.Iterable[Widget]]):
+        default_value = ()
 
-    def validate(self, obj, value):
-        return tuple(v for v in value if getattr(v, '_repr_mimebundle_', None))
+        def validate(self, obj, value):
+            return tuple(v for v in value if getattr(v, '_repr_mimebundle_', None))
 
 
 @register

--- a/python/ipywidgets/ipywidgets/widgets/widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_box.py
@@ -33,8 +33,18 @@ _doc_snippets['box_params'] = """
 class Children(TraitType["tuple[Widget,...]", typing.Iterable[Widget]]):
     default_value = ()
 
-    def validate(self, obj, value):
-        return tuple(v for v in value if isinstance(v, Widget) and v.comm)
+    def validate(self, obj:Box, value:typing.Iterable[Widget]):
+        invalid = []
+        valid = []
+        for v in value:
+            if isinstance(v, Widget) and v._repr_mimebundle_:
+                valid.append(v)
+            else:
+                invalid.append(v)
+        if invalid:
+            msg  = f"Invalid items found: {invalid}"
+            raise TypeError(msg)
+        return tuple(valid)
 
 
 @register

--- a/python/ipywidgets/ipywidgets/widgets/widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_box.py
@@ -70,7 +70,7 @@ class Box(DOMWidget, CoreWidget):
     # Child widgets in the container.
     # Using a tuple here to force reassignment to update the list.
     # When a proper notifying-list trait exists, use that instead.
-    children:"tuple[Widget]" = Children(help="List of widget children").tag(
+    children = Children(help="List of widget children").tag(
         sync=True, **widget_serialization)
 
     box_style = CaselessStrEnum(

--- a/python/ipywidgets/ipywidgets/widgets/widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_box.py
@@ -67,6 +67,9 @@ class Box(DOMWidget, CoreWidget):
     _view_name = Unicode('BoxView').tag(sync=True)
     _children_handlers = weakref.WeakKeyDictionary()
 
+    # Tooltip is not allowed for containers (override for DOMWidget). 
+    tooltip = None 
+
     # Child widgets in the container.
     # Using a tuple here to force reassignment to update the list.
     # When a proper notifying-list trait exists, use that instead.

--- a/python/ipywidgets/ipywidgets/widgets/widget_box.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_box.py
@@ -14,7 +14,7 @@ from .domwidget import DOMWidget
 from .widget_core import CoreWidget
 from .docutils import doc_subst
 from traitlets import Unicode, CaselessStrEnum, TraitType, observe
-
+import sys
 
 _doc_snippets = {}
 _doc_snippets['box_params'] = """
@@ -27,11 +27,19 @@ _doc_snippets['box_params'] = """
         which applies no pre-defined style.
 """
 
-class Children(TraitType[tuple[Widget],tuple[Widget]]):
-    default_value = ()
+# TODO: remove once 3.8 support is dropped.
+if sys.version_info < (3, 9):
+    class Children(TraitType):
+        default_value = ()
 
-    def validate(self, obj:'Box', value):
-        return tuple(v for v in value if isinstance(v, Widget) and not v.closed)
+        def validate(self, obj:'Box', value):
+            return tuple(v for v in value if isinstance(v, Widget) and not v.closed)
+else:    
+    class Children(TraitType[tuple[Widget],tuple[Widget]]):
+        default_value = ()
+
+        def validate(self, obj:'Box', value):
+            return tuple(v for v in value if isinstance(v, Widget) and not v.closed)
             
 
 @register

--- a/python/ipywidgets/ipywidgets/widgets/widget_button.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_button.py
@@ -14,8 +14,8 @@ from .widget_core import CoreWidget
 from .widget_style import Style
 from .trait_types import Color, InstanceDict
 
+import weakref
 from traitlets import Unicode, Bool, CaselessStrEnum, Instance, validate, default
-
 
 @register
 class ButtonStyle(Style, CoreWidget):
@@ -63,7 +63,8 @@ class Button(DOMWidget, CoreWidget):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._click_handlers = CallbackDispatcher()
-        self.on_msg(self._handle_button_msg)
+        ref = weakref.ref(self)
+        self.on_msg(lambda msg: ref()._handle_button_msg(msg))
 
     @validate('icon')
     def _validate_icon(self, proposal):

--- a/python/ipywidgets/ipywidgets/widgets/widget_button.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_button.py
@@ -64,7 +64,7 @@ class Button(DOMWidget, CoreWidget):
         super().__init__(**kwargs)
         self._click_handlers = CallbackDispatcher()
         ref = weakref.ref(self)
-        self.on_msg(lambda msg: ref()._handle_button_msg(msg))
+        self.on_msg(lambda w, c, b: ref()._handle_button_msg(w, c, b))
 
     @validate('icon')
     def _validate_icon(self, proposal):

--- a/python/ipywidgets/ipywidgets/widgets/widget_button.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_button.py
@@ -14,8 +14,7 @@ from .widget_core import CoreWidget
 from .widget_style import Style
 from .trait_types import Color, InstanceDict
 
-import weakref
-from traitlets import Unicode, Bool, CaselessStrEnum, Instance, validate, default
+from traitlets import Unicode, Bool, CaselessStrEnum,  validate
 
 @register
 class ButtonStyle(Style, CoreWidget):
@@ -63,8 +62,7 @@ class Button(DOMWidget, CoreWidget):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._click_handlers = CallbackDispatcher()
-        ref = weakref.ref(self)
-        self.on_msg(lambda w, c, b: ref()._handle_button_msg(w, c, b))
+        self.on_msg(self._handle_button_msg)
 
     @validate('icon')
     def _validate_icon(self, proposal):

--- a/python/ipywidgets/ipywidgets/widgets/widget_link.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_link.py
@@ -57,7 +57,7 @@ class Link(CoreWidget):
     target = WidgetTraitTuple(help="The target (widget, 'trait_name') pair").tag(sync=True, **widget_serialization)
     source = WidgetTraitTuple(help="The source (widget, 'trait_name') pair").tag(sync=True, **widget_serialization)
     
-    def __init__(self, source: tuple[Widget, str], target: tuple[Widget, str], **kwargs):
+    def __init__(self, source, target, **kwargs):
         super().__init__(source=source, target=target, **kwargs)
         self._all_links.add(self)
 

--- a/python/ipywidgets/ipywidgets/widgets/widget_link.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_link.py
@@ -6,6 +6,8 @@
 Propagate changes between widgets on the javascript side.
 """
 
+from __future__ import annotations
+
 from .widget import Widget, register, widget_serialization
 from .widget_core import CoreWidget
 
@@ -51,25 +53,19 @@ class Link(CoreWidget):
     source: a (Widget, 'trait_name') tuple for the source trait
     target: a (Widget, 'trait_name') tuple that should be updated
     """
-    # maintain a set of links to keep them alive 
-    _all_links = set()
     _model_name = Unicode('LinkModel').tag(sync=True)
     target = WidgetTraitTuple(help="The target (widget, 'trait_name') pair").tag(sync=True, **widget_serialization)
     source = WidgetTraitTuple(help="The source (widget, 'trait_name') pair").tag(sync=True, **widget_serialization)
-    
-    def __init__(self, source, target, **kwargs):
-        super().__init__(source=source, target=target, **kwargs)
-        self._all_links.add(self)
 
-    def close(self):
-        self._all_links.discard(self)
-        super().close()
+    def __init__(self, source: tuple[Widget, str], target: tuple[Widget, str], **kwargs):
+        super().__init__(source=source, target=target, **kwargs)
+
     # for compatibility with traitlet links
     def unlink(self):
         self.close()
 
 
-def jslink(attr1, attr2):
+def jslink(attr1: tuple[Widget, str], attr2: tuple[Widget, str]):
     """Link two widget attributes on the frontend so they remain in sync.
 
     The link is created in the front-end and does not rely on a roundtrip
@@ -99,7 +95,7 @@ class DirectionalLink(Link):
     _model_name = Unicode('DirectionalLinkModel').tag(sync=True)
 
 
-def jsdlink(source, target):
+def jsdlink(source: tuple[Widget, str], target: tuple[Widget, str]):
     """Link a source widget attribute with a target widget attribute.
 
     The link is created in the front-end and does not rely on a roundtrip

--- a/python/ipywidgets/ipywidgets/widgets/widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_output.py
@@ -59,6 +59,7 @@ class Output(DOMWidget):
 
     msg_id = Unicode('', help="Parent message id of messages to capture").tag(sync=True)
     outputs = TypedTuple(trait=Dict(), help="The output messages synced from the frontend.").tag(sync=True)
+    tooltip = Unicode('', allow_none=True, help="A tooltip caption.").tag(sync=True)
 
     __counter = 0
 

--- a/python/ipywidgets/ipywidgets/widgets/widget_string.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_string.py
@@ -13,7 +13,6 @@ from .widget_core import CoreWidget
 from .trait_types import Color, InstanceDict, TypedTuple
 from .utils import deprecation
 from traitlets import Unicode, Bool, Int
-import weakref
 
 
 class _StringStyle(DescriptionStyle, CoreWidget):
@@ -118,8 +117,7 @@ class Text(_String):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._submission_callbacks = CallbackDispatcher()
-        ref = weakref.ref(self)
-        self.on_msg(lambda w, c, b: ref()._handle_string_msg(w, c, b))
+        self.on_msg(self._handle_string_msg)
 
     def _handle_string_msg(self, _, content, buffers):
         """Handle a msg from the front-end.

--- a/python/ipywidgets/ipywidgets/widgets/widget_string.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_string.py
@@ -13,6 +13,7 @@ from .widget_core import CoreWidget
 from .trait_types import Color, InstanceDict, TypedTuple
 from .utils import deprecation
 from traitlets import Unicode, Bool, Int
+import weakref
 
 
 class _StringStyle(DescriptionStyle, CoreWidget):
@@ -117,7 +118,8 @@ class Text(_String):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._submission_callbacks = CallbackDispatcher()
-        self.on_msg(self._handle_string_msg)
+        ref = weakref.ref(self)
+        self.on_msg(lambda msg: ref()._handle_string_msg(msg))
 
     def _handle_string_msg(self, _, content, buffers):
         """Handle a msg from the front-end.

--- a/python/ipywidgets/ipywidgets/widgets/widget_string.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_string.py
@@ -119,7 +119,7 @@ class Text(_String):
         super().__init__(*args, **kwargs)
         self._submission_callbacks = CallbackDispatcher()
         ref = weakref.ref(self)
-        self.on_msg(lambda msg: ref()._handle_string_msg(msg))
+        self.on_msg(lambda w, c, b: ref()._handle_string_msg(w, c, b))
 
     def _handle_string_msg(self, _, content, buffers):
         """Handle a msg from the front-end.

--- a/python/jupyterlab_widgets/package.json
+++ b/python/jupyterlab_widgets/package.json
@@ -92,5 +92,16 @@
     "extension": true,
     "outputDir": "labextension",
     "schemaDir": "./schema"
+  },
+  "optionalDependencies": {
+    "react": "^18.3.1"
+  },
+  "peerDependencies": {
+    "react": "*"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   }
 }

--- a/python/jupyterlab_widgets/package.json
+++ b/python/jupyterlab_widgets/package.json
@@ -62,7 +62,7 @@
     "@jupyterlab/services": "^6.0.0 || ^7.0.0",
     "@jupyterlab/settingregistry": "^3.0.0 || ^4.0.0",
     "@jupyterlab/translation": "^3.0.0 || ^4.0.0",
-    "@lumino/algorithm": "^1.11.1 || ^2.0.0",
+    "@lumino/algorithm": "^1.9.2 || ^2.0.1",
     "@lumino/coreutils": "^1.11.1 || ^2.1",
     "@lumino/disposable": "^1.10.1 || ^2.1",
     "@lumino/properties": "^1.8.1 || ^2.1",

--- a/python/jupyterlab_widgets/src/manager.ts
+++ b/python/jupyterlab_widgets/src/manager.ts
@@ -2,20 +2,20 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  shims,
+  ExportData,
+  ExportMap,
+  ICallbacks,
   IClassicComm,
   IWidgetRegistryData,
-  ExportMap,
-  ExportData,
   WidgetModel,
   WidgetView,
-  ICallbacks,
+  shims,
 } from '@jupyter-widgets/base';
 
 import {
+  IStateOptions,
   ManagerBase,
   serialize_state,
-  IStateOptions,
 } from '@jupyter-widgets/base-manager';
 
 import { IDisposable } from '@lumino/disposable';
@@ -26,7 +26,18 @@ import { INotebookModel } from '@jupyterlab/notebook';
 
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
-import { Kernel, KernelMessage, Session } from '@jupyterlab/services';
+import { ObservableList, ObservableMap } from '@jupyterlab/observables';
+
+import * as nbformat from '@jupyterlab/nbformat';
+
+import { ILoggerRegistry, LogLevel } from '@jupyterlab/logconsole';
+
+import {
+  Kernel,
+  KernelConnection,
+  KernelMessage,
+  Session,
+} from '@jupyterlab/services';
 
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 
@@ -35,6 +46,11 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { valid } from 'semver';
 
 import { SemVerCache } from './semvercache';
+
+import Backbone from 'backbone';
+
+import * as base from '@jupyter-widgets/base';
+import { WidgetRenderer } from './renderer';
 
 /**
  * The mime type for a widget view.
@@ -330,23 +346,39 @@ export abstract class LabWidgetManager
     this,
     KernelMessage.IIOPubMessage
   >(this);
+  static WIDGET_REGISTRY = new ObservableList<base.IWidgetRegistryData>();
 }
 
 /**
- * A widget manager that returns Lumino widgets.
+ * A singleton widget manager per kernel for the lifecycle of the kernel.
  */
 export class KernelWidgetManager extends LabWidgetManager {
   constructor(
     kernel: Kernel.IKernelConnection,
     rendermime: IRenderMimeRegistry
   ) {
+    const instance = Private.kernelWidgetManagers.get(kernel.id);
+    if (instance) {
+      instance.attachToRendermime(rendermime);
+      return instance;
+    }
     super(rendermime);
-    this._kernel = kernel;
+    this.attachToRendermime(rendermime);
+    Private.kernelWidgetManagers.set(kernel.id, this);
+    this._kernel = new KernelConnection({ model: kernel.model });
+    this.loadCustomWidgetDefinitions();
+    LabWidgetManager.WIDGET_REGISTRY.changed.connect(() =>
+      this.loadCustomWidgetDefinitions()
+    );
+    this._kernel.registerCommTarget(
+      this.comm_target_name,
+      this._handleCommOpen
+    );
 
-    kernel.statusChanged.connect((sender, args) => {
+    this._kernel.statusChanged.connect((sender, args) => {
       this._handleKernelStatusChange(args);
     });
-    kernel.connectionStatusChanged.connect((sender, args) => {
+    this._kernel.connectionStatusChanged.connect((sender, args) => {
       this._handleKernelConnectionStatusChange(args);
     });
 
@@ -405,24 +437,50 @@ export class KernelWidgetManager extends LabWidgetManager {
     return this._kernel;
   }
 
+  loadCustomWidgetDefinitions() {
+    for (const data of LabWidgetManager.WIDGET_REGISTRY) {
+      this.register(data);
+    }
+  }
+
+  filterModelState(serialized_state: any): any {
+    return this.filterExistingModelState(serialized_state);
+  }
+
+  attachToRendermime(rendermime: IRenderMimeRegistry) {
+    rendermime.removeMimeType(WIDGET_VIEW_MIMETYPE);
+    rendermime.addFactory(
+      {
+        safe: false,
+        mimeTypes: [WIDGET_VIEW_MIMETYPE],
+        createRenderer: (options) => new WidgetRenderer(options, this),
+      },
+      -10
+    );
+  }
+
   private _kernel: Kernel.IKernelConnection;
+  protected _kernelRestoreInProgress = false;
 }
 
 /**
- * A widget manager that returns phosphor widgets.
+ * Monitor kernel of the Context swapping the kernel manager on demand.
+ * A better name would be `NotebookManagerSwitcher'.
  */
-export class WidgetManager extends LabWidgetManager {
+export class WidgetManager extends Backbone.Model implements IDisposable {
   constructor(
     context: DocumentRegistry.IContext<INotebookModel>,
     rendermime: IRenderMimeRegistry,
     settings: WidgetManager.Settings
   ) {
-    super(rendermime);
+    super();
+    this._rendermime = rendermime;
     this._context = context;
+    this._settings = settings;
 
-    context.sessionContext.kernelChanged.connect((sender, args) => {
-      this._handleKernelChanged(args);
-    });
+    context.sessionContext.kernelChanged.connect((sender, args) =>
+      this.updateWidgetManager()
+    );
 
     context.sessionContext.statusChanged.connect((sender, args) => {
       this._handleKernelStatusChange(args);
@@ -432,17 +490,11 @@ export class WidgetManager extends LabWidgetManager {
       this._handleKernelConnectionStatusChange(args);
     });
 
-    if (context.sessionContext.session?.kernel) {
-      this._handleKernelChanged({
-        name: 'kernel',
-        oldValue: null,
-        newValue: context.sessionContext.session?.kernel,
-      });
-    }
+    this.updateWidgetManager();
+    this.setDirty();
 
     this.restoreWidgets(this._context!.model);
 
-    this._settings = settings;
     context.saveState.connect((sender, saveState) => {
       if (saveState === 'started' && settings.saveState) {
         this._saveState();
@@ -454,7 +506,7 @@ export class WidgetManager extends LabWidgetManager {
    * Save the widget state to the context model.
    */
   private _saveState(): void {
-    const state = this.get_state_sync({ drop_defaults: true });
+    const state = this.widgetManager.get_state_sync({ drop_defaults: true });
     if (this._context.model.setMetadata) {
       this._context.model.setMetadata('widgets', {
         'application/vnd.jupyter.widget-state+json': state,
@@ -465,6 +517,44 @@ export class WidgetManager extends LabWidgetManager {
       this._context.model.metadata.set('widgets', {
         'application/vnd.jupyter.widget-state+json': state,
       });
+    }
+  }
+
+  updateWidgetManager() {
+    if (this._widgetManager) {
+      this.widgetManager.onUnhandledIOPubMessage.disconnect(
+        this.onUnhandledIOPubMessage,
+        this
+      );
+    }
+    if (this.kernel) {
+      this._widgetManager = getWidgetManager(this.kernel, this.rendermime);
+      this._widgetManager.onUnhandledIOPubMessage.connect(
+        this.onUnhandledIOPubMessage,
+        this
+      );
+    }
+  }
+
+  onUnhandledIOPubMessage(
+    sender: LabWidgetManager,
+    msg: KernelMessage.IIOPubMessage
+  ) {
+    if (WidgetManager.loggerRegistry) {
+      const logger = WidgetManager.loggerRegistry.getLogger(this.context.path);
+      let level: LogLevel = 'warning';
+      if (
+        KernelMessage.isErrorMsg(msg) ||
+        (KernelMessage.isStreamMsg(msg) && msg.content.name === 'stderr')
+      ) {
+        level = 'error';
+      }
+      const data: nbformat.IOutput = {
+        ...msg.content,
+        output_type: msg.header.msg_type,
+      };
+      // logger.rendermime = this.content.rendermime;
+      logger.log({ type: 'output', data, level });
     }
   }
 
@@ -483,9 +573,41 @@ export class WidgetManager extends LabWidgetManager {
   }
 
   _handleKernelStatusChange(status: Kernel.Status): void {
-    if (status === 'restarting') {
-      this.disconnect();
+    this.setDirty();
+  }
+
+  get widgetManager(): KernelWidgetManager {
+    return this._widgetManager;
+  }
+
+  /**
+   * A signal emitted when state is restored to the widget manager.
+   *
+   * #### Notes
+   * This indicates that previously-unavailable widget models might be available now.
+   */
+  get restored(): ISignal<this, void> {
+    return this._restored;
+  }
+
+  /**
+   * Whether the state has been restored yet or not.
+   */
+  get restoredStatus(): boolean {
+    return this._restoredStatus;
+  }
+
+  /**
+   *
+   * @param renderers
+   */
+  updateWidgetRenderers(renderers: IterableIterator<WidgetRenderer>) {
+    if (this.kernel) {
+      for (const r of renderers) {
+        r.manager = this.widgetManager;
+      }
     }
+    // Do we need to handle for if there isn't a kernel?
   }
 
   /**
@@ -500,7 +622,6 @@ export class WidgetManager extends LabWidgetManager {
       if (loadKernel) {
         try {
           this._kernelRestoreInProgress = true;
-          await this._loadFromKernel();
         } finally {
           this._kernelRestoreInProgress = false;
         }
@@ -529,9 +650,19 @@ export class WidgetManager extends LabWidgetManager {
     // Restore any widgets from saved state that are not live
     if (widget_md && widget_md[WIDGET_STATE_MIMETYPE]) {
       let state = widget_md[WIDGET_STATE_MIMETYPE];
-      state = this.filterExistingModelState(state);
-      await this.set_state(state);
+      state = this.widgetManager.filterModelState(state);
+      await this.widgetManager.set_state(state);
     }
+  }
+
+  /**
+   * Get whether the manager is disposed.
+   *
+   * #### Notes
+   * This is a read-only property.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
   }
 
   /**
@@ -543,7 +674,6 @@ export class WidgetManager extends LabWidgetManager {
     }
 
     this._context = null!;
-    super.dispose();
   }
 
   /**
@@ -562,11 +692,15 @@ export class WidgetManager extends LabWidgetManager {
     return this._context.sessionContext?.session?.kernel ?? null;
   }
 
+  get rendermime(): IRenderMimeRegistry {
+    return this._rendermime;
+  }
+
   /**
    * Register a widget model.
    */
   register_model(model_id: string, modelPromise: Promise<WidgetModel>): void {
-    super.register_model(model_id, modelPromise);
+    this.widgetManager.register_model(model_id, modelPromise);
     this.setDirty();
   }
 
@@ -575,7 +709,7 @@ export class WidgetManager extends LabWidgetManager {
    * @return Promise that resolves when the widget state is cleared.
    */
   async clear_state(): Promise<void> {
-    await super.clear_state();
+    // await this.widgetManager.clear_state();
     this.setDirty();
   }
 
@@ -589,13 +723,65 @@ export class WidgetManager extends LabWidgetManager {
       this._context!.model.dirty = true;
     }
   }
-
+  static loggerRegistry: ILoggerRegistry | null;
+  protected _restored = new Signal<this, void>(this);
+  protected _restoredStatus = false;
+  private _isDisposed = false;
   private _context: DocumentRegistry.IContext<INotebookModel>;
+  private _rendermime: IRenderMimeRegistry;
   private _settings: WidgetManager.Settings;
+  private _widgetManager: KernelWidgetManager;
+  protected _kernelRestoreInProgress = false;
 }
 
 export namespace WidgetManager {
   export type Settings = {
     saveState: boolean;
   };
+}
+
+/**
+ * Get the widget manager for the kernel. Calling this will ensure
+ * widgets to work in a kernel.
+ * With the widgetManager use the method `widgetManager.attachToRendermime`
+ * against any rendermime.
+ * @param kernel A kernel connection to which the widget manager is associated.
+ * @returns LabWidgetManager
+ */
+export function getWidgetManager(
+  kernel: Kernel.IKernelConnection,
+  rendermime: IRenderMimeRegistry
+): KernelWidgetManager {
+  if (!Private.kernelWidgetManagers.has(kernel.id)) {
+    new KernelWidgetManager(kernel, rendermime);
+  }
+  const wManager = Private.kernelWidgetManagers.get(kernel.id);
+  if (!wManager) {
+    throw new Error('Failed to create LabWidgetManager');
+  }
+  if (wManager.rendermime !== rendermime) {
+    wManager.attachToRendermime(rendermime);
+  }
+  return wManager;
+}
+
+/**
+ * Get the widgetManager that owns the model id=model_id.
+ * @param model_id An existing model_id
+ * @returns KernelWidgetManager
+ */
+export function findWidgetManager(model_id: string): KernelWidgetManager {
+  for (const wManager of Private.kernelWidgetManagers.values()) {
+    if (wManager.has_model(model_id)) {
+      return wManager;
+    }
+  }
+  throw new Error(`A widget manager was not found for model_id ${model_id}'`);
+}
+
+/**
+ * A namespace for private data
+ */
+namespace Private {
+  export const kernelWidgetManagers = new ObservableMap<KernelWidgetManager>();
 }

--- a/python/widgetsnbextension/package.json
+++ b/python/widgetsnbextension/package.json
@@ -28,7 +28,7 @@
     "@jupyter-widgets/html-manager": "^1.0.10",
     "@jupyter-widgets/output": "^6.0.7",
     "@jupyterlab/services": "^6.0.0 || ^7.0.0",
-    "@lumino/messaging": "^1.10.1 || ^2.1",
+    "@lumino/messaging": "^1.10.1 || ^2.0.1",
     "@lumino/widgets": "^1.30.0 || ^2.1",
     "backbone": "1.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -692,11 +692,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyter-widgets/base-manager@^1.0.7, @jupyter-widgets/base-manager@workspace:packages/base-manager":
+"@jupyter-widgets/base-manager@^1.0.8, @jupyter-widgets/base-manager@workspace:packages/base-manager":
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/base-manager@workspace:packages/base-manager"
   dependencies:
-    "@jupyter-widgets/base": ^6.0.6
+    "@jupyter-widgets/base": ^6.0.7
     "@jupyterlab/services": ^6.0.0 || ^7.0.0
     "@lumino/coreutils": ^1.11.1 || ^2
     "@types/base64-js": ^1.2.5
@@ -731,7 +731,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyter-widgets/base@^6.0.6, @jupyter-widgets/base@workspace:packages/base":
+"@jupyter-widgets/base@^6.0.7, @jupyter-widgets/base@workspace:packages/base":
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/base@workspace:packages/base"
   dependencies:
@@ -774,11 +774,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyter-widgets/controls@^5.0.7, @jupyter-widgets/controls@workspace:packages/controls":
+"@jupyter-widgets/controls@^5.0.8, @jupyter-widgets/controls@workspace:packages/controls":
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/controls@workspace:packages/controls"
   dependencies:
-    "@jupyter-widgets/base": ^6.0.6
+    "@jupyter-widgets/base": ^6.0.7
     "@jupyterlab/services": ^6.0.0 || ^7.0.0
     "@lumino/algorithm": ^1.9.1 || ^2.1
     "@lumino/domutils": ^1.8.1 || ^2.1
@@ -829,9 +829,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/example-web1@workspace:examples/web1"
   dependencies:
-    "@jupyter-widgets/base": ^6.0.6
-    "@jupyter-widgets/base-manager": ^1.0.7
-    "@jupyter-widgets/controls": ^5.0.7
+    "@jupyter-widgets/base": ^6.0.7
+    "@jupyter-widgets/base-manager": ^1.0.8
+    "@jupyter-widgets/controls": ^5.0.8
     chai: ^4.0.0
     css-loader: ^6.5.1
     karma: ^6.3.3
@@ -850,9 +850,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/example-web2@workspace:examples/web2"
   dependencies:
-    "@jupyter-widgets/base": ^6.0.6
-    "@jupyter-widgets/base-manager": ^1.0.7
-    "@jupyter-widgets/controls": ^5.0.7
+    "@jupyter-widgets/base": ^6.0.7
+    "@jupyter-widgets/base-manager": ^1.0.8
+    "@jupyter-widgets/controls": ^5.0.8
     codemirror: ^5.48.0
     css-loader: ^6.5.1
     font-awesome: ^4.7.0
@@ -865,9 +865,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/example-web3@workspace:examples/web3"
   dependencies:
-    "@jupyter-widgets/base": ^6.0.6
-    "@jupyter-widgets/controls": ^5.0.7
-    "@jupyter-widgets/html-manager": ^1.0.9
+    "@jupyter-widgets/base": ^6.0.7
+    "@jupyter-widgets/controls": ^5.0.8
+    "@jupyter-widgets/html-manager": ^1.0.10
     "@jupyterlab/services": ^6.0.0 || ^7.0.0
     "@types/codemirror": ^5.60.0
     "@types/node": ^17.0.2
@@ -887,7 +887,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/example-web4@workspace:examples/web4"
   dependencies:
-    "@jupyter-widgets/html-manager": ^1.0.9
+    "@jupyter-widgets/html-manager": ^1.0.10
     css-loader: ^6.5.1
     font-awesome: ^4.7.0
     style-loader: ^3.3.1
@@ -895,16 +895,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyter-widgets/html-manager@^1.0.9, @jupyter-widgets/html-manager@workspace:packages/html-manager":
+"@jupyter-widgets/html-manager@^1.0.10, @jupyter-widgets/html-manager@workspace:packages/html-manager":
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/html-manager@workspace:packages/html-manager"
   dependencies:
     "@fortawesome/fontawesome-free": ^5.12.0
-    "@jupyter-widgets/base": ^6.0.6
-    "@jupyter-widgets/base-manager": ^1.0.7
-    "@jupyter-widgets/controls": ^5.0.7
-    "@jupyter-widgets/output": ^6.0.6
-    "@jupyter-widgets/schema": ^0.5.3
+    "@jupyter-widgets/base": ^6.0.7
+    "@jupyter-widgets/base-manager": ^1.0.8
+    "@jupyter-widgets/controls": ^5.0.8
+    "@jupyter-widgets/output": ^6.0.7
+    "@jupyter-widgets/schema": ^0.5.4
     "@jupyterlab/outputarea": ^3.0.0 || ^4.0.0
     "@jupyterlab/rendermime": ^3.0.0 || ^4.0.0
     "@jupyterlab/rendermime-interfaces": ^3.0.0 || ^4.0.0
@@ -941,10 +941,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/jupyterlab-manager@workspace:python/jupyterlab_widgets"
   dependencies:
-    "@jupyter-widgets/base": ^6.0.6
-    "@jupyter-widgets/base-manager": ^1.0.7
-    "@jupyter-widgets/controls": ^5.0.7
-    "@jupyter-widgets/output": ^6.0.6
+    "@jupyter-widgets/base": ^6.0.7
+    "@jupyter-widgets/base-manager": ^1.0.8
+    "@jupyter-widgets/controls": ^5.0.8
+    "@jupyter-widgets/output": ^6.0.7
     "@jupyterlab/application": ^3.0.0 || ^4.0.0
     "@jupyterlab/builder": ^3.0.0 || ^4.0.0
     "@jupyterlab/cells": ^3.0.0 || ^4.0.0
@@ -987,11 +987,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/notebook-manager@workspace:python/widgetsnbextension"
   dependencies:
-    "@jupyter-widgets/base": ^6.0.6
-    "@jupyter-widgets/base-manager": ^1.0.7
-    "@jupyter-widgets/controls": ^5.0.7
-    "@jupyter-widgets/html-manager": ^1.0.9
-    "@jupyter-widgets/output": ^6.0.6
+    "@jupyter-widgets/base": ^6.0.7
+    "@jupyter-widgets/base-manager": ^1.0.8
+    "@jupyter-widgets/controls": ^5.0.8
+    "@jupyter-widgets/html-manager": ^1.0.10
+    "@jupyter-widgets/output": ^6.0.7
     "@jupyterlab/services": ^6.0.0 || ^7.0.0
     "@lumino/messaging": ^1.10.1 || ^2.1
     "@lumino/widgets": ^1.30.0 || ^2.1
@@ -1005,17 +1005,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyter-widgets/output@^6.0.6, @jupyter-widgets/output@workspace:packages/output":
+"@jupyter-widgets/output@^6.0.7, @jupyter-widgets/output@workspace:packages/output":
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/output@workspace:packages/output"
   dependencies:
-    "@jupyter-widgets/base": ^6.0.6
+    "@jupyter-widgets/base": ^6.0.7
     rimraf: ^3.0.2
     typescript: ~4.9.4
   languageName: unknown
   linkType: soft
 
-"@jupyter-widgets/schema@^0.5.3, @jupyter-widgets/schema@workspace:packages/schema":
+"@jupyter-widgets/schema@^0.5.4, @jupyter-widgets/schema@workspace:packages/schema":
   version: 0.0.0-use.local
   resolution: "@jupyter-widgets/schema@workspace:packages/schema"
   languageName: unknown
@@ -14908,11 +14908,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A~4.9.4#~builtin<compat/typescript>":
   version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
+  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,7 +711,6 @@ __metadata:
     chai: ^4.0.0
     chai-as-promised: ^7.0.0
     expect.js: ^0.3.1
-    istanbul-instrumenter-loader: ^3.0.1
     karma: ^6.3.3
     karma-chrome-launcher: ^3.1.0
     karma-coverage: ^2.0.3
@@ -753,7 +752,6 @@ __metadata:
     chai: ^4.0.0
     chai-as-promised: ^7.0.0
     expect.js: ^0.3.1
-    istanbul-instrumenter-loader: ^3.0.1
     jquery: ^3.1.1
     karma: ^6.3.3
     karma-chrome-launcher: ^3.1.0
@@ -797,7 +795,6 @@ __metadata:
     d3-color: ^3.0.1
     d3-format: ^3.0.1
     expect.js: ^0.3.1
-    istanbul-instrumenter-loader: ^3.0.1
     jquery: ^3.1.1
     karma: ^6.3.3
     karma-chrome-launcher: ^3.1.0
@@ -976,10 +973,19 @@ __metadata:
     jquery: ^3.1.1
     npm-run-all: ^4.1.5
     prettier: ^2.3.2
+    react: ^18.3.1
     rimraf: ^3.0.2
     semver: ^7.3.5
     source-map-loader: ^4.0.1
     typescript: ~4.9.4
+  peerDependencies:
+    react: "*"
+  dependenciesMeta:
+    react:
+      optional: true
+  peerDependenciesMeta:
+    react:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4466,18 +4472,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^5.0.0":
-  version: 5.5.2
-  resolution: "ajv@npm:5.5.2"
-  dependencies:
-    co: ^4.6.0
-    fast-deep-equal: ^1.0.0
-    fast-json-stable-stringify: ^2.0.0
-    json-schema-traverse: ^0.3.0
-  checksum: a69645c843e1676b0ae1c5192786e546427f808f386d26127c6585479378066c64341ceec0b127b6789d79628e71d2a732d402f575b98f9262db230d7b715a94
-  languageName: node
-  linkType: hard
-
 "ajv@npm:^6.10.0, ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
@@ -4525,13 +4519,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "ansi-regex@npm:2.1.1"
-  checksum: 190abd03e4ff86794f338a31795d262c1dfe8c91f7e01d04f13f646f1dcb16c5800818f886047876f1272f065570ab86b24b99089f8b68a0e11ff19aed4ca8f1
-  languageName: node
-  linkType: hard
-
 "ansi-regex@npm:^3.0.0":
   version: 3.0.1
   resolution: "ansi-regex@npm:3.0.1"
@@ -4557,13 +4544,6 @@ __metadata:
   version: 1.1.0
   resolution: "ansi-sequence-parser@npm:1.1.0"
   checksum: 75f4d3a4c555655a698aec05b5763cbddcd16ccccdbfd178fb0aa471ab74fdf98e031b875ef26e64be6a95cf970c89238744b26de6e34af97f316d5186b1df53
-  languageName: node
-  linkType: hard
-
-"ansi-styles@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "ansi-styles@npm:2.2.1"
-  checksum: ebc0e00381f2a29000d1dac8466a640ce11943cef3bda3cd0020dc042e31e1058ab59bf6169cd794a54c3a7338a61ebc404b7c91e004092dd20e028c432c9c2c
   languageName: node
   linkType: hard
 
@@ -4823,100 +4803,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-code-frame@npm:^6.26.0":
-  version: 6.26.0
-  resolution: "babel-code-frame@npm:6.26.0"
-  dependencies:
-    chalk: ^1.1.3
-    esutils: ^2.0.2
-    js-tokens: ^3.0.2
-  checksum: 9410c3d5a921eb02fa409675d1a758e493323a49e7b9dddb7a2a24d47e61d39ab1129dd29f9175836eac9ce8b1d4c0a0718fcdc57ce0b865b529fd250dbab313
-  languageName: node
-  linkType: hard
-
-"babel-generator@npm:^6.18.0":
-  version: 6.26.1
-  resolution: "babel-generator@npm:6.26.1"
-  dependencies:
-    babel-messages: ^6.23.0
-    babel-runtime: ^6.26.0
-    babel-types: ^6.26.0
-    detect-indent: ^4.0.0
-    jsesc: ^1.3.0
-    lodash: ^4.17.4
-    source-map: ^0.5.7
-    trim-right: ^1.0.1
-  checksum: 5397f4d4d1243e7157e3336be96c10fcb1f29f73bf2d9842229c71764d9a6431397d249483a38c4d8b1581459e67be4df6f32d26b1666f02d0f5bfc2c2f25193
-  languageName: node
-  linkType: hard
-
-"babel-messages@npm:^6.23.0":
-  version: 6.23.0
-  resolution: "babel-messages@npm:6.23.0"
-  dependencies:
-    babel-runtime: ^6.22.0
-  checksum: c8075c17587a33869e1a5bd0a5b73bbe395b68188362dacd5418debbc7c8fd784bcd3295e81ee7e410dc2c2655755add6af03698c522209f6a68334c15e6d6ca
-  languageName: node
-  linkType: hard
-
-"babel-runtime@npm:^6.22.0, babel-runtime@npm:^6.23.0, babel-runtime@npm:^6.26.0":
+"babel-runtime@npm:^6.23.0":
   version: 6.26.0
   resolution: "babel-runtime@npm:6.26.0"
   dependencies:
     core-js: ^2.4.0
     regenerator-runtime: ^0.11.0
   checksum: 8aeade94665e67a73c1ccc10f6fd42ba0c689b980032b70929de7a6d9a12eb87ef51902733f8fefede35afea7a5c3ef7e916a64d503446c1eedc9e3284bd3d50
-  languageName: node
-  linkType: hard
-
-"babel-template@npm:^6.16.0":
-  version: 6.26.0
-  resolution: "babel-template@npm:6.26.0"
-  dependencies:
-    babel-runtime: ^6.26.0
-    babel-traverse: ^6.26.0
-    babel-types: ^6.26.0
-    babylon: ^6.18.0
-    lodash: ^4.17.4
-  checksum: 028dd57380f09b5641b74874a19073c53c4fb3f1696e849575aae18f8c80eaf21db75209057db862f3b893ce2cd9b795d539efa591b58f4a0fb011df0a56fbed
-  languageName: node
-  linkType: hard
-
-"babel-traverse@npm:^6.18.0, babel-traverse@npm:^6.26.0":
-  version: 6.26.0
-  resolution: "babel-traverse@npm:6.26.0"
-  dependencies:
-    babel-code-frame: ^6.26.0
-    babel-messages: ^6.23.0
-    babel-runtime: ^6.26.0
-    babel-types: ^6.26.0
-    babylon: ^6.18.0
-    debug: ^2.6.8
-    globals: ^9.18.0
-    invariant: ^2.2.2
-    lodash: ^4.17.4
-  checksum: fca037588d2791ae0409f1b7aa56075b798699cccc53ea04d82dd1c0f97b9e7ab17065f7dd3ecd69101d7874c9c8fd5e0f88fa53abbae1fe94e37e6b81ebcb8d
-  languageName: node
-  linkType: hard
-
-"babel-types@npm:^6.18.0, babel-types@npm:^6.26.0":
-  version: 6.26.0
-  resolution: "babel-types@npm:6.26.0"
-  dependencies:
-    babel-runtime: ^6.26.0
-    esutils: ^2.0.2
-    lodash: ^4.17.4
-    to-fast-properties: ^1.0.3
-  checksum: d16b0fa86e9b0e4c2623be81d0a35679faff24dd2e43cde4ca58baf49f3e39415a011a889e6c2259ff09e1228e4c3a3db6449a62de59e80152fe1ce7398fde76
-  languageName: node
-  linkType: hard
-
-"babylon@npm:^6.18.0":
-  version: 6.18.0
-  resolution: "babylon@npm:6.18.0"
-  bin:
-    babylon: ./bin/babylon.js
-  checksum: 0777ae0c735ce1cbfc856d627589ed9aae212b84fb0c03c368b55e6c5d3507841780052808d0ad46e18a2ba516e93d55eeed8cd967f3b2938822dfeccfb2a16d
   languageName: node
   linkType: hard
 
@@ -5356,19 +5249,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "chalk@npm:1.1.3"
-  dependencies:
-    ansi-styles: ^2.2.1
-    escape-string-regexp: ^1.0.2
-    has-ansi: ^2.0.0
-    strip-ansi: ^3.0.0
-    supports-color: ^2.0.0
-  checksum: 9d2ea6b98fc2b7878829eec223abcf404622db6c48396a9b9257f6d0ead2acf18231ae368d6a664a83f272b0679158da12e97b5229f794939e555cc574478acd
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^2.0.0, chalk@npm:^2.0.1, chalk@npm:^2.1.0, chalk@npm:^2.3.0, chalk@npm:^2.4.1":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -5588,13 +5468,6 @@ __metadata:
   dependencies:
     mkdirp-infer-owner: ^2.0.0
   checksum: 83d2a46cdf4adbb38d3d3184364b2df0e4c001ac770f5ca94373825d7a48838b4cb8a59534ef48f02b0d556caa047728589ca65c640c17c0b417b3afb34acfbb
-  languageName: node
-  linkType: hard
-
-"co@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "co@npm:4.6.0"
-  checksum: 5210d9223010eb95b29df06a91116f2cf7c8e0748a9013ed853b53f362ea0e822f1e5bb054fb3cefc645239a4cf966af1f6133a3b43f40d591f3b68ed6cf0510
   languageName: node
   linkType: hard
 
@@ -5987,7 +5860,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"convert-source-map@npm:^1.5.0, convert-source-map@npm:^1.7.0":
+"convert-source-map@npm:^1.7.0":
   version: 1.9.0
   resolution: "convert-source-map@npm:1.9.0"
   checksum: dc55a1f28ddd0e9485ef13565f8f756b342f9a46c4ae18b843fe3c30c675d058d6a4823eff86d472f187b176f0adf51ea7b69ea38be34be4a63cbbf91b0593c8
@@ -6259,7 +6132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:2.6.9, debug@npm:^2.6.8":
+"debug@npm:2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -6457,15 +6330,6 @@ __metadata:
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
   checksum: 0acb300b7478a08b92d810ab229d5afe0d2f4399272045ab22affa0d99dbaf12637659411530a6fcd597a9bdac718fc94373a61a95b4651bbc7b83684a565e38
-  languageName: node
-  linkType: hard
-
-"detect-indent@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "detect-indent@npm:4.0.0"
-  dependencies:
-    repeating: ^2.0.0
-  checksum: 328f273915c1610899bc7d4784ce874413d0a698346364cd3ee5d79afba1c5cf4dbc97b85a801e20f4d903c0598bd5096af32b800dfb8696b81464ccb3dfda2c
   languageName: node
   linkType: hard
 
@@ -6997,7 +6861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-string-regexp@npm:^1.0.2, escape-string-regexp@npm:^1.0.5":
+"escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: 6092fda75c63b110c706b6a9bfde8a612ad595b628f0bd2147eea1d3406723020810e591effc7db1da91d80a71a737a313567c5abb3813e8d9c71f4aa595b410
@@ -7301,13 +7165,6 @@ __metadata:
   version: 1.4.1
   resolution: "extsprintf@npm:1.4.1"
   checksum: a2f29b241914a8d2bad64363de684821b6b1609d06ae68d5b539e4de6b28659715b5bea94a7265201603713b7027d35399d10b0548f09071c5513e65e8323d33
-  languageName: node
-  linkType: hard
-
-"fast-deep-equal@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "fast-deep-equal@npm:1.1.0"
-  checksum: 69b4c9534d9805f13a341aa72f69641d0b9ae3cc8beb25c64e68a257241c7bb34370266db27ae4fc3c4da0518448c01a5f587a096a211471c86a38facd9a1486
   languageName: node
   linkType: hard
 
@@ -8083,13 +7940,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^9.18.0":
-  version: 9.18.0
-  resolution: "globals@npm:9.18.0"
-  checksum: e9c066aecfdc5ea6f727344a4246ecc243aaf66ede3bffee10ddc0c73351794c25e727dd046090dcecd821199a63b9de6af299a6e3ba292c8b22f0a80ea32073
-  languageName: node
-  linkType: hard
-
 "globalthis@npm:^1.0.3":
   version: 1.0.3
   resolution: "globalthis@npm:1.0.3"
@@ -8244,15 +8094,6 @@ __metadata:
   version: 2.1.0
   resolution: "hard-rejection@npm:2.1.0"
   checksum: 7baaf80a0c7fff4ca79687b4060113f1529589852152fa935e6787a2bc96211e784ad4588fb3048136ff8ffc9dfcf3ae385314a5b24db32de20bea0d1597f9dc
-  languageName: node
-  linkType: hard
-
-"has-ansi@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "has-ansi@npm:2.0.0"
-  dependencies:
-    ansi-regex: ^2.0.0
-  checksum: 1b51daa0214440db171ff359d0a2d17bc20061164c57e76234f614c91dbd2a79ddd68dfc8ee73629366f7be45a6df5f2ea9de83f52e1ca24433f2cc78c35d8ec
   languageName: node
   linkType: hard
 
@@ -8768,15 +8609,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"invariant@npm:^2.2.2":
-  version: 2.2.4
-  resolution: "invariant@npm:2.2.4"
-  dependencies:
-    loose-envify: ^1.0.0
-  checksum: cc3182d793aad82a8d1f0af697b462939cb46066ec48bbf1707c150ad5fad6406137e91a262022c269702e01621f35ef60269f6c0d7fd178487959809acdfb14
-  languageName: node
-  linkType: hard
-
 "ip@npm:^2.0.0":
   version: 2.0.0
   resolution: "ip@npm:2.0.0"
@@ -8893,13 +8725,6 @@ __metadata:
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
   checksum: df033653d06d0eb567461e58a7a8c9f940bd8c22274b94bf7671ab36df5719791aae15eef6d83bbb5e23283967f2f984b8914559d4449efda578c775c4be6f85
-  languageName: node
-  linkType: hard
-
-"is-finite@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "is-finite@npm:1.1.0"
-  checksum: 532b97ed3d03e04c6bd203984d9e4ba3c0c390efee492bad5d1d1cd1802a68ab27adbd3ef6382f6312bed6c8bb1bd3e325ea79a8dc8fe080ed7a06f5f97b93e7
   languageName: node
   linkType: hard
 
@@ -9198,46 +9023,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-instrumenter-loader@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "istanbul-instrumenter-loader@npm:3.0.1"
-  dependencies:
-    convert-source-map: ^1.5.0
-    istanbul-lib-instrument: ^1.7.3
-    loader-utils: ^1.1.0
-    schema-utils: ^0.3.0
-  peerDependencies:
-    webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
-  checksum: 6b2eb9987f79dd451c43e0fcc6fa77bf0f7ac91f3237b7833a07ad6f35e15a6bff579e943edfc2dee203408b6c3a2b4b11f3028b8628cb7304df3decc7552831
-  languageName: node
-  linkType: hard
-
-"istanbul-lib-coverage@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "istanbul-lib-coverage@npm:1.2.1"
-  checksum: 72bfeaa9212f5a6abb243cbce4933712599ba9a6fbdee819f4f5a4cf87ed15cb92772fcab219e93c3712c578774d6d8e54084440423356b3da5d9f8ecaba9888
-  languageName: node
-  linkType: hard
-
 "istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
   version: 3.2.0
   resolution: "istanbul-lib-coverage@npm:3.2.0"
   checksum: a2a545033b9d56da04a8571ed05c8120bf10e9bce01cf8633a3a2b0d1d83dff4ac4fe78d6d5673c27fc29b7f21a41d75f83a36be09f82a61c367b56aa73c1ff9
-  languageName: node
-  linkType: hard
-
-"istanbul-lib-instrument@npm:^1.7.3":
-  version: 1.10.2
-  resolution: "istanbul-lib-instrument@npm:1.10.2"
-  dependencies:
-    babel-generator: ^6.18.0
-    babel-template: ^6.16.0
-    babel-traverse: ^6.18.0
-    babel-types: ^6.18.0
-    babylon: ^6.18.0
-    istanbul-lib-coverage: ^1.2.1
-    semver: ^5.3.0
-  checksum: c299d73820b0ac93d1c53f436181da09579083dc4a0febadbda93f598f9a5591fe4888c3071a913eede36148d6481fdf163fa0b6ec7156fffe2a95cff965fc51
   languageName: node
   linkType: hard
 
@@ -9345,13 +9134,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-tokens@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "js-tokens@npm:3.0.2"
-  checksum: ff24cf90e6e4ac446eba56e604781c1aaf3bdaf9b13a00596a0ebd972fa3b25dc83c0f0f67289c33252abb4111e0d14e952a5d9ffb61f5c22532d555ebd8d8a9
-  languageName: node
-  linkType: hard
-
 "js-yaml@npm:4.1.0, js-yaml@npm:^4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
@@ -9379,15 +9161,6 @@ __metadata:
   version: 0.1.1
   resolution: "jsbn@npm:0.1.1"
   checksum: e5ff29c1b8d965017ef3f9c219dacd6e40ad355c664e277d31246c90545a02e6047018c16c60a00f36d561b3647215c41894f5d869ada6908a2e0ce4200c88f2
-  languageName: node
-  linkType: hard
-
-"jsesc@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "jsesc@npm:1.3.0"
-  bin:
-    jsesc: bin/jsesc
-  checksum: 9384cc72bf8ef7f2eb75fea64176b8b0c1c5e77604854c72cb4670b7072e112e3baaa69ef134be98cb078834a7812b0bfe676ad441ccd749a59427f5ed2127f1
   languageName: node
   linkType: hard
 
@@ -9441,13 +9214,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-schema-traverse@npm:^0.3.0":
-  version: 0.3.1
-  resolution: "json-schema-traverse@npm:0.3.1"
-  checksum: a685c36222023471c25c86cddcff506306ecb8f8941922fd356008419889c41c38e1c16d661d5499d0a561b34f417693e9bb9212ba2b2b2f8f8a345a49e4ec1a
-  languageName: node
-  linkType: hard
-
 "json-schema-traverse@npm:^0.4.1":
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
@@ -9487,17 +9253,6 @@ __metadata:
   version: 5.0.1
   resolution: "json-stringify-safe@npm:5.0.1"
   checksum: 48ec0adad5280b8a96bb93f4563aa1667fd7a36334f79149abd42446d0989f2ddc58274b479f4819f1f00617957e6344c886c55d05a4e15ebb4ab931e4a6a8ee
-  languageName: node
-  linkType: hard
-
-"json5@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "json5@npm:1.0.2"
-  dependencies:
-    minimist: ^1.2.0
-  bin:
-    json5: lib/cli.js
-  checksum: 866458a8c58a95a49bef3adba929c625e82532bcff1fe93f01d29cb02cac7c3fe1f4b79951b7792c2da9de0b32871a8401a6e3c5b36778ad852bf5b8a61165d7
   languageName: node
   linkType: hard
 
@@ -10016,17 +9771,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loader-utils@npm:^1.1.0":
-  version: 1.4.2
-  resolution: "loader-utils@npm:1.4.2"
-  dependencies:
-    big.js: ^5.2.2
-    emojis-list: ^3.0.0
-    json5: ^1.0.1
-  checksum: eb6fb622efc0ffd1abdf68a2022f9eac62bef8ec599cf8adb75e94d1d338381780be6278534170e99edc03380a6d29bc7eb1563c89ce17c5fed3a0b17f1ad804
-  languageName: node
-  linkType: hard
-
 "loader-utils@npm:^2.0.0":
   version: 2.0.4
   resolution: "loader-utils@npm:2.0.4"
@@ -10208,7 +9952,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -12937,6 +12681,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
+  dependencies:
+    loose-envify: ^1.1.0
+  checksum: a27bcfa8ff7c15a1e50244ad0d0c1cb2ad4375eeffefd266a64889beea6f6b64c4966c9b37d14ee32d6c9fcd5aa6ba183b6988167ab4d127d13e7cb5b386a376
+  languageName: node
+  linkType: hard
+
 "read-cache@npm:^1.0.0":
   version: 1.0.0
   resolution: "read-cache@npm:1.0.0"
@@ -13192,15 +12945,6 @@ __metadata:
   dependencies:
     rc: ^1.2.8
   checksum: bcea86c84a0dbb66467b53187fadebfea79017cddfb4a45cf27530d7275e49082fe9f44301976eb0164c438e395684bcf3dae4819b36ff9d1640d8cc60c73df9
-  languageName: node
-  linkType: hard
-
-"repeating@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "repeating@npm:2.0.1"
-  dependencies:
-    is-finite: ^1.0.0
-  checksum: d2db0b69c5cb0c14dd750036e0abcd6b3c3f7b2da3ee179786b755cf737ca15fa0fff417ca72de33d6966056f4695440e680a352401fc02c95ade59899afbdd0
   languageName: node
   linkType: hard
 
@@ -13545,15 +13289,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"schema-utils@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "schema-utils@npm:0.3.0"
-  dependencies:
-    ajv: ^5.0.0
-  checksum: 441fa4bd4900afb19eb9da1d8d6271056b71ce3d8b1b73bbece791de1d4c90ac7e97ffc9787607aa53611aaf2996711af7c18ba8669f06b084b218cab1e701e3
-  languageName: node
-  linkType: hard
-
 "schema-utils@npm:^2.7.0":
   version: 2.7.1
   resolution: "schema-utils@npm:2.7.1"
@@ -13606,7 +13341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.3.0, semver@npm:^5.4.1, semver@npm:^5.5.0, semver@npm:^5.6.0":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.4.1, semver@npm:^5.5.0, semver@npm:^5.6.0":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
   bin:
@@ -14085,13 +13820,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.5.7":
-  version: 0.5.7
-  resolution: "source-map@npm:0.5.7"
-  checksum: 5dc2043b93d2f194142c7f38f74a24670cd7a0063acdaf4bf01d2964b402257ae843c2a8fa822ad5b71013b5fcafa55af7421383da919752f22ff488bc553f4d
-  languageName: node
-  linkType: hard
-
 "source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.0, source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
@@ -14336,15 +14064,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "strip-ansi@npm:3.0.1"
-  dependencies:
-    ansi-regex: ^2.0.0
-  checksum: 9b974de611ce5075c70629c00fa98c46144043db92ae17748fb780f706f7a789e9989fd10597b7c2053ae8d1513fd707816a91f1879b2f71e6ac0b6a863db465
-  languageName: node
-  linkType: hard
-
 "strip-ansi@npm:^4.0.0":
   version: 4.0.0
   resolution: "strip-ansi@npm:4.0.0"
@@ -14442,13 +14161,6 @@ __metadata:
   dependencies:
     has-flag: ^4.0.0
   checksum: c052193a7e43c6cdc741eb7f378df605636e01ad434badf7324f17fb60c69a880d8d8fcdcb562cf94c2350e57b937d7425ab5b8326c67c2adc48f7c87c1db406
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "supports-color@npm:2.0.0"
-  checksum: 602538c5812b9006404370b5a4b885d3e2a1f6567d314f8b4a41974ffe7d08e525bf92ae0f9c7030e3b4c78e4e34ace55d6a67a74f1571bc205959f5972f88f0
   languageName: node
   linkType: hard
 
@@ -14635,13 +14347,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"to-fast-properties@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "to-fast-properties@npm:1.0.3"
-  checksum: bd0abb58c4722851df63419de3f6d901d5118f0440d3f71293ed776dd363f2657edaaf2dc470e3f6b7b48eb84aa411193b60db8a4a552adac30de9516c5cc580
-  languageName: node
-  linkType: hard
-
 "to-fast-properties@npm:^2.0.0":
   version: 2.0.0
   resolution: "to-fast-properties@npm:2.0.0"
@@ -14709,13 +14414,6 @@ __metadata:
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: b530f3fadf78e570cf3c761fb74fef655beff6b0f84b29209bac6c9622db75ad1417f4a7b5d54c96605dcd72734ad44526fef9f396807b90839449eb543c6206
-  languageName: node
-  linkType: hard
-
-"trim-right@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "trim-right@npm:1.0.1"
-  checksum: 9120af534e006a7424a4f9358710e6e707887b6ccf7ea69e50d6ac6464db1fe22268400def01752f09769025d480395159778153fb98d4a2f6f40d4cf5d4f3b6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,7 +704,7 @@ __metadata:
     "@types/chai-as-promised": ^7.1.0
     "@types/expect.js": ^0.3.29
     "@types/mocha": ^9.0.0
-    "@types/sanitize-html": ^2.6.0
+    "@types/sanitize-html": ^2.11.0
     "@types/sinon": ^10.0.2
     "@types/sinon-chai": ^3.2.2
     base64-js: ^1.2.1
@@ -723,7 +723,7 @@ __metadata:
     mocha: ^9.0.0
     npm-run-all: ^4.1.5
     rimraf: ^3.0.2
-    sanitize-html: ^2.3
+    sanitize-html: ^2.13.0
     sinon: ^12.0.1
     sinon-chai: ^3.3.0
     typescript: ~4.9.4
@@ -737,7 +737,7 @@ __metadata:
   dependencies:
     "@jupyterlab/services": ^6.0.0 || ^7.0.0
     "@lumino/coreutils": ^1.11.1 || ^2.1
-    "@lumino/messaging": ^1.10.1 || ^2.1
+    "@lumino/messaging": ^1.10.1 || ^2.0.1
     "@lumino/widgets": ^1.30.0 || ^2.1
     "@types/backbone": 1.4.14
     "@types/base64-js": ^1.2.5
@@ -780,9 +780,9 @@ __metadata:
   dependencies:
     "@jupyter-widgets/base": ^6.0.7
     "@jupyterlab/services": ^6.0.0 || ^7.0.0
-    "@lumino/algorithm": ^1.9.1 || ^2.1
+    "@lumino/algorithm": ^1.9.2 || ^2.0.1
     "@lumino/domutils": ^1.8.1 || ^2.1
-    "@lumino/messaging": ^1.10.1 || ^2.1
+    "@lumino/messaging": ^1.10.1 || ^2.0.1
     "@lumino/signaling": ^1.10.1 || ^2.1
     "@lumino/widgets": ^1.30.0 || ^2.1
     "@types/d3-color": ^3.0.2
@@ -908,12 +908,12 @@ __metadata:
     "@jupyterlab/outputarea": ^3.0.0 || ^4.0.0
     "@jupyterlab/rendermime": ^3.0.0 || ^4.0.0
     "@jupyterlab/rendermime-interfaces": ^3.0.0 || ^4.0.0
-    "@lumino/messaging": ^1.10.1 || ^2.1
+    "@lumino/messaging": ^1.10.1 || ^2.0.1
     "@lumino/widgets": ^1.30.0 || ^2.1
     "@types/jquery": ^3.5.16
     "@types/mocha": ^9.0.0
     "@types/node": ^17.0.2
-    "@types/sanitize-html": ^2.6.0
+    "@types/sanitize-html": ^2.11.0
     ajv: ^8.6.0
     chai: ^4.0.0
     css-loader: ^6.5.1
@@ -959,7 +959,7 @@ __metadata:
     "@jupyterlab/services": ^6.0.0 || ^7.0.0
     "@jupyterlab/settingregistry": ^3.0.0 || ^4.0.0
     "@jupyterlab/translation": ^3.0.0 || ^4.0.0
-    "@lumino/algorithm": ^1.11.1 || ^2.0.0
+    "@lumino/algorithm": ^1.9.2 || ^2.0.1
     "@lumino/coreutils": ^1.11.1 || ^2.1
     "@lumino/disposable": ^1.10.1 || ^2.1
     "@lumino/properties": ^1.8.1 || ^2.1
@@ -993,7 +993,7 @@ __metadata:
     "@jupyter-widgets/html-manager": ^1.0.10
     "@jupyter-widgets/output": ^6.0.7
     "@jupyterlab/services": ^6.0.0 || ^7.0.0
-    "@lumino/messaging": ^1.10.1 || ^2.1
+    "@lumino/messaging": ^1.10.1 || ^2.0.1
     "@lumino/widgets": ^1.30.0 || ^2.1
     backbone: 1.4.0
     css-loader: ^6.5.1
@@ -2634,17 +2634,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/algorithm@npm:^1.11.1 || ^2.0.0, @lumino/algorithm@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@lumino/algorithm@npm:2.0.0"
-  checksum: 663edf536e94397b449c6a2643a735e602fbb396dec86b56ad1193a768dce27c6e7da5ad0384aa90086ea44cbb64dde3f9d565e9fd81858f1eb0c6b4253f3b94
+"@lumino/algorithm@npm:^1.9.2 || ^2.0.1, @lumino/algorithm@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@lumino/algorithm@npm:2.0.1"
+  checksum: cbf7fcf6ee6b785ea502cdfddc53d61f9d353dcb9659343511d5cd4b4030be2ff2ca4c08daec42f84417ab0318a3d9972a17319fa5231693e109ab112dcf8000
   languageName: node
   linkType: hard
 
-"@lumino/algorithm@npm:^1.9.1 || ^2.1, @lumino/algorithm@npm:^1.9.2":
-  version: 1.9.2
-  resolution: "@lumino/algorithm@npm:1.9.2"
-  checksum: a89e7c63504236119634858e271db1cc649684d30ced5a6ebe2788af7c0837f1e05a6fd3047d8525eb756c42ce137f76b3688f75fd3ef915b71cd4f213dfbb96
+"@lumino/algorithm@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@lumino/algorithm@npm:2.0.0"
+  checksum: 663edf536e94397b449c6a2643a735e602fbb396dec86b56ad1193a768dce27c6e7da5ad0384aa90086ea44cbb64dde3f9d565e9fd81858f1eb0c6b4253f3b94
   languageName: node
   linkType: hard
 
@@ -2659,21 +2659,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/collections@npm:^1.9.3":
-  version: 1.9.3
-  resolution: "@lumino/collections@npm:1.9.3"
-  dependencies:
-    "@lumino/algorithm": ^1.9.2
-  checksum: 1c87a12743eddd6f6b593e47945a5645e2f99ad61c5192499b0745e48ee9aff263c7145541e77dfeea4c9f50bdd017fddfa47bfc60e718de4f28533ce45bf8c3
-  languageName: node
-  linkType: hard
-
 "@lumino/collections@npm:^2.0.0":
   version: 2.0.0
   resolution: "@lumino/collections@npm:2.0.0"
   dependencies:
     "@lumino/algorithm": ^2.0.0
   checksum: 4a7fc3571e92a1368a1ef01300ad7b6e0d4ff13cb78b89533d5962eea66d4a7550e15d8b80fa3ab1816b1a89382f35015f9dddf72ab04654c17e5b516b845d8f
+  languageName: node
+  linkType: hard
+
+"@lumino/collections@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@lumino/collections@npm:2.0.1"
+  dependencies:
+    "@lumino/algorithm": ^2.0.1
+  checksum: 8a29b7973a388a33c5beda0819dcd2dc2aad51a8406dcfd4581b055a9f77a39dc5800f7a8b4ae3c0bb97ae7b56a7a869e2560ffb7a920a28e93b477ba05907d6
   languageName: node
   linkType: hard
 
@@ -2739,13 +2739,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/messaging@npm:^1.10.1 || ^2.1":
-  version: 1.10.3
-  resolution: "@lumino/messaging@npm:1.10.3"
+"@lumino/messaging@npm:^1.10.1 || ^2.0.1":
+  version: 2.0.1
+  resolution: "@lumino/messaging@npm:2.0.1"
   dependencies:
-    "@lumino/algorithm": ^1.9.2
-    "@lumino/collections": ^1.9.3
-  checksum: 1131e80379fa9b8a9b5d3418c90e25d4be48e2c92ec711518190772f9e8845a695bef45daddd06a129168cf6f158c8ad80ae86cb245f566e9195bbd9a0843b7a
+    "@lumino/algorithm": ^2.0.1
+    "@lumino/collections": ^2.0.1
+  checksum: 964c4651c374b17452b4252b7d71500b32d2ecd87c192fc5bcf5d3bd1070661d78d07edcac8eca7d1d6fd50aa25992505485e1296d6dd995691b8e349b652045
   languageName: node
   linkType: hard
 
@@ -3646,12 +3646,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/sanitize-html@npm:^2.6.0":
-  version: 2.9.0
-  resolution: "@types/sanitize-html@npm:2.9.0"
+"@types/sanitize-html@npm:^2.11.0":
+  version: 2.11.0
+  resolution: "@types/sanitize-html@npm:2.11.0"
   dependencies:
     htmlparser2: ^8.0.0
-  checksum: b60f42b740bbfb1b1434ce8b43925a38ecc608b60aa654fd009d2e22e33f324b61d370768c55bd2fd98e03de08518ffa8911d61606c483526fb931bb8b59d1b0
+  checksum: a901d55d31cd946a7fce0130cc7cf6bcf56602af9c87291be77d8149c60e7afc47c83ca74c67c2d84e6ba029fe9bbd6f14f89a8cb30fbd185766eebc5722c251
   languageName: node
   linkType: hard
 
@@ -13501,9 +13501,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sanitize-html@npm:^2.3":
-  version: 2.10.0
-  resolution: "sanitize-html@npm:2.10.0"
+"sanitize-html@npm:^2.13.0":
+  version: 2.13.0
+  resolution: "sanitize-html@npm:2.13.0"
   dependencies:
     deepmerge: ^4.2.2
     escape-string-regexp: ^4.0.0
@@ -13511,7 +13511,7 @@ __metadata:
     is-plain-object: ^5.0.0
     parse-srcset: ^1.0.2
     postcss: ^8.3.11
-  checksum: 0cb2bb330ed966a4d667b1890322dd868a67f527f87c04d7e3be1688fcfda20f7452a9a7744870751f51e255742e7264a287d9bcfcd64d4cd74a3c99f99c73d2
+  checksum: d88602328306dbbddb9c5e2a5798783a3b38977a7ef40bf81dae31220d7fb583149c1046a33ec6817e9d96d172b1aaa9ea159776eb1ee08f6a0571150114c9bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is exploring the possibility of a per-kernel widget manager as suggested  by @jasongrout in the comments of the recently merged PR: https://github.com/jupyter-widgets/ipywidgets/pull/3004.

This PR follows on from a recent PR https://github.com/jupyter-widgets/ipywidgets/pull/3893, but could be easily re-based independently.

In it's current form, it can render the same widget in notebook[s] and consoles connected to the same kernel. The only requirement being that the KernelWidgetManager is registered to (instantiated with) the kernel.

![image](https://github.com/jupyter-widgets/ipywidgets/assets/1474668/3290db27-7bd8-4137-9815-c5b4c14bbf8c)

### How it works

`KernelWidgetManager` was modified to create only one instance per kernel.id.
`WidgetManager` was changed to be an interface for notebooks that swaps the notebook (panel) rendermime factory to use the KernelWidgetManager corresponding to the new kernel as the kernel is changed.

### Other changes

* `WidgetRenderer` was modified to search for the widget manager of a model_id if the widgetManager wasn't specified.
* A timeout was added to ManagerBase.get_model which help avoid 'model not found' errors that occur when the view tries to render before the model promise has been created. 
* The plugin system was also modified to make it easier to create a KernelWidgetManager for a kernel that doesn't have a notebook attached (downstream use).