### PR TITLE
Remove confusing error message

### DIFF
--- a/packages/base-manager/src/manager-base.ts
+++ b/packages/base-manager/src/manager-base.ts
@@ -427,10 +427,6 @@ export abstract class ManagerBase implements IWidgetManager {
 
       initComm.close();
     } catch (error) {
-      console.warn(
-        'Failed to fetch ipywidgets through the "jupyter.widget.control" comm channel, fallback to fetching individual model state. Reason:',
-        error
-      );
       // Fall back to the old implementation for old ipywidgets backend versions (ipywidgets<=7.6)
       return this._loadFromKernelModels();
     }


### PR DESCRIPTION
This error message was introduced in https://github.com/jupyter-widgets/ipywidgets/pull/3335.

It shows up when the user refreshes the JupyterLab page on a kernel that has not yet imported ipywidgets, because the manager requests for widgets states, but the kernel is not able to answer back any widget model as ipwidgets was not imported. It is a normal workflow that should not show any error message.

This error message would also show up when using the manager with a kernel using ipywidgets 7, in that case as well we should not show any error message as it's a normal workflow too.

This PR removes the error message to prevent any confusion from the user.