### PR TITLE
Update jupyterlite in docs to 0.8

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - bqplot
   - ipykernel
   - ipyleaflet
-  - jupyterlite-core >=0.3.0,<0.4.0
+  - jupyterlite-core >=0.8.0,<0.9.0
   - jupyterlite-pyodide-kernel
   - matplotlib-base
   - numpy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,8 +6,8 @@ ipyleaflet
 jupyter-client
 jupyter-packaging
 jupyterlab >=4
-jupyterlite-core >=0.3.0,<0.4.0
-jupyterlite-pyodide-kernel >=0.3.0,<0.4.0
+jupyterlite-core >=0.8.0,<0.9.0
+jupyterlite-pyodide-kernel >=0.8.0,<0.9.0
 matplotlib
 myst-nb >=0.17
 numpy


### PR DESCRIPTION
Update jupyterlite in docs to 0.8.x

As part of working on the docs integration, I also [manually migrated](https://docs.readthedocs.com/platform/stable/reference/git-integration.html#manually-migrating-a-project) ipywidgets to use the ReadTheDocs GitHub App

Claude helped in this PR.