### PR TITLE
Fix deprecation warning when importing the backend_inline

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/interaction.py
+++ b/python/ipywidgets/ipywidgets/widgets/interaction.py
@@ -41,7 +41,7 @@ def show_inline_matplotlib_plots():
 
     try:
         import matplotlib as mpl
-        from ipykernel.pylab.backend_inline import flush_figures
+        from matplotlib_inline.backend_inline import flush_figures
     except ImportError:
         return
 


### PR DESCRIPTION
This PR is to resolve #3865 