### PR TITLE
Fix saving notebook with disconnected widgets losing widget model state

### DIFF
--- a/python/jupyterlab_widgets/src/manager.ts
+++ b/python/jupyterlab_widgets/src/manager.ts
@@ -287,9 +287,9 @@ export abstract class LabWidgetManager
   }
 
   /**
-   * Synchronously get the state of the live widgets in the widget manager.
+   * Synchronously get the state of the widget models in the widget manager.
    *
-   * This includes all of the live widget models, and follows the format given in
+   * This includes all of the widget models, and follows the format given in
    * the @jupyter-widgets/schema package.
    *
    * @param options - The options for what state to return.
@@ -298,9 +298,7 @@ export abstract class LabWidgetManager
   get_state_sync(options: IStateOptions = {}): ReadonlyPartialJSONValue {
     const models = [];
     for (const model of this._modelsSync.values()) {
-      if (model.comm_live) {
-        models.push(model);
-      }
+      models.push(model);
     }
     return serialize_state(models, options);
   }


### PR DESCRIPTION
When saving a notebook containing disconnected widgets (restored from saved state but without a live kernel), the widget state was being dropped from notebook metadata. This happened because get_state_sync() only serialized models with comm_live=true, filtering out any widgets that had been restored from saved state without a kernel connection.

On subsequent reopens, the widget output cells still referenced model IDs that no longer existed in the metadata, causing "Error displaying widget: model not found" errors.

The fix removes the comm_live filter from get_state_sync(), so all registered widget models are serialized when saving. This aligns with the base manager's async get_state() method, which already includes all models regardless of comm_live status.

Fixes #3270