### PR TITLE
Update the documentation to use JupyterLite 0.8.x

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - bqplot
   - ipykernel
   - ipyleaflet
-  - jupyterlite-core >=0.3.0,<0.4.0
+  - jupyterlite-core >=0.8.0,<0.9.0
   - jupyterlite-pyodide-kernel
   - matplotlib-base
   - numpy

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - ipykernel
   - ipyleaflet
   - jupyterlite-core >=0.8.0,<0.9.0
-  - jupyterlite-pyodide-kernel
+  - jupyterlite-pyodide-kernel >=0.8.0,<0.9.0
   - matplotlib-base
   - numpy
   - scikit-image

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,8 +6,8 @@ ipyleaflet
 jupyter-client
 jupyter-packaging
 jupyterlab >=4
-jupyterlite-core >=0.3.0,<0.4.0
-jupyterlite-pyodide-kernel >=0.3.0,<0.4.0
+jupyterlite-core >=0.8.0,<0.9.0
+jupyterlite-pyodide-kernel >=0.8.0,<0.9.0
 matplotlib
 myst-nb >=0.17
 numpy

--- a/docs/source/_static/theme.css
+++ b/docs/source/_static/theme.css
@@ -17,9 +17,40 @@ table.indextable tr.cap {
   margin: 0.75rem 0.25rem 0 0.25rem;
 }
 
-.demo-app > * {
+.demo-app > label {
   flex: 1 auto;
   white-space: nowrap;
+}
+
+/*
+ * Keep the button on its own row under the app picker, and set its colors
+ * explicitly. Inheriting the theme link color makes the label unreadable on
+ * Jupyter-branded sites, where the link color is the Jupyter orange.
+ */
+#demo-sidebar #demo-button {
+  flex: 1 0 100%;
+  margin-top: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.25rem;
+  font-weight: 500;
+  text-align: center;
+  white-space: nowrap;
+}
+
+#demo-sidebar #demo-button,
+#demo-sidebar #demo-button:link,
+#demo-sidebar #demo-button:visited,
+#demo-sidebar #demo-button:hover,
+#demo-sidebar #demo-button:focus,
+#demo-sidebar #demo-button:active {
+  background-color: var(--pst-color-info);
+  color: var(--pst-color-background);
+  text-decoration: none;
+}
+
+#demo-sidebar #demo-button:hover,
+#demo-sidebar #demo-button:focus {
+  filter: brightness(0.9);
 }
 
 #demo-sidebar .admonition-title::after {

--- a/docs/source/_static/theme.css
+++ b/docs/source/_static/theme.css
@@ -29,35 +29,24 @@ table.indextable tr.cap {
   white-space: nowrap;
 }
 
-/*
- * Keep the button on its own row under the app picker, and set its colors
- * explicitly. Inheriting the theme link color makes the label unreadable on
- * Jupyter-branded sites, where the link color is the Jupyter orange.
- */
+/* Keep the button on its own row under the app picker. */
 #demo-sidebar #demo-button {
   display: block;
   margin-top: 0.5rem;
-  padding: 0.375rem 0.75rem;
-  border-radius: 0.25rem;
-  font-weight: 500;
-  text-align: center;
-  white-space: nowrap;
 }
 
-#demo-sidebar #demo-button,
+/*
+ * The theme's link rules (a:link, a:visited, ...) outrank .btn-primary's text
+ * color, leaving the label unreadable on Jupyter-branded sites, where the link
+ * color is the Jupyter orange. Pin the label back to the button's own colors.
+ */
 #demo-sidebar #demo-button:link,
 #demo-sidebar #demo-button:visited,
 #demo-sidebar #demo-button:hover,
 #demo-sidebar #demo-button:focus,
 #demo-sidebar #demo-button:active {
-  background-color: var(--pst-color-info);
-  color: var(--pst-color-background);
+  color: var(--bs-btn-color);
   text-decoration: none;
-}
-
-#demo-sidebar #demo-button:hover,
-#demo-sidebar #demo-button:focus {
-  filter: brightness(0.9);
 }
 
 #demo-sidebar .admonition-title::after {

--- a/docs/source/_static/theme.css
+++ b/docs/source/_static/theme.css
@@ -9,15 +9,23 @@ table.indextable tr.cap {
 }
 
 #demo-sidebar .demo-app {
-  display: inline;
+  margin: 0.75rem 0.25rem 0 0.25rem;
+}
+
+/* Strip the fieldset's default chrome; it is here for radio-group semantics,
+ * not as a visual box. */
+.demo-app > .demo-app-picker {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
   display: flex;
   flex-direction: row;
   align-items: baseline;
   flex-wrap: wrap;
-  margin: 0.75rem 0.25rem 0 0.25rem;
 }
 
-.demo-app > label {
+.demo-app-picker > label {
   flex: 1 auto;
   white-space: nowrap;
 }
@@ -28,7 +36,7 @@ table.indextable tr.cap {
  * Jupyter-branded sites, where the link color is the Jupyter orange.
  */
 #demo-sidebar #demo-button {
-  flex: 1 0 100%;
+  display: block;
   margin-top: 0.5rem;
   padding: 0.375rem 0.75rem;
   border-radius: 0.25rem;

--- a/docs/source/_static/theme.css
+++ b/docs/source/_static/theme.css
@@ -12,8 +12,7 @@ table.indextable tr.cap {
   margin: 0.75rem 0.25rem 0 0.25rem;
 }
 
-/* Strip the fieldset's default chrome; it is here for radio-group semantics,
- * not as a visual box. */
+/* Strip the fieldset's default chrome */
 .demo-app > .demo-app-picker {
   border: 0;
   margin: 0;

--- a/docs/source/_templates/demo.html
+++ b/docs/source/_templates/demo.html
@@ -26,7 +26,6 @@
     </label>
     <a
       href="{{ pathto('try/lab/index') }}?path=Widget%20List.ipynb"
-      class="btn btn-primary"
       target="_blank"
       title="Try Jupyter Widgets in your browser."
       id="demo-button"
@@ -37,9 +36,19 @@
   </div>
 
 
-  <script>$(function() {
-    $('.demo-app input').on('change', (event) => {
-      $("#demo-button").attr("href", (event.currentTarget.value));
-    });
-  });</script>
+  <script>
+    (function() {
+      const button = document.getElementById("demo-button");
+      const inputs = document.querySelectorAll(".demo-app input[name='demo-app']");
+      const sync = () => {
+        const checked = document.querySelector(".demo-app input[name='demo-app']:checked");
+        if (checked) {
+          button.href = checked.value;
+        }
+      };
+      inputs.forEach((input) => input.addEventListener("change", sync));
+      // Browsers may restore a previous selection when navigating back.
+      sync();
+    })();
+  </script>
 </div>

--- a/docs/source/_templates/demo.html
+++ b/docs/source/_templates/demo.html
@@ -1,36 +1,38 @@
 <div id="demo-sidebar" class="admonition warning">
-  <p class="demo-title admonition-title" role="heading" aria-level="1">
-    <img src="https://jupyterlite.readthedocs.io/en/latest/_static/icon.svg" width="16" />
+  <p class="demo-title admonition-title" role="heading" aria-level="2">
+    <img src="https://jupyterlite.readthedocs.io/en/latest/_static/icon.svg" width="16" alt="" />
     Try Jupyter Widgets
   </p>
 
   <div class="demo-app">
-    <label title="Try Widgets in a multi-document UI">
-      <input
-        type="radio"
-        name="demo-app"
-        autocomplete="off"
-        checked
-        value="{{ pathto('try/lab/index') }}?path=Widget%20List.ipynb"
-      >
-      <i class="fas fa-flask"></i> Lab
-    </label>
-    <label title="Try Widgets in a single-document UI">
-      <input
-        type="radio"
-        name="demo-app"
-        autocomplete="off"
-        value="{{ pathto('try/tree/index') }}?path=Widget%20List.ipynb"
-      >
-      <i class="fas fa-book"></i> Notebook
-    </label>
+    <fieldset class="demo-app-picker" aria-label="Choose an interface">
+      <label title="Try Widgets in a multi-document UI">
+        <input
+          type="radio"
+          name="demo-app"
+          autocomplete="off"
+          checked
+          value="{{ pathto('try/lab/index') }}?path=Widget%20List.ipynb"
+        >
+        <i class="fas fa-flask" aria-hidden="true"></i> Lab
+      </label>
+      <label title="Try Widgets in a single-document UI">
+        <input
+          type="radio"
+          name="demo-app"
+          autocomplete="off"
+          value="{{ pathto('try/tree/index') }}?path=Widget%20List.ipynb"
+        >
+        <i class="fas fa-book" aria-hidden="true"></i> Notebook
+      </label>
+    </fieldset>
     <a
       href="{{ pathto('try/lab/index') }}?path=Widget%20List.ipynb"
       target="_blank"
       title="Try Jupyter Widgets in your browser."
       id="demo-button"
     >
-      <i class="fas fa-play"></i>
+      <i class="fas fa-play" aria-hidden="true"></i>
       Try Now
     </a>
   </div>

--- a/docs/source/_templates/demo.html
+++ b/docs/source/_templates/demo.html
@@ -29,6 +29,7 @@
     <a
       href="{{ pathto('try/lab/index') }}?path=Widget%20List.ipynb"
       target="_blank"
+      rel="noopener"
       title="Try Jupyter Widgets in your browser."
       id="demo-button"
     >

--- a/docs/source/_templates/demo.html
+++ b/docs/source/_templates/demo.html
@@ -28,6 +28,7 @@
     </fieldset>
     <a
       href="{{ pathto('try/lab/index') }}?path=Widget%20List.ipynb"
+      class="btn btn-primary"
       target="_blank"
       rel="noopener"
       title="Try Jupyter Widgets in your browser."


### PR DESCRIPTION
Update jupyterlite in docs to 0.8.x and revise the JupyterLite picker in the docs sidebar.

As part of working on the docs integration, I also [manually migrated](https://docs.readthedocs.com/platform/stable/reference/git-integration.html#manually-migrating-a-project) ipywidgets to use the ReadTheDocs GitHub App

Claude helped in this PR.