### PR TITLE
7.x: Fix Tabs and Accordions CSS when using lab 4

### DIFF
--- a/packages/controls/css/phosphor.css
+++ b/packages/controls/css/phosphor.css
@@ -31,11 +31,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 /*
- * The following section is derived from https://github.com/phosphorjs/phosphor/blob/23b9d075ebc5b73ab148b6ebfc20af97f85714c4/packages/widgets/style/tabbar.css 
+ * The following section is derived from https://github.com/phosphorjs/phosphor/blob/23b9d075ebc5b73ab148b6ebfc20af97f85714c4/packages/widgets/style/tabbar.css
  * We've scoped the rules so that they are consistent with exactly our code.
  */
 
-.jupyter-widgets.widget-tab > .p-TabBar {
+.jupyter-widgets.widget-tab > .p-TabBar,
+.jupyter-widgets.widget-tab > .lm-TabBar {
   display: flex;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -44,17 +45,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar[data-orientation='horizontal'] {
+.jupyter-widgets.widget-tab > .p-TabBar[data-orientation='horizontal'],
+.jupyter-widgets.widget-tab > .lm-TabBar[data-orientation='horizontal'] {
   flex-direction: row;
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar[data-orientation='vertical'] {
+.jupyter-widgets.widget-tab > .p-TabBar[data-orientation='vertical'],
+.jupyter-widgets.widget-tab > .lm-TabBar[data-orientation='vertical'] {
   flex-direction: column;
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar > .p-TabBar-content {
+.jupyter-widgets.widget-tab > .p-TabBar > .p-TabBar-content,
+.jupyter-widgets.widget-tab > .lm-TabBar > .lm-TabBar-content {
   margin: 0;
   padding: 0;
   display: flex;
@@ -63,17 +67,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar[data-orientation='horizontal'] > .p-TabBar-content {
+.jupyter-widgets.widget-tab > .p-TabBar[data-orientation='horizontal'] > .p-TabBar-content,
+.jupyter-widgets.widget-tab > .lm-TabBar[data-orientation='horizontal'] > .lm-TabBar-content {
   flex-direction: row;
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar[data-orientation='vertical'] > .p-TabBar-content {
+.jupyter-widgets.widget-tab > .p-TabBar[data-orientation='vertical'] > .p-TabBar-content,
+.jupyter-widgets.widget-tab > .lm-TabBar[data-orientation='vertical'] > .lm-TabBar-content {
   flex-direction: column;
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab {
+.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tab {
   display: flex;
   flex-direction: row;
   box-sizing: border-box;
@@ -82,41 +89,49 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 .jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tabIcon,
-.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tabCloseIcon {
+.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tabCloseIcon,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tabIcon,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tabCloseIcon {
   flex: 0 0 auto;
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tabLabel {
+.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tabLabel,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tabLabel {
   flex: 1 1 auto;
   overflow: hidden;
   white-space: nowrap;
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab.p-mod-hidden {
+.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab.p-mod-hidden,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tab.lm-mod-hidden {
   display: none !important;
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar.p-mod-dragging .p-TabBar-tab {
+.jupyter-widgets.widget-tab > .p-TabBar.p-mod-dragging .p-TabBar-tab,
+.jupyter-widgets.widget-tab > .lm-TabBar.lm-mod-dragging .lm-TabBar-tab {
   position: relative;
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar.p-mod-dragging[data-orientation='horizontal'] .p-TabBar-tab {
+.jupyter-widgets.widget-tab > .p-TabBar.p-mod-dragging[data-orientation='horizontal'] .p-TabBar-tab,
+.jupyter-widgets.widget-tab > .lm-TabBar.lm-mod-dragging[data-orientation='horizontal'] .lm-TabBar-tab {
   left: 0;
   transition: left 150ms ease;
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar.p-mod-dragging[data-orientation='vertical'] .p-TabBar-tab {
+.jupyter-widgets.widget-tab > .p-TabBar.p-mod-dragging[data-orientation='vertical'] .p-TabBar-tab,
+.jupyter-widgets.widget-tab > .lm-TabBar.lm-mod-dragging[data-orientation='vertical'] .lm-TabBar-tab {
   top: 0;
   transition: top 150ms ease;
 }
 
 
-.jupyter-widgets.widget-tab > .p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging {
+.jupyter-widgets.widget-tab > .p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging,
+.jupyter-widgets.widget-tab > .lm-TabBar.lm-mod-dragging .lm-TabBar-tab.lm-mod-dragging {
   transition: none;
 }
 

--- a/packages/controls/css/widgets-base.css
+++ b/packages/controls/css/widgets-base.css
@@ -420,7 +420,7 @@
     flex-shrink: 1;
     outline: none !important;
 }
-    
+
 .widget-text input[type="text"], .widget-text input[type="password"], .widget-textarea textarea {
     padding: var(--jp-widgets-input-padding) calc( var(--jp-widgets-input-padding) *  2);
 }
@@ -893,13 +893,15 @@
     flex-direction: column;
 }
 
-.jupyter-widgets.widget-tab > .p-TabBar {
+.jupyter-widgets.widget-tab > .p-TabBar,
+.jupyter-widgets.widget-tab > .lm-TabBar {
     /* Necessary so that a tab can be shifted down to overlay the border of the box below. */
     overflow-x: visible;
     overflow-y: visible;
 }
 
-.jupyter-widgets.widget-tab > .p-TabBar > .p-TabBar-content {
+.jupyter-widgets.widget-tab > .p-TabBar > .p-TabBar-content,
+.jupyter-widgets.widget-tab > .lm-TabBar > .lm-TabBar-content {
     /* Make sure that the tab grows from bottom up */
     align-items: flex-end;
     min-width: 0;
@@ -918,12 +920,14 @@
     overflow: auto;
 }
 
-.jupyter-widgets.widget-tab > .p-TabBar {
+.jupyter-widgets.widget-tab > .p-TabBar,
+.jupyter-widgets.widget-tab > .lm-TabBar {
     font: var(--jp-widgets-font-size) Helvetica, Arial, sans-serif;
     min-height: calc(var(--jp-widgets-horizontal-tab-height) + var(--jp-border-width));
 }
 
-.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab {
+.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tab {
     flex: 0 1 var(--jp-widgets-horizontal-tab-width);
     min-width: 35px;
     min-height: calc(var(--jp-widgets-horizontal-tab-height) + var(--jp-border-width));
@@ -937,7 +941,8 @@
     position: relative;
 }
 
-.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab.p-mod-current {
+.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab.p-mod-current,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tab.lm-mod-current {
     color: var(--jp-ui-font-color0);
     /* We want the background to match the tab content background */
     background: var(--jp-layout-color1);
@@ -946,7 +951,8 @@
     overflow: visible;
 }
 
-.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab.p-mod-current:before {
+.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab.p-mod-current:before,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tab.lm-mod-current:before {
     position: absolute;
     top: calc(-1 * var(--jp-border-width));
     left: calc(-1 * var(--jp-border-width));
@@ -956,29 +962,36 @@
     background: var(--jp-brand-color1);
 }
 
-.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab:first-child {
+.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab:first-child,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tab:first-child {
     margin-left: 0;
 }
 
-.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab:hover:not(.p-mod-current) {
+.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tab:hover:not(.p-mod-current),
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tab:hover:not(.lm-mod-current) {
     background: var(--jp-layout-color1);
     color: var(--jp-ui-font-color1);
 }
 
-.jupyter-widgets.widget-tab > .p-TabBar .p-mod-closable > .p-TabBar-tabCloseIcon {
+.jupyter-widgets.widget-tab > .p-TabBar .p-mod-closable > .p-TabBar-tabCloseIcon,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-mod-closable > .lm-TabBar-tabCloseIcon {
     margin-left: 4px;
 }
 
 /* This font-awesome strategy may not work across FA4 and FA5, but we don't
 actually support closable tabs, so it really doesn't matter */
-.jupyter-widgets.widget-tab > .p-TabBar .p-mod-closable > .p-TabBar-tabCloseIcon:before {
+.jupyter-widgets.widget-tab > .p-TabBar .p-mod-closable > .p-TabBar-tabCloseIcon:before,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-mod-closable > .lm-TabBar-tabCloseIcon:before {
     font-family: FontAwesome;
     content: '\f00d'; /* close */
 }
 
 .jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tabIcon,
 .jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tabLabel,
-.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tabCloseIcon {
+.jupyter-widgets.widget-tab > .p-TabBar .p-TabBar-tabCloseIcon,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tabIcon,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tabLabel,
+.jupyter-widgets.widget-tab > .lm-TabBar .lm-TabBar-tabCloseIcon {
     line-height: var(--jp-widgets-horizontal-tab-height);
 }
 


### PR DESCRIPTION
Backport backward-compatible parts of https://github.com/jupyter-widgets/ipywidgets/pull/3366

This fixes Tabs and Accordions display when using lab 4:

![Screenshot from 2024-07-26 09-29-43](https://github.com/user-attachments/assets/b8808dea-2fc6-44b8-90c0-b913045b6557)
