### PR TITLE
Make sure that all session contexts has unique IDs even if they don't have a kernel

### DIFF
--- a/python/jupyterlab_widgets/src/plugin.ts
+++ b/python/jupyterlab_widgets/src/plugin.ts
@@ -138,6 +138,8 @@ function* chain<T>(
   }
 }
 
+const NO_KERNEL_SESSION_CONTEXT_IDS = new WeakMap<ISessionContext, string>();
+
 /**
  * Get the kernel id of current notebook or console panel, this value
  * is used as key for `Private.widgetManagerProperty` to store the widget
@@ -150,7 +152,15 @@ async function getWidgetManagerOwner(
   sessionContext: ISessionContext
 ): Promise<Private.IWidgetManagerOwner> {
   await sessionContext.ready;
-  return sessionContext.session!.kernel!.id;
+  let id = sessionContext.session?.kernel?.id;
+  if (id === undefined) {
+    id = NO_KERNEL_SESSION_CONTEXT_IDS.get(sessionContext);
+    if (id === undefined) {
+      id = 'no-kernel-' + base.uuid();
+      NO_KERNEL_SESSION_CONTEXT_IDS.set(sessionContext, id);
+    }
+  }
+  return id;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/jupyter-widgets/ipywidgets/issues/3970 by making sure that we can always retrieve the widget manager owner from a session context, even if the session context does not have kernel attached. This gets rid of the exception when retrieving the kernel ID from session context with no kernel:

```
plugin.ts:153 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'kernel')
    at getWidgetManagerOwner (plugin.ts:153:34)
    at async registerWidgetHandler (plugin.ts:175:25)
    at async plugin.ts:424:7
```

ipywidgets works properly after attaching ipykernel to a notebook that initially has no kernel after applying this fix.