### PR TITLE
doc: update yarn version in dev_install.md

### DIFF
--- a/docs/source/dev_install.md
+++ b/docs/source/dev_install.md
@@ -7,7 +7,7 @@ The core Jupyter Widgets packages are developed in the
 
 To install ipywidgets from git, you will need:
 
-- [yarn](https://yarnpkg.com/) package manager ** version 1.2.1 or later **
+- [yarn](https://yarnpkg.com/) package manager ** version 3.0 or later **
 
 - the latest [Jupyter Notebook development release](https://github.com/jupyter/notebook/releases)
 


### PR DESCRIPTION
This pull-request fixes #3928 by updating the reference to the Yarn version specified in the `dev_install.md` file.