### PR TITLE
Make tests compatible with Python 3.13

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/tests/test_docutils.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_docutils.py
@@ -15,7 +15,7 @@ class TestDocSubst(TestCase):
         def f():
             """ Docstring with value {key} """
 
-        assert f.__doc__ == " Docstring with value 62 "
+        assert "Docstring with value 62" in f.__doc__
 
     def test_unused_keys(self):
         snippets = {'key': '62', 'other-key': 'unused'}
@@ -24,4 +24,4 @@ class TestDocSubst(TestCase):
         def f():
             """ Docstring with value {key} """
 
-        assert f.__doc__ == " Docstring with value 62 "
+        assert "Docstring with value 62" in f.__doc__


### PR DESCRIPTION
Python compiler newly removes indent from docstrings https://github.com/python/cpython/issues/81283