### PR TITLE
Include sourcemaps in npm tarballs

### DIFF
--- a/packages/base-manager/package.json
+++ b/packages/base-manager/package.json
@@ -14,7 +14,8 @@
     "lib/**/*.map",
     "lib/**/*.d.ts",
     "lib/**/*.js",
-    "css/*.css"
+    "css/*.css",
+    "src"
   ],
   "scripts": {
     "build": "npm run build:src",

--- a/packages/base-manager/package.json
+++ b/packages/base-manager/package.json
@@ -11,6 +11,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [
+    "lib/**/*.map",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "css/*.css"

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -14,7 +14,8 @@
     "lib/**/*.map",
     "lib/**/*.d.ts",
     "lib/**/*.js",
-    "css/*.css"
+    "css/*.css",
+    "src"
   ],
   "scripts": {
     "build": "npm run build:src",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -11,6 +11,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [
+    "lib/**/*.map",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "css/*.css"

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -11,6 +11,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [
+    "lib/**/*.map",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "css/*.css",

--- a/packages/controls/package.json
+++ b/packages/controls/package.json
@@ -15,7 +15,8 @@
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "css/*.css",
-    "dist/"
+    "dist/",
+    "src"
   ],
   "scripts": {
     "build": "npm run build:src && npm run build:css",

--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -15,6 +15,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [
+    "lib/**/*.map",
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "dist/",

--- a/packages/html-manager/package.json
+++ b/packages/html-manager/package.json
@@ -19,7 +19,8 @@
     "lib/**/*.d.ts",
     "lib/**/*.js",
     "dist/",
-    "css/*.css"
+    "css/*.css",
+    "src"
   ],
   "scripts": {
     "build": "npm run build:src && webpack && npm run build:embed-amd",

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -16,7 +16,8 @@
   "files": [
     "lib/**/*.map",
     "lib/**/*.d.ts",
-    "lib/**/*.js"
+    "lib/**/*.js",
+    "src"
   ],
   "scripts": {
     "build": "npm run build:src",

--- a/packages/output/package.json
+++ b/packages/output/package.json
@@ -14,6 +14,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [
+    "lib/**/*.map",
     "lib/**/*.d.ts",
     "lib/**/*.js"
   ],


### PR DESCRIPTION
Sourcemaps are not currently published to npm due to the omission of
`*.map` under `"files"` in `package.json`. This leads to many downstream
challenges with editors and developers tools that expect these files
(since they are linked to the source `.d.ts` and `.js` files).

To illustrate:

```sh
yarn build
cd packages/base
npm pack
```

**before**

```sh
npm notice
npm notice 📦  @jupyter-widgets/base@6.0.10
npm notice Tarball Contents
npm notice 1.0kB css/index.css
npm notice 203B lib/backbone-patch.d.ts
npm notice 4.6kB lib/backbone-patch.js
npm notice 468B lib/errorwidget.d.ts
npm notice 2.8kB lib/errorwidget.js
npm notice 325B lib/index.d.ts
npm notice 426B lib/index.js
npm notice 4.9kB lib/manager.d.ts
npm notice 149B lib/manager.js
npm notice 1.4kB lib/nativeview.d.ts
npm notice 5.5kB lib/nativeview.js
npm notice 1.1kB lib/registry.d.ts
npm notice 335B lib/registry.js
npm notice 6.2kB lib/services-shim.d.ts
npm notice 7.8kB lib/services-shim.js
npm notice 4.1kB lib/utils.d.ts
npm notice 8.6kB lib/utils.js
npm notice 142B lib/version.d.ts
npm notice 227B lib/version.js
npm notice 2.4kB lib/viewlist.d.ts
npm notice 3.9kB lib/viewlist.js
npm notice 926B lib/widget_layout.d.ts
npm notice 3.5kB lib/widget_layout.js
npm notice 1.1kB lib/widget_style.d.ts
npm notice 3.7kB lib/widget_style.js
npm notice 12.9kB lib/widget.d.ts
npm notice 36.8kB lib/widget.js
npm notice 2.6kB package.json
npm notice Tarball Details
npm notice name: @jupyter-widgets/base
npm notice version: 6.0.10
npm notice filename: jupyter-widgets-base-6.0.10.tgz
npm notice package size: 30.3 kB
npm notice unpacked size: 118.2 kB
npm notice shasum: 87223c07f6e1f9321cbee063f211c5c4cf4a7daa
npm notice integrity: sha512-oF09hEiOTGr0j[...]r0pGFdcDc2K6A==
npm notice total files: 28
npm notice
jupyter-widgets-base-6.0.10.tgz
```

**after**

```sh
npm notice
npm notice 📦  @jupyter-widgets/base@6.0.10
npm notice Tarball Contents
npm notice 1.0kB css/index.css
npm notice 203B lib/backbone-patch.d.ts
npm notice 309B lib/backbone-patch.d.ts.map
npm notice 4.6kB lib/backbone-patch.js
npm notice 2.6kB lib/backbone-patch.js.map
npm notice 468B lib/errorwidget.d.ts
npm notice 486B lib/errorwidget.d.ts.map
npm notice 2.8kB lib/errorwidget.js
npm notice 2.5kB lib/errorwidget.js.map
npm notice 325B lib/index.d.ts
npm notice 318B lib/index.d.ts.map
npm notice 426B lib/index.js
npm notice 342B lib/index.js.map
npm notice 4.9kB lib/manager.d.ts
npm notice 2.0kB lib/manager.d.ts.map
npm notice 149B lib/manager.js
npm notice 130B lib/manager.js.map
npm notice 1.4kB lib/nativeview.d.ts
npm notice 728B lib/nativeview.d.ts.map
npm notice 5.5kB lib/nativeview.js
npm notice 3.7kB lib/nativeview.js.map
npm notice 1.1kB lib/registry.d.ts
npm notice 713B lib/registry.d.ts.map
npm notice 335B lib/registry.js
npm notice 253B lib/registry.js.map
npm notice 6.2kB lib/services-shim.d.ts
npm notice 3.1kB lib/services-shim.d.ts.map
npm notice 7.8kB lib/services-shim.js
npm notice 4.4kB lib/services-shim.js.map
npm notice 4.1kB lib/utils.d.ts
npm notice 1.6kB lib/utils.d.ts.map
npm notice 8.6kB lib/utils.js
npm notice 5.2kB lib/utils.js.map
npm notice 142B lib/version.d.ts
npm notice 172B lib/version.d.ts.map
npm notice 227B lib/version.js
npm notice 216B lib/version.js.map
npm notice 2.4kB lib/viewlist.d.ts
npm notice 1.1kB lib/viewlist.d.ts.map
npm notice 3.9kB lib/viewlist.js
npm notice 2.2kB lib/viewlist.js.map
npm notice 926B lib/widget_layout.d.ts
npm notice 570B lib/widget_layout.d.ts.map
npm notice 3.5kB lib/widget_layout.js
npm notice 2.8kB lib/widget_layout.js.map
npm notice 1.1kB lib/widget_style.d.ts
npm notice 726B lib/widget_style.d.ts.map
npm notice 3.7kB lib/widget_style.js
npm notice 3.2kB lib/widget_style.js.map
npm notice 12.9kB lib/widget.d.ts
npm notice 6.4kB lib/widget.d.ts.map
npm notice 36.8kB lib/widget.js
npm notice 24.6kB lib/widget.js.map
npm notice 2.7kB package.json
npm notice Tarball Details
npm notice name: @jupyter-widgets/base
npm notice version: 6.0.10
npm notice filename: jupyter-widgets-base-6.0.10.tgz
npm notice package size: 45.4 kB
npm notice unpacked size: 188.6 kB
npm notice shasum: c7436f7bface4b92e483197fc0a04f5377b68d12
npm notice integrity: sha512-OC6OkpnLmcvtX[...]LbJo267ryfang==
npm notice total files: 54
npm notice
jupyter-widgets-base-6.0.10.tgz
```