### PR TITLE
Remove JupyterCon 2025 announcement banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -164,7 +164,6 @@ templates_path = ["_templates"]
 htmlhelp_basename = 'ipywidgetsdoc'
 
 html_theme_options = {
-    "announcement": "🚀 Join us in San Diego · JupyterCon 2025 · Nov 4-5 · <a href=\"https://events.linuxfoundation.org/jupytercon/program/schedule/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">SCHEDULE</a> · <a href=\"https://events.linuxfoundation.org/jupytercon/register/?ajs_aid=53afb00d-be65-4a99-9112-28cdaac99463\">REGISTER NOW</a>",
     "icon_links": [
         {
             "name": "PyPI",


### PR DESCRIPTION
This removes the JupyterCon 2025 promotional announcement banner from the documentation configuration.

Closes jupyter-governance/ec-team-compass#146

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed by @jasongrout 