### PR TITLE
Update pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
           pip install -e ./python/ipywidgets[test]
       - name: Test with pytest
         run: |
-          pip install "pytest<8"
+          pip install pytest
           cd python/ipywidgets
           pytest --cov=ipywidgets ipywidgets
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,6 @@ jobs:
           pip install -e ./python/ipywidgets[test]
       - name: Test with pytest
         run: |
-          pip install pytest
           cd python/ipywidgets
           pytest --cov=ipywidgets ipywidgets
 

--- a/python/ipywidgets/ipywidgets/tests/test_embed.py
+++ b/python/ipywidgets/ipywidgets/tests/test_embed.py
@@ -28,7 +28,7 @@ class CaseWidget(Widget):
 
 class TestEmbed:
 
-    def teardown(self):
+    def teardown_method(self):
         for w in tuple(widget_module._instances.values()):
             w.close()
 


### PR DESCRIPTION
Update pytest, which exposed a teardown method with an obsolete name (see #3883).

Based on a Claude recommendation at https://github.com/jasongrout/ipywidgets/pull/15