### PR TITLE
Fix the new line when pressing enter in textarea widget

### DIFF
--- a/packages/controls/src/widget_string.ts
+++ b/packages/controls/src/widget_string.ts
@@ -390,8 +390,8 @@ export class TextareaView extends StringView {
 
   events(): { [e: string]: string } {
     return {
-      'keydown input': 'handleKeyDown',
-      'keypress input': 'handleKeypress',
+      'keydown textarea': 'handleKeyDown',
+      'keypress textarea': 'handleKeypress',
       'input textarea': 'handleChanging',
       'change textarea': 'handleChanged',
     };


### PR DESCRIPTION
Fixes #3950 

The selector to handle the key events in the textarea was wrong. Fixing it fixes the issue about creating a line break when pressing `Enter`.
The logic is that the function handling the `KeyDown` event is stopping propagation, which means that the event is not handled by the lumino events handling anymore (bubbling on document, so the last to catch the event).

