### PR TITLE
Add JupyterCon banner and jupyter colors

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,8 @@ def on_config_inited(*args):
 
 def setup(app):
     app.connect("config-inited", on_config_inited)
+    app.add_css_file("https://docs.jupyter.org/en/latest/_static/jupyter.css")
+
 
 
 # -- Sphinx extensions and configuration ------------------------
@@ -221,6 +223,3 @@ epub_title = project
 epub_author = author
 epub_publisher = author
 epub_copyright = copyright
-
-def setup(app):
-    app.add_css_file("https://docs.jupyter.org/en/latest/_static/jupyter.css")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -155,6 +155,7 @@ templates_path = ["_templates"]
 htmlhelp_basename = 'ipywidgetsdoc'
 
 html_theme_options = {
+    "announcement": "🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href=\"https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">SCHEDULE</a> · <a href=\"https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">REGISTER NOW</a>",
     "icon_links": [
         {
             "name": "PyPI",
@@ -220,3 +221,6 @@ epub_title = project
 epub_author = author
 epub_publisher = author
 epub_copyright = copyright
+
+def setup(app):
+    app.add_css_file("https://docs.jupyter.org/en/latest/_static/jupyter.css")


### PR DESCRIPTION
This PR does a couple of things:

- Adds an announcement banner for JupyterCon
- Links a CSS file from the Jupyter documentation that we can use for jupyter colors in our docs

